### PR TITLE
feat(retain): hide hindsight_retain tool when session is not retained

### DIFF
--- a/src/commands/meta.ts
+++ b/src/commands/meta.ts
@@ -7,6 +7,7 @@ import type { HindsightClientWrapper } from "../client";
 import type { HindsightConfig } from "../config";
 import { getHindsightMeta, type HindsightMeta, shouldSessionBeRetained } from "../meta";
 import { deleteAutoQueue, deleteToolQueue } from "../queue";
+import { isToolEnabled, updateRetainToolVisibility } from "../tools";
 import type { Subcommand } from "./types";
 import { parseAndUpsertSession } from "./utils";
 
@@ -81,6 +82,11 @@ export function createToggleRetainSubcommand(
             "warning"
           );
         }
+
+        // Show hindsight_retain tool now that session is retained
+        if (isToolEnabled(config, "retain")) {
+          updateRetainToolVisibility(pi, true);
+        }
       } else {
         // Toggling OFF: build new meta, preserving existing tags
         const existingMeta = getHindsightMeta(entries);
@@ -97,6 +103,11 @@ export function createToggleRetainSubcommand(
         }
 
         ctx.ui.notify("Session retention: disabled (will be ignored)", "info");
+
+        // Hide hindsight_retain tool now that session is not retained
+        if (isToolEnabled(config, "retain")) {
+          updateRetainToolVisibility(pi, false);
+        }
       }
     },
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import { getHindsightMeta, shouldSessionBeRetained } from "./meta";
 import { prepareEntry, shouldRetainMessage } from "./prepare";
 import { enqueueAutoMessage } from "./queue";
 import { flushQueues, getQueueCount } from "./retention";
-import { registerTools } from "./tools";
+import { isToolEnabled, registerTools, updateRetainToolVisibility } from "./tools";
 import { extractParentSessionId, getProjectName, getSessionDisplayName, truncate } from "./utils";
 
 // Runtime toggle for recall display (overrides config)
@@ -143,6 +143,14 @@ export default function (pi: ExtensionAPI) {
     const existingMeta = getHindsightMeta(entries);
     if (!existingMeta) {
       pi.appendEntry("hindsight-meta", { retained: config.retainSessionsByDefault });
+    }
+
+    // Update hindsight_retain tool visibility based on retention state.
+    // When not retained, the tool is hidden from the LLM entirely (instead
+    // of being available but failing on execution).
+    if (isToolEnabled(config, "retain")) {
+      const isRetained = shouldSessionBeRetained(entries, config);
+      updateRetainToolVisibility(pi, isRetained);
     }
 
     if (!hasUsableConfig) {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -62,7 +62,7 @@ interface ReflectDetails {
  * - `false`: no tools enabled
  * - array of tool names: only listed tools enabled
  */
-function isToolEnabled(config: HindsightConfig, tool: ToolName): boolean {
+export function isToolEnabled(config: HindsightConfig, tool: ToolName): boolean {
   const { toolsEnabled } = config;
   if (typeof toolsEnabled === "boolean") return toolsEnabled;
   return toolsEnabled.includes(tool);
@@ -301,5 +301,32 @@ export function registerTools(
         };
       },
     });
+  }
+}
+
+/**
+ * Update whether hindsight_retain is visible to the LLM based on retention state.
+ *
+ * When a session is not retained, hindsight_retain is removed from active tools
+ * so the LLM never sees it as an option (instead of seeing it and having calls fail).
+ * When retained, it's added back if it was previously removed.
+ *
+ * Note: The execute-time check in hindsight_retain remains as a defensive
+ * fallback in case the tool is called through edge cases (e.g., mid-turn toggle).
+ */
+export function updateRetainToolVisibility(pi: ExtensionAPI, retained: boolean): void {
+  const toolName = "hindsight_retain";
+  const activeNames = pi.getActiveTools();
+
+  if (retained) {
+    // Add hindsight_retain if not already active
+    if (!activeNames.includes(toolName)) {
+      pi.setActiveTools([...activeNames, toolName]);
+    }
+  } else {
+    // Remove hindsight_retain from active tools
+    if (activeNames.includes(toolName)) {
+      pi.setActiveTools(activeNames.filter((n) => n !== toolName));
+    }
   }
 }

--- a/tests/bootstrap.test.ts
+++ b/tests/bootstrap.test.ts
@@ -1995,4 +1995,92 @@ describe("real entrypoint bootstrap", () => {
       { not: { tags: ["session:test-session-123"], match: "any_strict" } },
     ]);
   });
+
+  // ============================================
+  // updateRetainToolVisibility integration tests
+  // ============================================
+
+  it("session_start hides hindsight_retain when retainSessionsByDefault=false", async () => {
+    activeConfig = { ...testConfig, retainSessionsByDefault: false };
+
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+
+    // getEntries returns no hindsight-meta entries (auto-create will use retained=false)
+    const ctx = createMockContext({
+      sessionManager: {
+        ...createMockContext().sessionManager,
+        getEntries: mock(() => []),
+      },
+    });
+    const handler = pi.handlers.get("session_start")!;
+    await handler({ type: "session_start" }, ctx);
+
+    // setActiveTools should have been called to remove hindsight_retain
+    expect(pi.setActiveToolsCalls.length).toBeGreaterThan(0);
+    const lastCall = pi.setActiveToolsCalls[pi.setActiveToolsCalls.length - 1]!;
+    expect(lastCall).not.toContain("hindsight_retain");
+  });
+
+  it("session_start keeps hindsight_retain visible when retainSessionsByDefault=true", async () => {
+    // Default config has retainSessionsByDefault=true
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+
+    const ctx = createMockContext({
+      sessionManager: {
+        ...createMockContext().sessionManager,
+        getEntries: mock(() => []), // no meta → auto-create with retained=true
+      },
+    });
+    const handler = pi.handlers.get("session_start")!;
+    await handler({ type: "session_start" }, ctx);
+
+    // setActiveTools should NOT have been called (tool is already active by default)
+    expect(pi.setActiveToolsCalls.length).toBe(0);
+  });
+
+  it("session_start respects existing retained=false metadata", async () => {
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+
+    const ctx = createMockContext({
+      sessionManager: {
+        ...createMockContext().sessionManager,
+        getEntries: mock(() => [
+          { type: "custom", customType: "hindsight-meta", data: { retained: false } },
+        ]),
+      },
+    });
+    const handler = pi.handlers.get("session_start")!;
+    await handler({ type: "session_start" }, ctx);
+
+    // setActiveTools should have been called to remove hindsight_retain
+    expect(pi.setActiveToolsCalls.length).toBeGreaterThan(0);
+    const lastCall = pi.setActiveToolsCalls[pi.setActiveToolsCalls.length - 1]!;
+    expect(lastCall).not.toContain("hindsight_retain");
+  });
+
+  it("session_start does not call updateRetainToolVisibility when retain tool is not in toolsEnabled array", async () => {
+    activeConfig = { ...testConfig, toolsEnabled: ["recall" as const] };
+
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+
+    const ctx = createMockContext({
+      sessionManager: {
+        ...createMockContext().sessionManager,
+        getEntries: mock(() => []),
+      },
+    });
+    const handler = pi.handlers.get("session_start")!;
+    await handler({ type: "session_start" }, ctx);
+
+    // setActiveTools should NOT have been called — retain tool isn't registered
+    expect(pi.setActiveToolsCalls.length).toBe(0);
+  });
 });

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -19,7 +19,12 @@ interface RegisteredCmd {
 
 describe("registerCommands", () => {
   let registeredCommands: Map<string, RegisteredCmd>;
-  let mockPi: { registerCommand: ReturnType<typeof mock>; appendEntry: ReturnType<typeof mock> };
+  let mockPi: {
+    registerCommand: ReturnType<typeof mock>;
+    appendEntry: ReturnType<typeof mock>;
+    getActiveTools: ReturnType<typeof mock>;
+    setActiveTools: ReturnType<typeof mock>;
+  };
   let mockClient: HindsightClientWrapper | null;
   let recallDetails: RecallMessageDetails | null;
   let autoRecallDisplayOverride: boolean | null;
@@ -46,6 +51,19 @@ describe("registerCommands", () => {
       appendEntry: mock((customType: string, data?: unknown) => {
         appendedEntries.push({ customType, data });
       }),
+      getActiveTools: mock(() => [
+        "read",
+        "bash",
+        "edit",
+        "write",
+        "grep",
+        "find",
+        "ls",
+        "hindsight_retain",
+        "hindsight_recall",
+        "hindsight_reflect",
+      ]),
+      setActiveTools: mock(() => {}),
     } as unknown as typeof mockPi;
   });
 

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -298,6 +298,10 @@ export interface CapturedExtension {
   commands: Map<string, unknown>;
   renderers: Map<string, unknown>;
   appendedEntries: { customType: string; data?: unknown }[];
+  /** Current active tool names, or null if all tools are active (default). */
+  activeToolNames: string[] | null;
+  /** History of all setActiveTools calls for assertions. */
+  setActiveToolsCalls: string[][];
 }
 
 /** Builder for mock ExtensionAPI instances with fluent configuration. */
@@ -312,13 +316,26 @@ export class MockPiBuilder {
   private renderers = new Map<string, unknown>();
   private appendedEntries: { customType: string; data?: unknown }[] = [];
 
+  private state = {
+    activeToolNames: null as string[] | null,
+    setActiveToolsCalls: [] as string[][],
+  };
+
   build(): ExtensionAPI & CapturedExtension {
+    const state = this.state;
     return {
       handlers: this.handlers,
       tools: this.tools,
       commands: this.commands,
       renderers: this.renderers,
       appendedEntries: this.appendedEntries,
+      get activeToolNames() {
+        return state.activeToolNames;
+      },
+      set activeToolNames(value: string[] | null) {
+        state.activeToolNames = value;
+      },
+      setActiveToolsCalls: state.setActiveToolsCalls,
       on: mock((event: string, handler: (...args: unknown[]) => unknown) => {
         this.handlers.set(event, handler);
       }),
@@ -335,6 +352,16 @@ export class MockPiBuilder {
       }),
       appendEntry: mock((customType: string, data?: unknown) => {
         this.appendedEntries.push({ customType, data });
+      }),
+      getActiveTools: mock(() => {
+        if (state.activeToolNames === null) {
+          return this.tools.map((t) => t.name);
+        }
+        return this.tools.filter((t) => state.activeToolNames!.includes(t.name)).map((t) => t.name);
+      }),
+      setActiveTools: mock((names: string[]) => {
+        state.activeToolNames = names;
+        state.setActiveToolsCalls.push(names);
       }),
     } as unknown as ExtensionAPI & CapturedExtension;
   }

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -9,7 +9,7 @@ import type { RecallResponse, ReflectResponse } from "@vectorize-io/hindsight-cl
 import type { HindsightClientWrapper } from "../src/client";
 import type { HindsightConfig } from "../src/config";
 import { deleteAutoQueue, deleteToolQueue, readToolQueue } from "../src/queue";
-import { registerTools } from "../src/tools";
+import { isToolEnabled, registerTools, updateRetainToolVisibility } from "../src/tools";
 import { testConfig as sharedTestConfig } from "./fixtures";
 
 const TEST_SESSION_ID = "test-tools-session";
@@ -37,14 +37,40 @@ interface ToolDef {
 }
 
 // Track registered tools
-function createMockPi(): ExtensionAPI & { tools: ToolDef[] } {
+function createMockPi(): ExtensionAPI & {
+  tools: ToolDef[];
+  activeToolNames: string[] | null;
+  setActiveToolsCalls: string[][];
+} {
   const tools: ToolDef[] = [];
+  // Use a mutable object so the closure-based getActiveTools/setActiveTools share state
+  const state = { activeToolNames: null as string[] | null, setActiveToolsCalls: [] as string[][] };
   return {
     tools,
+    get activeToolNames() {
+      return state.activeToolNames;
+    },
+    get setActiveToolsCalls() {
+      return state.setActiveToolsCalls;
+    },
     registerTool: mock((tool: ToolDef) => {
       tools.push(tool);
     }),
-  } as unknown as ExtensionAPI & { tools: ToolDef[] };
+    getActiveTools: mock(() => {
+      if (state.activeToolNames === null) {
+        return tools.map((t) => t.name);
+      }
+      return tools.filter((t) => state.activeToolNames!.includes(t.name)).map((t) => t.name);
+    }),
+    setActiveTools: mock((names: string[]) => {
+      state.activeToolNames = names;
+      state.setActiveToolsCalls.push(names);
+    }),
+  } as unknown as ExtensionAPI & {
+    tools: ToolDef[];
+    activeToolNames: string[] | null;
+    setActiveToolsCalls: string[][];
+  };
 }
 
 // Create a mock session manager context
@@ -692,5 +718,102 @@ describe("hindsight_retain context forwarding", () => {
     const tags = queueEntries[0]?.tags ?? [];
     expect(tags).toContain("topic:ai");
     expect(tags).toContain("project:x");
+  });
+});
+
+// ============================================
+// updateRetainToolVisibility tests
+// ============================================
+
+describe("updateRetainToolVisibility", () => {
+  it("removes hindsight_retain from active tools when not retained", () => {
+    const pi = createMockPi();
+    registerTools(pi, testConfig, createMockClient());
+
+    // Initially all tools are active
+    const activeBefore = pi.getActiveTools();
+    expect(activeBefore).toContain("hindsight_retain");
+
+    updateRetainToolVisibility(pi, false);
+
+    const activeAfter = pi.getActiveTools();
+    expect(activeAfter).not.toContain("hindsight_retain");
+    // Other hindsight tools should remain
+    expect(activeAfter).toContain("hindsight_recall");
+    expect(activeAfter).toContain("hindsight_reflect");
+  });
+
+  it("adds hindsight_retain back when session becomes retained", () => {
+    const pi = createMockPi();
+    registerTools(pi, testConfig, createMockClient());
+
+    // Remove first
+    updateRetainToolVisibility(pi, false);
+    const activeAfterRemove = pi.getActiveTools();
+    expect(activeAfterRemove).not.toContain("hindsight_retain");
+
+    // Add back
+    updateRetainToolVisibility(pi, true);
+    const activeAfterAdd = pi.getActiveTools();
+    expect(activeAfterAdd).toContain("hindsight_retain");
+  });
+
+  it("is a no-op when retained=true and tool is already active", () => {
+    const pi = createMockPi();
+    registerTools(pi, testConfig, createMockClient());
+
+    // Tool is active by default
+    const callCountBefore = pi.setActiveToolsCalls.length;
+    updateRetainToolVisibility(pi, true);
+
+    // setActiveTools should not have been called
+    expect(pi.setActiveToolsCalls.length).toBe(callCountBefore);
+  });
+
+  it("is a no-op when retained=false and tool is already inactive", () => {
+    const pi = createMockPi();
+    registerTools(pi, testConfig, createMockClient());
+
+    // Remove first
+    updateRetainToolVisibility(pi, false);
+    const callCountAfterRemove = pi.setActiveToolsCalls.length;
+
+    // Calling again should be a no-op
+    updateRetainToolVisibility(pi, false);
+    expect(pi.setActiveToolsCalls.length).toBe(callCountAfterRemove);
+  });
+});
+
+describe("isToolEnabled", () => {
+  it("returns true when toolsEnabled is true", () => {
+    expect(isToolEnabled({ ...testConfig, toolsEnabled: true }, "retain")).toBe(true);
+    expect(isToolEnabled({ ...testConfig, toolsEnabled: true }, "recall")).toBe(true);
+    expect(isToolEnabled({ ...testConfig, toolsEnabled: true }, "reflect")).toBe(true);
+  });
+
+  it("returns false when toolsEnabled is false", () => {
+    expect(isToolEnabled({ ...testConfig, toolsEnabled: false }, "retain")).toBe(false);
+    expect(isToolEnabled({ ...testConfig, toolsEnabled: false }, "recall")).toBe(false);
+    expect(isToolEnabled({ ...testConfig, toolsEnabled: false }, "reflect")).toBe(false);
+  });
+
+  it("returns true only for tools listed in the array", () => {
+    const config = { ...testConfig, toolsEnabled: ["retain", "recall"] as ["retain", "recall"] };
+    expect(isToolEnabled(config, "retain")).toBe(true);
+    expect(isToolEnabled(config, "recall")).toBe(true);
+    expect(isToolEnabled(config, "reflect")).toBe(false);
+  });
+
+  it("returns false for all tools when toolsEnabled is an empty array", () => {
+    const config = { ...testConfig, toolsEnabled: [] as [] };
+    expect(isToolEnabled(config, "retain")).toBe(false);
+    expect(isToolEnabled(config, "recall")).toBe(false);
+    expect(isToolEnabled(config, "reflect")).toBe(false);
+  });
+
+  it("returns false when the tool is not in the array", () => {
+    const config = { ...testConfig, toolsEnabled: ["recall"] as ["recall"] };
+    expect(isToolEnabled(config, "retain")).toBe(false);
+    expect(isToolEnabled(config, "reflect")).toBe(false);
   });
 });


### PR DESCRIPTION
Previously, hindsight_retain was always visible to the LLM but returned an error on execution when the session was not retained.

Now the tool is proactively removed from the active tools list via pi.setActiveTools() when the session is not retained, and added back when retention is enabled. This happens on:

- session_start: visibility set based on retainSessionsByDefault or existing hindsight-meta retained state
- toggle-retain command: visibility updated immediately on toggle

The execute-time retained check in hindsight_retain remains as a defensive fallback.