### PR TITLE
ffeat: add confirmation when toggling retention off

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,4 +11,5 @@ Keep runtime logic (`src/index.ts` event handlers) and parsing logic (`src/docum
 ## Testing
 - **No simulation tests**: Do not reimplement production logic in tests (e.g., copying filtering/transform logic into a test helper). This gives false confidence — the test passes even if the real code breaks. Instead, exercise the real handlers via integration tests (invoke handlers from `createMockPi()`, call `parseAndUpsertSession()`, etc.). See `tests/bootstrap.test.ts` for the pattern.
 - **Test behavior, not implementation**: Test descriptions and assertions should describe observable behavior (e.g. "recall works on first message") not implementation details (e.g. "uses event.prompt").
+- **Never modify the user's actual pi agent directory in tests**: Use `setupTempAgentDir()` from `fixtures.ts`. Us `makeCtx()` with an explicit session ID so queue/file operations target the test session.
 - **Run `bun run ci` after completing tasks**

--- a/src/commands/meta.ts
+++ b/src/commands/meta.ts
@@ -88,7 +88,21 @@ export function createToggleRetainSubcommand(
           updateRetainToolVisibility(pi, true);
         }
       } else {
-        // Toggling OFF: build new meta, preserving existing tags
+        // Toggling OFF: confirm since queued messages will be deleted
+        const answer = await ctx.ui.confirm(
+          "Disable retention?",
+          "Queued messages will be deleted and will not be flushed."
+        );
+
+        if (!answer) {
+          ctx.ui.notify(
+            "Retention not disabled. Use /hindsight toggle-retain again to disable.",
+            "info"
+          );
+          return;
+        }
+
+        // Build new meta, preserving existing tags
         const existingMeta = getHindsightMeta(entries);
         const meta: HindsightMeta = {
           retained: false,
@@ -102,7 +116,7 @@ export function createToggleRetainSubcommand(
           deleteToolQueue(sessionId);
         }
 
-        ctx.ui.notify("Session retention: disabled (will be ignored)", "info");
+        ctx.ui.notify("Session retention: disabled (queued messages deleted)", "info");
 
         // Hide hindsight_retain tool now that session is not retained
         if (isToolEnabled(config, "retain")) {

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -517,7 +517,7 @@ describe("registerCommands", () => {
         expect(readAutoQueue(sessionId)).toHaveLength(1);
 
         register();
-        await getHandler()("toggle-retain", makeCtx());
+        await getHandler()("toggle-retain", makeCtx(sessionId));
 
         expect(readAutoQueue(sessionId)).toHaveLength(0);
         expect(lastNotification?.message).toContain("disabled");
@@ -550,6 +550,47 @@ describe("registerCommands", () => {
       await getHandler()("toggle-retain", makeCtx());
       expect(appendedEntries).toHaveLength(0);
       expect(lastNotification?.message).toContain("Retention not enabled");
+    });
+
+    it("toggles retention off with confirm=no, does not disable or delete queues", async () => {
+      const sessionId = "test-session-confirm-no";
+      const {
+        enqueueAutoMessage,
+        enqueueToolMessage,
+        readAutoQueue,
+        readToolQueue,
+        deleteAutoQueue,
+        deleteToolQueue,
+      } = await import("../src/queue");
+      try {
+        enqueueAutoMessage(sessionId, {
+          entry: { message: { role: "user", content: "Hello" } },
+          store_method: "auto",
+        });
+        enqueueToolMessage(sessionId, {
+          content: "Tool memory",
+          tags: ["test"],
+          store_method: "tool",
+          timestamp: new Date().toISOString(),
+        });
+        expect(readAutoQueue(sessionId)).toHaveLength(1);
+        expect(readToolQueue(sessionId)).toHaveLength(1);
+
+        sessionEntries = [
+          { type: "custom", customType: "hindsight-meta", data: { retained: true } },
+        ];
+        confirmResult = false;
+        register();
+        await getHandler()("toggle-retain", makeCtx(sessionId));
+
+        expect(appendedEntries).toHaveLength(0);
+        expect(lastNotification?.message).toContain("Retention not disabled");
+        expect(readAutoQueue(sessionId)).toHaveLength(1);
+        expect(readToolQueue(sessionId)).toHaveLength(1);
+      } finally {
+        deleteAutoQueue(sessionId);
+        deleteToolQueue(sessionId);
+      }
     });
 
     it("preserves existing tags when toggling off", async () => {


### PR DESCRIPTION
Warns that queued messages will be deleted before disabling retention. Allows the user to cancel and keep retention enabled.