### PR TITLE
test: isolate tests from user pi directory and fix mock.module pollution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - run: bun install --frozen-lockfile
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
       - name: Run tests with coverage
-        run: bun test --coverage | tee coverage-output.txt
+        run: bun test --isolate --coverage | tee coverage-output.txt
       - name: Check coverage threshold
         run: |
           COVERAGE=$(grep 'All files' coverage-output.txt | awk -F'|' '{gsub(/ /, "", $3); print $3}')

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "check:fix": "biome check . --write && sed -i'' -e 's/[[:space:]]*$//' src/*.ts *.md",
     "typecheck": "bun run --bun tsc --noEmit",
     "commitlint": "commitlint",
-    "ci": "bun run check && bun run typecheck && bun test"
+    "ci": "bun run check && bun run typecheck && bun test --isolate"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.12",

--- a/tests/bootstrap.test.ts
+++ b/tests/bootstrap.test.ts
@@ -12,7 +12,6 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
-
 // Import the real config module BEFORE mocking to preserve exports
 import * as realConfig from "../src/config";
 
@@ -21,9 +20,15 @@ import {
   createMockPi,
   HINDSIGHT_ENV_KEYS,
   saveEnvKeys,
+  setupTempAgentDir,
   testConfig,
 } from "./fixtures";
 
+// ============================================
+// Setup: redirect agent-dir filesystem operations to temp directory
+// ============================================
+
+setupTempAgentDir("bootstrap");
 // ============================================
 // Mutable state for mock.module() — tests set these before exercising handlers
 // ============================================

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -3,11 +3,23 @@
  */
 
 import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { HindsightClientWrapper } from "../src/client";
 import { registerCommands } from "../src/commands";
 import type { RecallMessageDetails } from "../src/index";
-import { createMockClient, statusTestConfig, withTempDir, writeSessionFile } from "./fixtures";
+import {
+  createMockClient,
+  setupTempAgentDir,
+  statusTestConfig,
+  withTempDir,
+  writeSessionFile,
+} from "./fixtures";
+
+// Redirect agent-dir filesystem operations to a temp directory instead of
+// the real user's ~/.pi/agent/ directory.
+setupTempAgentDir("commands");
 
 interface RegisteredCmd {
   description: string;
@@ -835,14 +847,12 @@ describe("registerCommands", () => {
     });
 
     it("asks for confirmation before upserting", async () => {
-      const { mkdirSync, writeFileSync: writeFile, rmSync } = await import("node:fs");
-      const { join } = await import("node:path");
       const { getAgentDir } = await import("@mariozechner/pi-coding-agent");
       const parsedDir = join(getAgentDir(), "extensions", "pi-hindsight", "parsed-sessions");
       const testFile = join(parsedDir, "test-upsert-confirm.json");
 
       mkdirSync(parsedDir, { recursive: true });
-      writeFile(
+      writeFileSync(
         testFile,
         JSON.stringify({
           messages: [{ role: "user", content: "hello" }],
@@ -890,14 +900,12 @@ describe("registerCommands", () => {
     });
 
     it("cancels upsert when user declines confirmation", async () => {
-      const { mkdirSync, writeFileSync: writeFile, rmSync } = await import("node:fs");
-      const { join } = await import("node:path");
       const { getAgentDir } = await import("@mariozechner/pi-coding-agent");
       const parsedDir = join(getAgentDir(), "extensions", "pi-hindsight", "parsed-sessions");
       const testFile = join(parsedDir, "test-upsert-cancel.json");
 
       mkdirSync(parsedDir, { recursive: true });
-      writeFile(
+      writeFileSync(
         testFile,
         JSON.stringify({
           messages: [{ role: "user", content: "hello" }],
@@ -936,14 +944,12 @@ describe("registerCommands", () => {
     });
 
     it("proceeds with upsert when user accepts confirmation", async () => {
-      const { mkdirSync, writeFileSync: writeFile, rmSync } = await import("node:fs");
-      const { join } = await import("node:path");
       const { getAgentDir } = await import("@mariozechner/pi-coding-agent");
       const parsedDir = join(getAgentDir(), "extensions", "pi-hindsight", "parsed-sessions");
       const testFile = join(parsedDir, "test-upsert-proceed.json");
 
       mkdirSync(parsedDir, { recursive: true });
-      writeFile(
+      writeFileSync(
         testFile,
         JSON.stringify({
           messages: [{ role: "user", content: "hello" }],

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -5,7 +5,7 @@
  * to avoid duplication across test files.
  */
 
-import { mock } from "bun:test";
+import { afterAll, mock } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -166,6 +166,38 @@ export function createMockContext(overrides: Record<string, unknown> = {}): Exte
     hasPendingMessages: mock(() => false),
     ...overrides,
   } as unknown as ExtensionContext;
+}
+
+// ============================================
+// Agent directory isolation for tests
+// ============================================
+
+/**
+ * Set up a temp directory as PI_CODING_AGENT_DIR so tests don't write to the
+ * real user's ~/.pi/agent/ directory. Registers an afterAll hook to clean up.
+ *
+ * Must be called at module top level (before any test code runs) so that
+ * getAgentDir() resolves to the temp directory from the start.
+ *
+ * Saves and restores any previous PI_CODING_AGENT_DIR value in afterAll,
+ * so a developer-set value is not silently clobbered.
+ *
+ * @param label - Short label to identify the test file in the temp dir name
+ * @returns The temp directory path
+ */
+export function setupTempAgentDir(label: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `pi-hindsight-${label}-`));
+  const prevValue = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = dir;
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+    if (prevValue !== undefined) {
+      process.env.PI_CODING_AGENT_DIR = prevValue;
+    } else {
+      delete process.env.PI_CODING_AGENT_DIR;
+    }
+  });
+  return dir;
 }
 
 // ============================================

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -2,8 +2,9 @@
  * Unit tests for queue file management.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { chmodSync, existsSync, writeFileSync } from "node:fs";
+import { afterEach, describe, expect, it } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { chmodSync, existsSync, statSync, writeFileSync } from "node:fs";
 import {
   autoQueueExists,
   deleteAutoQueue,
@@ -18,14 +19,15 @@ import {
   readToolQueue,
   toolQueueExists,
 } from "../src/queue";
+import { setupTempAgentDir } from "./fixtures";
 
-// Use a unique session ID per test run to avoid collisions with real queues
+// Use a unique session ID per test run to avoid collisions
 const TEST_SESSION_ID = `test-session-${Date.now()}`;
 
-beforeEach(() => {
-  // Ensure the queue dir exists
-  ensureQueueDir();
-});
+// Redirect agent-dir filesystem operations to a temp directory instead of
+// the real user's ~/.pi/agent/ directory. PI_CODING_AGENT_DIR is read by
+// getAgentDir() in @mariozechner/pi-coding-agent.
+setupTempAgentDir("queue");
 
 afterEach(() => {
   // Clean up any queue files created during tests
@@ -49,6 +51,7 @@ describe("getToolQueuePath", () => {
 
 describe("ensureQueueDir", () => {
   it("creates queue directory if it does not exist", () => {
+    ensureQueueDir();
     const queueDir = getQueueDir();
     expect(existsSync(queueDir)).toBe(true);
   });
@@ -300,18 +303,58 @@ describe("separate queues", () => {
 // Filesystem failure tests
 // ============================================
 
+/**
+ * Attempt to make a path unwritable.
+ * - As root: uses chattr +i (immutable flag) — root bypasses unix permissions
+ * - As non-root: uses chmod 0o444
+ *
+ * Returns a restore function on success, or null if the path cannot be
+ * made unwritable (caller should skip the test).
+ */
+function tryMakeUnwritable(path: string): (() => void) | null {
+  if (process.getuid?.() === 0) {
+    // Root bypasses unix permissions — try chattr +i
+    try {
+      execFileSync("chattr", ["+i", path], { stdio: "pipe" });
+      return () => {
+        try {
+          execFileSync("chattr", ["-i", path], { stdio: "pipe" });
+        } catch {
+          // Best-effort: don't let cleanup failure mask test failures
+        }
+      };
+    } catch {
+      // Filesystem doesn't support chattr (overlayfs, FUSE, etc.)
+      return null;
+    }
+  }
+  // Non-root: chmod is sufficient. Save original mode for restore.
+  // Directories get 0o555 (traversable but not writable) so that
+  // existsSync still works and unlink actually fails with EACCES.
+  // Files get 0o444 (read-only).
+  const stats = statSync(path);
+  const originalMode = stats.mode & 0o777;
+  chmodSync(path, stats.isDirectory() ? 0o555 : 0o444);
+  return () => {
+    try {
+      chmodSync(path, originalMode);
+    } catch {
+      // Best-effort: don't let cleanup failure mask test failures
+    }
+  };
+}
+
 describe("filesystem failures", () => {
   it("enqueueAutoMessage returns false when queue dir is unwritable", () => {
-    // Make the queue directory read-only to trigger write failure
     const queueDir = getQueueDir();
-
-    // Ensure dir exists first
     ensureQueueDir();
 
-    // Make dir read-only (no write permission)
-    try {
-      chmodSync(queueDir, 0o444);
+    const restore = tryMakeUnwritable(queueDir);
+    expect(restore).not.toBeNull();
+    // Type narrowing: restore is () => void after expect guard
+    const restoreFn = restore!;
 
+    try {
       const result = enqueueAutoMessage("fs-fail-auto", {
         entry: { message: { role: "user", content: "fail" } },
         store_method: "auto",
@@ -319,19 +362,21 @@ describe("filesystem failures", () => {
 
       expect(result).toBe(false);
     } finally {
-      // Restore permissions
-      chmodSync(queueDir, 0o755);
-      // Clean up
+      restoreFn();
       deleteAutoQueue("fs-fail-auto");
     }
   });
 
   it("enqueueToolMessage returns false when queue dir is unwritable", () => {
     const queueDir = getQueueDir();
+    ensureQueueDir();
+
+    const restore = tryMakeUnwritable(queueDir);
+    expect(restore).not.toBeNull();
+    // Type narrowing: restore is () => void after expect guard
+    const restoreFn = restore!;
 
     try {
-      chmodSync(queueDir, 0o444);
-
       const result = enqueueToolMessage("fs-fail-tool", {
         content: "fail",
         timestamp: "2026-01-01T00:00:00Z",
@@ -340,7 +385,7 @@ describe("filesystem failures", () => {
 
       expect(result).toBe(false);
     } finally {
-      chmodSync(queueDir, 0o755);
+      restoreFn();
       deleteToolQueue("fs-fail-tool");
     }
   });
@@ -352,17 +397,22 @@ describe("filesystem failures", () => {
     const queuePath = getQueuePath("fs-fail-delete");
     writeFileSync(queuePath, '{"store_method":"auto","entry":{}}\n', "utf8");
 
-    // Make the file read-only so unlink fails
-    try {
-      chmodSync(queuePath, 0o444);
-      // Also make parent dir read-only to prevent deletion
-      chmodSync(queueDir, 0o555);
+    const restoreFile = tryMakeUnwritable(queuePath);
+    const restoreDir = tryMakeUnwritable(queueDir);
+    expect(restoreFile).not.toBeNull();
+    expect(restoreDir).not.toBeNull();
+    // Type narrowing: non-null after expect guards
+    const restoreFileFn = restoreFile!;
+    const restoreDirFn = restoreDir!;
 
+    try {
       // Should not throw
       expect(() => deleteAutoQueue("fs-fail-delete")).not.toThrow();
     } finally {
-      chmodSync(queueDir, 0o755);
-      chmodSync(queuePath, 0o644);
+      // Restore directory first, then file — directory must be writable
+      // before we can chmod the file back (if using chmod path).
+      restoreDirFn();
+      restoreFileFn();
       deleteAutoQueue("fs-fail-delete");
     }
   });

--- a/tests/retention.test.ts
+++ b/tests/retention.test.ts
@@ -21,8 +21,16 @@ import {
   getQueueCount,
   queueToolRetain,
 } from "../src/retention";
+import {
+  HINDSIGHT_ENV_KEYS,
+  saveEnvKeys,
+  setupTempAgentDir,
+  testConfig as sharedTestConfig,
+} from "./fixtures";
 
 const TEST_SESSION_ID = "test-session-retention";
+
+setupTempAgentDir("retention");
 
 // Type for mock client wrapper
 interface MockClientWrapper {
@@ -85,8 +93,6 @@ function createMockWrapper(
     },
   };
 }
-
-import { HINDSIGHT_ENV_KEYS, saveEnvKeys, testConfig as sharedTestConfig } from "./fixtures";
 
 // Extend shared config with retention-test-specific overrides
 const defaultConfig: HindsightConfig = {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -10,7 +10,9 @@ import type { HindsightClientWrapper } from "../src/client";
 import type { HindsightConfig } from "../src/config";
 import { deleteAutoQueue, deleteToolQueue, readToolQueue } from "../src/queue";
 import { isToolEnabled, registerTools, updateRetainToolVisibility } from "../src/tools";
-import { testConfig as sharedTestConfig } from "./fixtures";
+import { setupTempAgentDir, testConfig as sharedTestConfig } from "./fixtures";
+
+setupTempAgentDir("tools");
 
 const TEST_SESSION_ID = "test-tools-session";
 


### PR DESCRIPTION
Redirect all test files to a temp PI_CODING_AGENT_DIR instead of writing to the real ~/.pi/agent/ directory. Queue, parsed-session, and other agent directory artifacts are now created under there and cleaned up after tests. This prevents test pollution and enables chattr +i (needed for root filesystem-permission tests) since /tmp is on ext4 rather than FUSE/sandboxfs in gondolin.

Add --isolate to bun test in CI (package.json and ci.yml) so each test file runs in a fresh global object, preventing mock.module() calls in bootstrap.test.ts from permanently polluting the module registry and breaking client.test.ts and config.test.ts.