### PR TITLE
feat(tools): show full retained content in hindsight_retain tool UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 - **Selective tool registration via `toolsEnabled`** — `toolsEnabled` now accepts an array of tool names (e.g. `["retain", "recall"]`) to register only listed tools. Boolean `true`/`false` behavior is preserved.
 - **`hindsight_retain` tool visibility** — The `hindsight_retain` tool is now proactively hidden via `pi.setActiveTools()` when the session is not retained, instead of showing an error on execution. Visibility is updated on `session_start` and `toggle-retain`.
 - **Retention toggle confirmation** — Toggling retention off now warns that queued messages will be deleted and asks for confirmation.
-- **Retained content in tool UI** — `hindsight_retain` now shows the actual retained content (dimmed, truncated to 200 chars) in the TUI alongside the success indicator.
+- **Retained content in tool UI** — `hindsight_retain` now shows the full retained content (dimmed) in the TUI alongside the success indicator.
+- **Config validation is non-fatal for most settings** — Invalid values now produce warnings and reset to defaults instead of disabling the plugin. Only `apiUrl`, `apiKey`, `bankId`, and missing `observationScopes` remain as errors. Warnings now include the fallback value. Also fixes several validation bugs: shallow copy bug sharing references with `DEFAULT_CONFIG`, crash on missing `retainContent`/`strip` sub-properties, suppressed warnings when config is invalid, and more.
 
 ### Deprecations
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -107,9 +107,8 @@ export function registerTools(
         const details = result.details as RetainDetails;
         if (details.success) {
           const retained = context.args.content ?? "";
-          const preview = retained.length > 200 ? `${retained.slice(0, 200)}...` : retained;
           text.setText(
-            `${theme.fg("success", "✓ Memory queued for storage")}\n${theme.fg("dim", preview)}`
+            `${theme.fg("success", "✓ Memory queued for storage")}\n${theme.fg("dim", retained)}`
           );
         } else {
           text.setText(theme.fg("error", `✗ ${details.error ?? "Failed to store memory"}`));


### PR DESCRIPTION
Remove 200-character truncation of the retained text preview. The user needs to see the full content to verify what was stored.

Also update changelog for previous config validation commit.