### PR TITLE
feat: add extra context field, flush guard, and get/set tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ jobs:
       - run: bun install --frozen-lockfile
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
       - name: Run tests with coverage
-        run: bun test --isolate --coverage | tee coverage-output.txt
+        run: |
+          set -o pipefail
+          bun test --isolate --coverage | tee coverage-output.txt
       - name: Check coverage threshold
         run: |
           COVERAGE=$(grep 'All files' coverage-output.txt | awk -F'|' '{gsub(/ /, "", $3); print $3}')

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,6 @@
 # Agent Instructions for pi-hindsight
 - Use conventional commit messages
+- Update CHANGELOG.md under the Pending section for any user-facing or internal changes
 
 ## Runtime vs Parsing Parity
 Keep runtime logic (`src/index.ts` event handlers) and parsing logic (`src/document.ts` `isConversationMessage()`, `src/prepare.ts`) consistent:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,34 @@
 
 ### Features
 
+- **Extra context field and flush guard** — New `requireExtraContextBeforeFlush` config option that blocks automatic flushing until extra context is set via `/hindsight set-extra-context` or the `hindsight_set_extra_context` tool. Helps prevent incorrect extraction for sessions involving fiction, satire, or external content. Extra context is appended to the Hindsight `context` field after the session name.
+- **`hindsight_set_extra_context` tool** — Set extra context/caveats for extraction from the LLM. Setting an empty string satisfies the flush guard.
+- **`hindsight_get_extra_context` tool** — Query the current extra context. Shows distinct messages for set, empty (flush guard satisfied), and not-set states.
+- **`/hindsight set-extra-context` subcommand** — Slash command to set extra context. Call with no text to set empty extra context (satisfies flush guard).
+- **`autoRecallRole` config** — Choose whether auto-recall messages are injected as `user` or `assistant` role (default: `user`). Env var: `PI_HINDSIGHT_AUTO_RECALL_ROLE`.
 - **`autoRecallTagGroups` config** — Compound boolean tag expressions (and/or/not) for auto-recall filtering. Supports recursive nesting and the same placeholders as `autoRecallTags`. When both `autoRecallTags` and `autoRecallTagGroups` are set, both are sent to the recall API and combined. Env var: `PI_HINDSIGHT_AUTO_RECALL_TAG_GROUPS`.
 - **Selective tool registration via `toolsEnabled`** — `toolsEnabled` now accepts an array of tool names (e.g. `["retain", "recall"]`) to register only listed tools. Boolean `true`/`false` behavior is preserved.
 - **`hindsight_retain` tool visibility** — The `hindsight_retain` tool is now proactively hidden via `pi.setActiveTools()` when the session is not retained, instead of showing an error on execution. Visibility is updated on `session_start` and `toggle-retain`.
 - **Retention toggle confirmation** — Toggling retention off now warns that queued messages will be deleted and asks for confirmation.
 - **Retained content in tool UI** — `hindsight_retain` now shows the full retained content (dimmed) in the TUI alongside the success indicator.
 - **Config validation is non-fatal for most settings** — Invalid values now produce warnings and reset to defaults instead of disabling the plugin. Only `apiUrl`, `apiKey`, `bankId`, and missing `observationScopes` remain as errors. Warnings now include the fallback value. Also fixes several validation bugs: shallow copy bug sharing references with `DEFAULT_CONFIG`, crash on missing `retainContent`/`strip` sub-properties, suppressed warnings when config is invalid, and more.
+
+### Fixes
+
+- **Deduplicate session shutdown flush** — `session_shutdown` no longer re-flushes for `new`/`resume`/`fork` reasons since `session_before_switch`/`session_before_fork` already handle those cases. Prevents duplicate messages on `/new` and `/resume`.
+- **`flushOnCompact` uses `session_before_compact`** — Switched from `session_compact` (which was not reliably dispatched) to `session_before_compact`, which also flushes before the compaction rewrites context — a better fit.
+- **`NaN`/`Infinity` config values** — `setConfigValue` now rejects `NaN` and `Infinity` for numeric fields (`hindsightContextMaxLength`, `recallMaxQueryChars`, `maxRecallTokens`) instead of silently accepting them.
+- **`hindsightContextPrefix` longer than max** — `validateConfig` now warns when the prefix exceeds `hindsightContextMaxLength`, since auto-derived names won't be truncated in that case.
+- **Consistent `??` operator** — Replaced `||` with `??` for optional header fields (`timestamp`, `cwd`) to correctly handle empty-string edge cases.
+- **Consistent flush guard wording** — Aligned "No extra context needed" wording between `get_extra_context` execute result and renderer (previously "set" vs "needed").
+
+### Changes
+
+- **Unified session name derivation** — Consolidated `truncateSessionTitle` and `getHindsightContextFromEntries` into a new `deriveSessionName` function (single source of truth). Removed `appendExtraContext`. All callers use `deriveSessionName`/`getSessionDisplayName` + `buildContextFromSessionName`, ensuring runtime/parsing parity. `hindsightContextMaxLength` limits the total context length (prefix + name); manually set names are preserved as-is.
+- **Extra context in `/hindsight status`** — Moved to its own `== Extra Context ==` section with clearer messaging: full text if set, "(empty — flush guard satisfied)" if explicitly empty, or "(not set)" if never configured.
+- **Feature flags in `/hindsight status`** — Added `Flush on compact` and `Require extra context` to the `== Features ==` section.
+- **Documentation: `hindsightContextMaxLength`** — Clarified that it limits the total context field length (prefix + name), not just the name portion. Manually set session names are preserved as-is and may exceed this length.
+- **Documentation: `set-extra-context`** — Removed misleading quoted examples (e.g. `"..."`) since the command handler does not strip quotes. To set empty extra context, call with no text.
 
 ### Deprecations
 
@@ -23,6 +45,9 @@
 - Added `--isolate` to `bun test` in CI to prevent `mock.module()` pollution across test files.
 - Added commitlint with conventional config.
 - Compressed tool descriptions and parameter docs for token savings.
+- Fixed CI masking test failures: `set -o pipefail` ensures `bun test` exit code propagates through `tee` pipe.
+- Split reference documentation into `docs/reference.md` for detailed config, tools, commands, and operational docs.
+- Improved README clarity and completeness.
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Pending
 
+## 0.3.0
+
 ### Features
 
 - **Extra context field and flush guard** — New `requireExtraContextBeforeFlush` config option that blocks automatic flushing until extra context is set via `/hindsight set-extra-context` or the `hindsight_set_extra_context` tool. Helps prevent incorrect extraction for sessions involving fiction, satire, or external content. Extra context is appended to the Hindsight `context` field after the session name.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Status: I would call this beta level software, though I am focusing on stability
 
 # Table of Contents
 - [Key Features](#key-features)
+  - [Retain Memories](#retain-memories)
+  - [Auto-Recall Memories](#auto-recall-memories)
+  - [Reflect](#reflect)
 - [Philosophy](#philosophy)
 - [Local Quickstart](#local-quickstart)
 - [Configuration](#configuration)
@@ -46,7 +49,7 @@ You can set up [mental models](https://hindsight.vectorize.io/developer/api/ment
 Follow [hindsight best practices](https://hindsight.vectorize.io/best-practices):
 - Retains messages as JSON, which hindsight can intelligently chunk
 - Retains all data for the same session with the same `document_id`
-- Uses manually set session name or truncated first message as `context` field
+- Uses manually set session name (preserved as-is) or truncated first message as `context` field
 - Sets the `timestamp` field
 
 Additionally:
@@ -140,7 +143,10 @@ Configuration is stored in `<getAgentDir()>/extensions/pi-hindsight/config.json`
   // switch to ["{project}"] if you want project-scoped recall instead
   "autoRecallTags": ["user:<me>"],
   // don't include untagged memories
-  "autoRecallTagsMatch": "any_strict"
+  "autoRecallTagsMatch": "any_strict",
+  // require extra context to be set before flushing prevents accidental retention
+  // of fiction or content not about the user that could be misclassified by extraction
+  // "requireExtraContextBeforeFlush": true,
 }
 ```
 
@@ -151,6 +157,7 @@ Configuration is stored in `<getAgentDir()>/extensions/pi-hindsight/config.json`
 - Configure your [observation scopes](docs/reference.md#observationscopes) to control how observations are consolidated across sessions.
 - Consider whether you want to ingest tool calls and results. Including tool calls might be useful for remembering details about writes/edits (especially if you use pi for writing prose). Including tool results might be useful, for example, if you want to store memories about reads. You can always keep both and put more details about what should be ignored in your retain mission.
 - Consider whether you want to ingest assistant thinking or just the final output
+- If you are getting incorrect memories extracted (e.g. other people conflated with the user), consider [setting extra context](docs/reference.md#extra-context--flush-guard) for sessions; this is especially useful for non-programming sessions
 
 Example - For the retain mission, you may want to experiment with including something like this to avoid retaining duplicate information that may end up in the LLM thinking or final output after recall/reflect:
 - "Ignore resurfaced information that has already been stored or meta-commentary about it (unless the commentary is a new realization, surprise, correction, or new connection; in that case retain only the new commentary)"

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -10,6 +10,8 @@ Detailed configuration, tools, commands, and operational details for pi-hindsigh
     - [autoRecallPersist Tradeoffs](#autorecallpersist-tradeoffs)
   - [Status Bar Indicator](#status-bar-indicator)
   - [Session Retention Control](#session-retention-control)
+  - [Extra Context & Flush Guard](#extra-context--flush-guard)
+    - [Flush Guard](#flush-guard)
   - [Content Retention & Stripping Settings](#content-retention--stripping-settings)
     - [retainContent](#retaincontent)
     - [strip](#strip)
@@ -35,17 +37,18 @@ Configuration is stored in `<getAgentDir()>/extensions/pi-hindsight/config.json`
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `enabled` | `true` | Enable or disable the extension. When `false`, the extension runs in a lightweight disabled mode (see [Disabled Mode](#disabled-mode)). |
-| `toolsEnabled` | `true` | Which tools to register: `true` (all), `false` (none), or array of tool names (`"retain"`, `"recall"`, `"reflect"`) |
+| `toolsEnabled` | `true` | Which tools to register: `true` (all), `false` (none), or array of tool names (`"retain"`, `"recall"`, `"reflect"`, `"set_extra_context"`, `"get_extra_context"`) |
 | `autoRecallEnabled` | `true` | Automatically recall relevant memories before each LLM call |
 | `autoRetainEnabled` | `true` | Automatically queue messages for retention on `message_end` (see [Session Retention Control](#session-retention-control)) |
 | `autoRecallBudget` | `"mid"` | Recall retrieval budget. One of `"low"`, `"mid"`, `"high"`. Controls how many results Hindsight returns. |
 | `hindsightContextPrefix` | `"pi: "` | Prefix prepended to the session name or first message when building the `context` field for retained documents |
-| `hindsightContextMaxLength` | `100` | Maximum character length for the `context` field (after prefix). The context is truncated to this length. |
+| `hindsightContextMaxLength` | `100` | Maximum character length for the `context` field (including prefix) when the session name is auto-derived from the first user message. Manually set session names are preserved as-is and may exceed this length. |
 | `maxRecallTokens` | `null` | Maximum tokens for recalled content. When `null`, uses Hindsight's default (4096). See [max tokens context window size](https://hindsight.vectorize.io/developer/retrieval#max-tokens-context-window-size) for details. |
 | `recallMaxQueryChars` | `800` | Maximum characters from the user's message to use as the recall query |
 | `recallPromptPreamble` | *(see defaults)* | The system note text inside `<hindsight_memories>` fences that instructs the LLM how to use recalled memories |
 | `constantTags` | `["harness:pi"]` | Tags included on every retained document (useful for filtering in Hindsight) |
 | `flushOnCompact` | `false` | Flush queued messages to Hindsight after a compaction event |
+| `requireExtraContextBeforeFlush` | `false` | Block automatic flush until extra context is set via `/hindsight set-extra-context` or the `hindsight_set_extra_context` tool. Helps prevent incorrect extraction for sessions involving satire, fiction, external blog posts, or other content that could be misclassified. See [Extra Context & Flush Guard](#extra-context--flush-guard). |
 
 ### Disabled Mode
 When `enabled: false`, pi-hindsight runs in a lightweight disabled mode. No tools, commands, API client, auto-recall, auto-retain, or status indicator are registered. However, two things are still handled:
@@ -146,7 +149,40 @@ When toggling retention:
 
 Tags added via `/hindsight tag` are included in the document tags when flushing to Hindsight, alongside the automatic tags (session ID, cwd, parent, etc.).
 
-Session metadata (retention state and tags) is stored as a `CustomEntry` in the session file with `customType: "hindsight-meta"`, so it persists across session restarts but is not sent to the LLM.
+Session metadata (retention state, tags, and extra context) is stored as a `CustomEntry` in the session file with `customType: "hindsight-meta"`, so it persists across session restarts but is not sent to the LLM.
+
+## Extra Context & Flush Guard
+
+**Extra context** is an optional caveat string appended to the Hindsight `context` field (after the session name), separated by a newline. It helps Hindsight correctly classify content during extraction — for example, indicating that a session involves taking notes on fiction or any content not written by the user.
+
+Extra context is used in all places the Hindsight context field is used:
+- **Fact extraction**: Included in the extraction prompt so the LLM knows the nature of the source
+- **Full-text search**: Indexed in the tsvector for recall filtering
+- **Consolidation**: Included in source fact data passed to the observation synthesis LLM
+- **Recall results**: Returned as a field on each memory fact
+- **Reflect agent**: Available as context for answer synthesis
+
+There are two ways to set extra context:
+1. **Slash command**: `/hindsight set-extra-context This session involves reading Dune by Frank Herbert; characters are not the user`
+2. **Tool**: `hindsight_set_extra_context` — the LLM can set extra context directly (useful when the model recognizes the need or at the end of a session - ask model to summarize the overall session and provide necessary context to avoid out-of-context/incorrect memories)
+
+Call with no text (`/hindsight set-extra-context`) to indicate no extra context is needed (satisfies the flush guard).
+
+### Flush Guard
+
+When `requireExtraContextBeforeFlush: true`, automatic and manual flush operations are blocked until extra context is explicitly set. This prevents accidental retention of content that could be misclassified by Hindsight's extraction.
+
+The flush guard distinguishes between three states:
+
+| Extra Context | Flush Guard | Behavior |
+|---------------|-------------|----------|
+| Never set | **Blocked** | Flush is blocked — you must set extra context first |
+| Set to empty string (`""`) | **Satisfied** | Flush proceeds — you've confirmed no extra context is needed |
+| Set to non-empty string | **Satisfied** | Flush proceeds — extraction will use the provided caveats |
+
+This is particularly useful for sessions involving prose to prevent Hindsight from treating fictional characters as real people, fictional events as factual, or even real people as the user.
+
+The guard is checked at every flush point: session switch, shutdown, compact (if `flushOnCompact: true`), and manual `/hindsight flush`.
 
 ## Content Retention & Stripping Settings
 ### `retainContent`
@@ -490,6 +526,7 @@ Configuration options can also be set via environment variables (override config
 | `PI_HINDSIGHT_AUTO_RECALL_TAG_GROUPS` | `autoRecallTagGroups` | TagGroupInput[] (JSON) | `null` |
 | `PI_HINDSIGHT_CONSTANT_TAGS` | `constantTags` | string[] (JSON) | `["harness:pi"]` |
 | `PI_HINDSIGHT_FLUSH_ON_COMPACT` | `flushOnCompact` | boolean | `false` |
+| `PI_HINDSIGHT_REQUIRE_EXTRA_CONTEXT_BEFORE_FLUSH` | `requireExtraContextBeforeFlush` | boolean | `false` |
 | `PI_HINDSIGHT_RETAIN_SESSIONS_BY_DEFAULT` | `retainSessionsByDefault` | boolean | `true` |
 | `PI_HINDSIGHT_RETAIN_CONTENT` | `retainContent` | RetainContent (JSON) | *(see retainContent default)* |
 | `PI_HINDSIGHT_STRIP` | `strip` | StripConfig (JSON) | *(see strip default)* |
@@ -534,13 +571,15 @@ The `recallPromptPreamble` config option (shown inside the fence above) defaults
 | Queue file corruption | Skip malformed lines on read (partial data loss) |
 
 # Tools
-When `toolsEnabled: true` (default), all three tools are available. Set to an array of tool names (`"retain"`, `"recall"`, `"reflect"`) to register only specific tools, or `false` to disable all tools.
+When `toolsEnabled: true` (default), all tools are available. Set to an array of tool names (`"retain"`, `"recall"`, `"reflect"`, `"set_extra_context"`, `"get_extra_context"`) to register only specific tools, or `false` to disable all tools.
 
 | Tool | Description |
 |------|-------------|
 | `hindsight_retain` | Store information to long-term memory. Queues to disk and retains on next flush. Use for facts, preferences, decisions, or any information worth remembering. |
 | `hindsight_recall` | Search long-term memory using multi-strategy retrieval. Supports filtering by tags, memory types (`world`/`experience`/`observation`), and budget. |
 | `hindsight_reflect` | Generate a synthesized answer from long-term memory. Unlike recall which returns raw facts, reflect uses the bank's identity, mental models, and multi-step reasoning to produce a contextual markdown answer. Best for questions requiring synthesis of multiple memories. |
+| `hindsight_set_extra_context` | Set extra context/caveats for Hindsight extraction. Appended to the context field (after session name) to help extraction correctly extract memories. See [Extra Context & Flush Guard](#extra-context--flush-guard). |
+| `hindsight_get_extra_context` | Get the current extra context set for this session. |
 
 # Slash Commands
 All commands are under `/hindsight <subcommand>`. With no subcommand, defaults to `status`.
@@ -551,10 +590,10 @@ All commands are under `/hindsight <subcommand>`. With no subcommand, defaults t
 | `toggle-retain` | Toggle whether the current session should be retained |
 | `tag <tag>` | Add a tag to the session's hindsight metadata |
 | `remove-tag <tag>` | Remove a tag from the session's hindsight metadata |
+| `set-extra-context <text>` | Set extra context for extraction caveats (appended to Hindsight context field). Call with no text to indicate no extra context is needed (satisfies the flush guard). |
 | `toggle-display` | Toggle recall message visibility in UI |
 | `popup` | Pop up last recalled messages in overlay |
-| `queue-status` | Show count of queued messages |
-| `status` | Show operational status (connection, session, recall info) |
+| `status` | Show operational status (connection, session, recall info, queue count) |
 | `config` | Show configuration (file path, env vars, masked config) |
 | `parse-session` | Parse current session to file for manual review |
 | `parse-and-upsert-session` | Parse and upsert the full current session to Hindsight |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -47,7 +47,7 @@ Configuration is stored in `<getAgentDir()>/extensions/pi-hindsight/config.json`
 | `recallMaxQueryChars` | `800` | Maximum characters from the user's message to use as the recall query |
 | `recallPromptPreamble` | *(see defaults)* | The system note text inside `<hindsight_memories>` fences that instructs the LLM how to use recalled memories |
 | `constantTags` | `["harness:pi"]` | Tags included on every retained document (useful for filtering in Hindsight) |
-| `flushOnCompact` | `false` | Flush queued messages to Hindsight after a compaction event |
+| `flushOnCompact` | `false` | Flush queued messages to Hindsight before a compaction event |
 | `requireExtraContextBeforeFlush` | `false` | Block automatic flush until extra context is set via `/hindsight set-extra-context` or the `hindsight_set_extra_context` tool. Helps prevent incorrect extraction for sessions involving satire, fiction, external blog posts, or other content that could be misclassified. See [Extra Context & Flush Guard](#extra-context--flush-guard). |
 
 ### Disabled Mode

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hindsight",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -13,6 +13,7 @@ import type { HindsightClientWrapper } from "../client";
 import type { HindsightConfig } from "../config";
 import type { RecallMessageDetails } from "../index";
 import {
+  createExtraContextSubcommand,
   createRemoveTagSubcommand,
   createTagSubcommand,
   createToggleRetainSubcommand,
@@ -60,6 +61,7 @@ export function registerCommands(
     "toggle-retain": createToggleRetainSubcommand(pi, client, config),
     tag: createTagSubcommand(pi),
     "remove-tag": createRemoveTagSubcommand(pi),
+    "set-extra-context": createExtraContextSubcommand(pi),
     "toggle-display": createToggleDisplaySubcommand(
       config,
       getAutoRecallDisplayOverride,

--- a/src/commands/meta.ts
+++ b/src/commands/meta.ts
@@ -5,7 +5,12 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { HindsightClientWrapper } from "../client";
 import type { HindsightConfig } from "../config";
-import { getHindsightMeta, type HindsightMeta, shouldSessionBeRetained } from "../meta";
+import {
+  buildMetaUpdate,
+  getHindsightMeta,
+  hasExtraContext,
+  shouldSessionBeRetained,
+} from "../meta";
 import { deleteAutoQueue, deleteToolQueue } from "../queue";
 import { isToolEnabled, updateRetainToolVisibility } from "../tools";
 import type { Subcommand } from "./types";
@@ -39,6 +44,16 @@ export function createToggleRetainSubcommand(
       const sessionId = ctx.sessionManager.getSessionId();
 
       if (newShouldRetain) {
+        // Block toggling on if flush guard is active and extra context isn't set.
+        // Without extra context, the subsequent parse-and-upsert would also be blocked.
+        if (config.requireExtraContextBeforeFlush && !hasExtraContext(getHindsightMeta(entries))) {
+          ctx.ui.notify(
+            "Cannot enable retention: extra context not set. Use /hindsight set-extra-context or the hindsight_set_extra_context tool first.",
+            "warning"
+          );
+          return;
+        }
+
         // Toggling ON: ask if user wants to parse-and-upsert first so the
         // full session content is retained (newly queued messages append correctly)
         const answer = await ctx.ui.confirm(
@@ -54,12 +69,8 @@ export function createToggleRetainSubcommand(
           return;
         }
 
-        // Build new meta, preserving existing tags
         const existingMeta = getHindsightMeta(entries);
-        const meta: HindsightMeta = {
-          retained: true,
-          ...(existingMeta?.tags ? { tags: existingMeta.tags } : {}),
-        };
+        const meta = buildMetaUpdate(existingMeta, { retained: true });
         pi.appendEntry("hindsight-meta", meta);
 
         // Delete any existing queue files
@@ -102,12 +113,8 @@ export function createToggleRetainSubcommand(
           return;
         }
 
-        // Build new meta, preserving existing tags
         const existingMeta = getHindsightMeta(entries);
-        const meta: HindsightMeta = {
-          retained: false,
-          ...(existingMeta?.tags ? { tags: existingMeta.tags } : {}),
-        };
+        const meta = buildMetaUpdate(existingMeta, { retained: false });
         pi.appendEntry("hindsight-meta", meta);
 
         // Delete queue files so queued messages will NOT be flushed
@@ -154,11 +161,7 @@ export function createTagSubcommand(pi: ExtensionAPI): Subcommand {
 
       tags.push(tag);
 
-      const meta: HindsightMeta = {
-        ...(existingMeta?.retained !== undefined ? { retained: existingMeta.retained } : {}),
-        tags,
-      };
-
+      const meta = buildMetaUpdate(existingMeta, { tags });
       pi.appendEntry("hindsight-meta", meta);
       ctx.ui.notify(`Tag "${tag}" added`, "info");
     },
@@ -193,13 +196,52 @@ export function createRemoveTagSubcommand(pi: ExtensionAPI): Subcommand {
 
       tags.splice(index, 1);
 
-      const meta: HindsightMeta = {
-        ...(existingMeta?.retained !== undefined ? { retained: existingMeta.retained } : {}),
-        ...(tags.length > 0 ? { tags } : {}),
-      };
-
+      const meta = buildMetaUpdate(existingMeta, { tags });
       pi.appendEntry("hindsight-meta", meta);
       ctx.ui.notify(`Tag "${tag}" removed`, "info");
+    },
+  };
+}
+
+/**
+ * Create the set-extra-context subcommand — set extra context for the Hindsight context field.
+ *
+ * Extra context is appended after the session name in the Hindsight context string,
+ * separated by a newline. It provides caveats/instructions for extraction to help
+ * Hindsight correctly classify content (e.g., "This session involves reading a fiction
+ * book; characters are not the user and information is not factual").
+ *
+ * The extra context is used in all places the Hindsight context field is used:
+ * - Fact extraction: included in the extraction prompt so the LLM knows the nature of the source
+ * - Full-text search: indexed in the tsvector for recall filtering
+ * - Consolidation: included in source fact data passed to the observation synthesis LLM
+ * - Recall results: returned as a field on each memory fact
+ * - Reflect agent: available as context for answer synthesis
+ *
+ * Pass an empty string ("") to indicate that no extra context is needed for this session.
+ * This is distinct from not having set extra context at all: when requireExtraContextBeforeFlush
+ * is enabled, an explicit empty string satisfies the flush guard (you've confirmed you don't
+ * need extra context), while never having set it blocks the flush.
+ * Replaces any previously set extra context.
+ */
+export function createExtraContextSubcommand(pi: ExtensionAPI): Subcommand {
+  return {
+    description: "Set extra context for extraction caveats (appended to Hindsight context field)",
+    handler: async (args: string, ctx: ExtensionContext) => {
+      const extraContext = args.trim();
+
+      const entries = ctx.sessionManager.getEntries();
+      const existingMeta = getHindsightMeta(entries);
+
+      // Always store extraContext (even empty string) so the flush guard
+      // can distinguish "explicitly set to empty" from "never set".
+      const meta = buildMetaUpdate(existingMeta, { extraContext });
+      pi.appendEntry("hindsight-meta", meta);
+      if (extraContext) {
+        ctx.ui.notify(`Extra context set`, "info");
+      } else {
+        ctx.ui.notify(`No extra context needed (flush guard satisfied)`, "info");
+      }
     },
   };
 }

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -8,8 +8,9 @@ import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import type { HindsightClientWrapper } from "../client";
 import type { HindsightConfig } from "../config";
-import { flushQueues, getQueueCount } from "../retention";
-import { extractParentSessionId, getSessionDisplayName } from "../utils";
+import { getHindsightMeta, hasExtraContext } from "../meta";
+import { FLUSH_BLOCKED_NO_EXTRA_CONTEXT, flushQueues, getQueueCount } from "../retention";
+import { deriveSessionName, extractParentSessionId, getContextNameMaxLength } from "../utils";
 import type { Subcommand } from "./types";
 import { parseAndUpsertSession, parseCurrentSession, upsertToHindsight } from "./utils";
 
@@ -43,15 +44,26 @@ export function createFlushSubcommand(
         return;
       }
 
+      // Check flush guard: requireExtraContextBeforeFlush
+      if (config.requireExtraContextBeforeFlush) {
+        const entries = ctx.sessionManager.getEntries();
+        const meta = getHindsightMeta(entries);
+        if (!hasExtraContext(meta)) {
+          ctx.ui.notify(FLUSH_BLOCKED_NO_EXTRA_CONTEXT, "warning");
+          return;
+        }
+      }
+
       const header = ctx.sessionManager.getHeader();
-      const sessionName = getSessionDisplayName(
-        ctx.sessionManager.getSessionName.bind(ctx.sessionManager),
-        ctx.sessionManager.getEntries.bind(ctx.sessionManager)
-      );
-      const sessionStartTime = header?.timestamp || new Date().toISOString();
-      const sessionCwd = header?.cwd || ctx.cwd;
-      const parentSessionId = extractParentSessionId(header?.parentSession);
       const entries = ctx.sessionManager.getEntries();
+      const sessionName = deriveSessionName(
+        ctx.sessionManager.getSessionName(),
+        entries,
+        getContextNameMaxLength(config)
+      );
+      const sessionStartTime = header?.timestamp ?? new Date().toISOString();
+      const sessionCwd = header?.cwd ?? ctx.cwd;
+      const parentSessionId = extractParentSessionId(header?.parentSession);
 
       ctx.ui.notify(`Flushing ${count} messages...`, "info");
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -39,7 +39,7 @@ export function createStatusSubcommand(
         lines.push("  Server: not configured");
       }
 
-      // Bank and session info
+      // Session and queue info
       lines.push("\n== Session ==");
       lines.push(`  Bank ID: ${config.bankId}`);
       const sessionId = ctx.sessionManager.getSessionId();
@@ -52,12 +52,19 @@ export function createStatusSubcommand(
       const meta = getHindsightMeta(sessionEntries);
       const tags = meta?.tags ?? [];
       lines.push(`  Tags: ${tags.length > 0 ? tags.join(", ") : "none"}`);
-
-      // Queue status
       if (sessionId) {
         const queueCount = getQueueCount(sessionId);
         lines.push(`  Queued messages: ${queueCount}`);
       }
+
+      // Extra context
+      lines.push("\n== Extra Context ==");
+      const extraContext = meta?.extraContext;
+      lines.push(
+        extraContext !== undefined
+          ? extraContext || "(empty — no extra context needed, flush guard satisfied)"
+          : "(not set)"
+      );
 
       // Last recall status
       lines.push("\n== Last Recall ==");
@@ -75,6 +82,10 @@ export function createStatusSubcommand(
       lines.push("\n== Features ==");
       lines.push(`  Auto-recall: ${config.autoRecallEnabled ? "enabled" : "disabled"}`);
       lines.push(`  Auto-retain: ${config.autoRetainEnabled ? "enabled" : "disabled"}`);
+      lines.push(`  Flush on compact: ${config.flushOnCompact ? "enabled" : "disabled"}`);
+      lines.push(
+        `  Require extra context: ${config.requireExtraContextBeforeFlush ? "enabled" : "disabled"}`
+      );
 
       // Active recall settings
       lines.push("\n== Auto Recall Settings ==");

--- a/src/commands/utils.ts
+++ b/src/commands/utils.ts
@@ -9,14 +9,20 @@ import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import type { HindsightClientWrapper } from "../client";
 import { expandSessionObservationScopes, type HindsightConfig } from "../config";
 import {
+  buildContextFromSessionName,
   buildDocumentTags,
   buildMessageArrayFromParsedSession,
-  getHindsightContextFromEntries,
   parseSessionFile,
 } from "../document";
-import { getHindsightMeta, shouldSessionBeRetained } from "../meta";
+import { getHindsightMeta, hasExtraContext, shouldSessionBeRetained } from "../meta";
 import { deleteAutoQueue } from "../queue";
-import { extractParentSessionId, getProjectName, getSessionDisplayName } from "../utils";
+import { FLUSH_BLOCKED_NO_EXTRA_CONTEXT } from "../retention";
+import {
+  extractParentSessionId,
+  getContextNameMaxLength,
+  getProjectName,
+  getSessionDisplayName,
+} from "../utils";
 
 /** Notification level for early-exit results from {@link parseCurrentSession}. */
 export type ParseExitLevel = "error" | "warning";
@@ -96,12 +102,17 @@ export function parseCurrentSession(
   const sessionTags = parsedMeta?.tags ?? [];
   const sessionName = getSessionDisplayName(
     ctx.sessionManager.getSessionName.bind(ctx.sessionManager),
-    ctx.sessionManager.getEntries.bind(ctx.sessionManager)
+    ctx.sessionManager.getEntries.bind(ctx.sessionManager),
+    getContextNameMaxLength(config)
   );
 
   const parentSessionId = extractParentSessionId(header.parentSession);
   const tags = buildDocumentTags(header, config, { sessionTags, parentSessionId });
-  const context = getHindsightContextFromEntries(originalEntries, config, sessionName);
+  const context = buildContextFromSessionName(
+    config.hindsightContextPrefix,
+    sessionName,
+    parsedMeta?.extraContext
+  );
   const parsedSession = {
     documentId,
     context,
@@ -184,6 +195,21 @@ export async function parseAndUpsertSession(
   config: HindsightConfig,
   client: HindsightClientWrapper
 ): Promise<{ message: string; level: "info" | ParseExitLevel }> {
+  // Check flush guard: requireExtraContextBeforeFlush
+  // This applies to all insertion paths (not just the auto-flush path)
+  // because the point of the setting is to ensure extra context is always
+  // set before inserting to Hindsight.
+  if (config.requireExtraContextBeforeFlush) {
+    const entries = ctx.sessionManager.getEntries();
+    const meta = getHindsightMeta(entries);
+    if (!hasExtraContext(meta)) {
+      return {
+        message: FLUSH_BLOCKED_NO_EXTRA_CONTEXT,
+        level: "warning",
+      };
+    }
+  }
+
   const result = parseCurrentSession(ctx, config);
 
   if ("message" in result) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,9 +72,15 @@ export type TagGroupInput = TagGroupLeaf | TagGroupAndInput | TagGroupOrInput | 
 /** Role used when injecting auto-recall messages into the LLM context. */
 export type AutoRecallRole = "user" | "assistant";
 
-export type ToolName = "retain" | "recall" | "reflect";
+export type ToolName = "retain" | "recall" | "reflect" | "set_extra_context" | "get_extra_context";
 
-const VALID_TOOL_NAMES: ToolName[] = ["retain", "recall", "reflect"];
+const VALID_TOOL_NAMES: ToolName[] = [
+  "retain",
+  "recall",
+  "reflect",
+  "set_extra_context",
+  "get_extra_context",
+];
 
 export interface HindsightConfig {
   enabled: boolean;
@@ -104,6 +110,8 @@ export interface HindsightConfig {
   toolFilter: ToolFilter;
   flushOnCompact: boolean;
   retainSessionsByDefault: boolean;
+  /** When true, auto-flush events are blocked (warn instead) until extra context is set via /hindsight set-extra-context or the hindsight_set_extra_context tool. Default: false. */
+  requireExtraContextBeforeFlush: boolean;
   entities: EntityInput[];
   observationScopes: ObservationScopes;
   statusHealthy: string;
@@ -162,6 +170,7 @@ const DEFAULT_CONFIG: HindsightConfig = {
   },
   flushOnCompact: false,
   retainSessionsByDefault: true,
+  requireExtraContextBeforeFlush: false,
   entities: [],
   observationScopes: null,
   statusHealthy: "🧠",
@@ -197,6 +206,7 @@ const VALID_CONFIG_KEYS = new Set<keyof HindsightConfig>([
   "toolFilter",
   "flushOnCompact",
   "retainSessionsByDefault",
+  "requireExtraContextBeforeFlush",
   "entities",
   "observationScopes",
   "statusHealthy",
@@ -502,6 +512,7 @@ function setConfigValue(
     case "autoRecallDisplay":
     case "autoRecallPersist":
     case "retainSessionsByDefault":
+    case "requireExtraContextBeforeFlush":
     case "flushOnCompact": {
       if (typeof value === "boolean") {
         config[key] = value;
@@ -525,7 +536,7 @@ function setConfigValue(
     }
     case "hindsightContextMaxLength":
     case "recallMaxQueryChars": {
-      if (typeof value === "number") {
+      if (typeof value === "number" && Number.isFinite(value)) {
         config[key] = value;
         return;
       }
@@ -534,7 +545,7 @@ function setConfigValue(
       return result.warning;
     }
     case "maxRecallTokens": {
-      if (typeof value === "number") {
+      if (typeof value === "number" && Number.isFinite(value)) {
         config[key] = value;
         return;
       }
@@ -1099,6 +1110,7 @@ export function loadConfig(extensionsDir?: string): {
     PI_HINDSIGHT_CONSTANT_TAGS: "constantTags",
     PI_HINDSIGHT_FLUSH_ON_COMPACT: "flushOnCompact",
     PI_HINDSIGHT_RETAIN_SESSIONS_BY_DEFAULT: "retainSessionsByDefault",
+    PI_HINDSIGHT_REQUIRE_EXTRA_CONTEXT_BEFORE_FLUSH: "requireExtraContextBeforeFlush",
     PI_HINDSIGHT_RETAIN_CONTENT: "retainContent",
     PI_HINDSIGHT_STRIP: "strip",
     PI_HINDSIGHT_TOOL_FILTER: "toolFilter",
@@ -1196,6 +1208,11 @@ export function validateConfig(config: HindsightConfig): {
       `hindsightContextMaxLength must be >= 0. Using default: ${DEFAULT_CONFIG.hindsightContextMaxLength}.`
     );
     config.hindsightContextMaxLength = DEFAULT_CONFIG.hindsightContextMaxLength;
+  }
+  if (config.hindsightContextPrefix.length > config.hindsightContextMaxLength) {
+    warnings.push(
+      `hindsightContextPrefix ("${config.hindsightContextPrefix}", ${config.hindsightContextPrefix.length} chars) is longer than hindsightContextMaxLength (${config.hindsightContextMaxLength}). Auto-derived session names will not be truncated. Consider increasing hindsightContextMaxLength.`
+    );
   }
 
   // Validate recallMaxQueryChars - reset to default if out of range

--- a/src/document.ts
+++ b/src/document.ts
@@ -6,11 +6,11 @@ import { existsSync, readFileSync } from "node:fs";
 import type { HindsightConfig, RetainContent, ToolFilter } from "./config";
 import { prepareEntry, shouldRetainMessage } from "./prepare";
 import {
+  deriveSessionName,
   extractParentSessionId,
-  extractTextFromContent,
   getBasedir,
+  getContextNameMaxLength,
   getProjectName,
-  truncate,
 } from "./utils";
 
 export interface SessionHeader {
@@ -158,23 +158,6 @@ function findForkStartIndex(conversationEntries: SessionEntry[], forkPoint: numb
 }
 
 /**
- * Truncate session title for Hindsight context field.
- */
-function truncateSessionTitle(entries: SessionEntry[], config: HindsightConfig): string {
-  // Find first user message or use session name
-  for (const entry of entries) {
-    if (entry.type === "message" && entry.message?.role === "user") {
-      const text = extractTextFromContent(entry.message.content);
-      if (text) {
-        return truncate(config.hindsightContextPrefix + text, config.hindsightContextMaxLength);
-      }
-    }
-  }
-
-  return `${config.hindsightContextPrefix}pi session`;
-}
-
-/**
  * Build document content from a session file.
  *
  * Delegates to {@link buildMessageArrayFromParsedSession} and serializes to JSON.
@@ -317,37 +300,37 @@ export function buildDocumentTags(
 }
 
 /**
+ * Build context string from a session name.
+ *
+ * Uses only the prefix + session name + extra context, with NO truncation.
+ * The session name should already be derived and truncated by
+ * {@link deriveSessionName} — this function just assembles the final string.
+ * Shared by document.ts (for parse-and-upsert) and retention.ts (for auto-flush).
+ */
+export function buildContextFromSessionName(
+  hindsightContextPrefix: string,
+  sessionName: string,
+  extraContext?: string
+): string {
+  const base = hindsightContextPrefix + sessionName;
+  if (!extraContext) return base;
+  return `${base}\n${extraContext}`;
+}
+
+/**
  * Get context string for Hindsight.
- * Prefers session name if provided, otherwise falls back to first user message.
+ *
+ * Derives the session name using {@link deriveSessionName} (with proper
+ * truncation via hindsightContextMaxLength) and assembles the final context
+ * string with prefix and extra context.
  */
 export function getHindsightContext(
   sessionPath: string,
   config: HindsightConfig,
-  sessionName?: string
+  sessionName?: string,
+  extraContext?: string
 ): string {
-  // Prefer session name if provided
-  if (sessionName) {
-    return truncate(config.hindsightContextPrefix + sessionName, config.hindsightContextMaxLength);
-  }
-
-  // Fall back to first user message
   const { entries } = parseSessionFile(sessionPath);
-  return truncateSessionTitle(entries, config);
-}
-
-/**
- * Get context string from pre-parsed session entries.
- * Prefers session name if provided, otherwise falls back to first user message.
- */
-export function getHindsightContextFromEntries(
-  entries: SessionEntry[],
-  config: HindsightConfig,
-  sessionName?: string
-): string {
-  // Prefer session name if provided
-  if (sessionName) {
-    return truncate(config.hindsightContextPrefix + sessionName, config.hindsightContextMaxLength);
-  }
-
-  return truncateSessionTitle(entries, config);
+  const name = deriveSessionName(sessionName, entries, getContextNameMaxLength(config));
+  return buildContextFromSessionName(config.hindsightContextPrefix, name, extraContext);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -361,15 +361,17 @@ export default function (pi: ExtensionAPI) {
     await flushCurrentSession(ctx, "before session fork");
   });
 
-  // Flush queues after compaction (if enabled)
-  pi.on("session_compact", async (_event, ctx: ExtensionContext) => {
+  // Flush queues before compaction (if enabled)
+  pi.on("session_before_compact", async (_event, ctx: ExtensionContext) => {
     if (config.flushOnCompact) {
-      await flushCurrentSession(ctx, "after compaction");
+      await flushCurrentSession(ctx, "before compaction");
     }
   });
 
-  // Flush queues on session shutdown
-  pi.on("session_shutdown", async (_event, ctx: ExtensionContext) => {
+  // Flush queues on session shutdown (quit/reload only)
+  // For new/resume/fork, session_before_switch or session_before_fork already flushed
+  pi.on("session_shutdown", async (event, ctx: ExtensionContext) => {
+    if (event.reason === "new" || event.reason === "resume" || event.reason === "fork") return;
     await flushCurrentSession(ctx, "on shutdown", true);
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,12 +17,18 @@ import {
   type TagGroupInput,
   validateConfig,
 } from "./config";
-import { getHindsightMeta, shouldSessionBeRetained } from "./meta";
+import { getHindsightMeta, hasExtraContext, shouldSessionBeRetained } from "./meta";
 import { prepareEntry, shouldRetainMessage } from "./prepare";
 import { enqueueAutoMessage } from "./queue";
-import { flushQueues, getQueueCount } from "./retention";
+import { FLUSH_BLOCKED_NO_EXTRA_CONTEXT, flushQueues, getQueueCount } from "./retention";
 import { isToolEnabled, registerTools, updateRetainToolVisibility } from "./tools";
-import { extractParentSessionId, getProjectName, getSessionDisplayName, truncate } from "./utils";
+import {
+  deriveSessionName,
+  extractParentSessionId,
+  getContextNameMaxLength,
+  getProjectName,
+  truncate,
+} from "./utils";
 
 // Runtime toggle for recall display (overrides config)
 let autoRecallDisplayOverride: boolean | null = null;
@@ -238,7 +244,7 @@ export default function (pi: ExtensionAPI) {
       console.warn("pi-hindsight: auto-recall skipped: no active session");
       return;
     }
-    const sessionCwd = header?.cwd || ctx.cwd;
+    const sessionCwd = header?.cwd ?? ctx.cwd;
     const parentSessionId = extractParentSessionId(header?.parentSession);
     const result = await doAutoRecall(
       query,
@@ -431,20 +437,32 @@ export default function (pi: ExtensionAPI) {
     const count = getQueueCount(sessionId);
     if (count === 0) return;
 
+    // Check flush guard: requireExtraContextBeforeFlush
+    if (config.requireExtraContextBeforeFlush) {
+      const entries = ctx.sessionManager.getEntries();
+      const meta = getHindsightMeta(entries);
+      if (!hasExtraContext(meta)) {
+        console.warn(`pi-hindsight: ${FLUSH_BLOCKED_NO_EXTRA_CONTEXT}`);
+        ctx.ui.notify(FLUSH_BLOCKED_NO_EXTRA_CONTEXT, "warning");
+        return;
+      }
+    }
+
     console.log(`pi-hindsight: Flushing ${count} messages ${reason}`);
 
     const header = ctx.sessionManager.getHeader();
     const entries = ctx.sessionManager.getEntries();
-    const sessionName = getSessionDisplayName(
-      ctx.sessionManager.getSessionName.bind(ctx.sessionManager),
-      ctx.sessionManager.getEntries.bind(ctx.sessionManager)
+    const sessionName = deriveSessionName(
+      ctx.sessionManager.getSessionName(),
+      entries,
+      getContextNameMaxLength(config)
     );
     const parentSessionId = extractParentSessionId(header?.parentSession);
     const result = await flushQueues(
       sessionId,
       sessionName,
       header?.timestamp ?? new Date().toISOString(),
-      header?.cwd || ctx.cwd,
+      header?.cwd ?? ctx.cwd,
       parentSessionId,
       config,
       client,

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -11,11 +11,13 @@ import type { HindsightConfig } from "./config";
 
 /**
  * Session metadata stored in CustomEntry with customType "hindsight-meta".
- * Both fields are optional - only the fields that have been set are present.
+ * All fields are optional - only the fields that have been set are present.
  */
 export interface HindsightMeta {
   retained?: boolean;
   tags?: string[];
+  /** Extra context appended to the Hindsight context field (after session name). Used to provide caveats/instructions for extraction, e.g. "This session involves reading a fiction book; characters are not the user and information is not factual." */
+  extraContext?: string;
 }
 
 /**
@@ -41,7 +43,62 @@ export function getHindsightMeta(
 }
 
 /**
- * Determine whether a session should be retained.
+ * Build a new HindsightMeta by merging partial updates with existing metadata.
+ *
+ * Preserves existing fields that aren't being overridden. Uses `!== undefined`
+ * for `retained` and `extraContext` (not truthiness) so that `false` and `""`
+ * are preserved as intentional values. Uses truthiness for `tags` since an
+ * empty tag array is pointless and should be omitted.
+ *
+ * A field in `updates` that is `undefined` means "keep existing" (not "clear").
+ * To drop `tags` from the result, pass an empty array (empty tag lists are omitted).
+ * The effect is the same as clearing — the next `getHindsightMeta` call won't
+ * see a `tags` field.
+ */
+export function buildMetaUpdate(
+  existing: HindsightMeta | null,
+  updates: Partial<HindsightMeta>
+): HindsightMeta {
+  const meta: HindsightMeta = {};
+
+  // retained: preserve from existing if not overridden
+  const retained = updates.retained ?? existing?.retained;
+  if (retained !== undefined) {
+    meta.retained = retained;
+  }
+
+  // tags: preserve from existing if not overridden.
+  // An empty array in updates means "explicitly clear tags" (don't carry forward).
+  // undefined in updates means "keep existing".
+  const tags = updates.tags !== undefined ? updates.tags : existing?.tags;
+  if (tags && tags.length > 0) {
+    meta.tags = tags;
+  }
+
+  // extraContext: preserve from existing if not overridden
+  const extraContext =
+    updates.extraContext !== undefined ? updates.extraContext : existing?.extraContext;
+  if (extraContext !== undefined) {
+    meta.extraContext = extraContext;
+  }
+
+  return meta;
+}
+
+/**
+ * Check whether extra context has been explicitly set in session metadata.
+ * Returns true if the extraContext key exists in the meta (even if empty string).
+ * Returns false if the key doesn't exist (extra context was never chosen).
+ *
+ * This distinction matters for requireExtraContextBeforeFlush:
+ * - Key not present: user hasn't made a choice → block flush
+ * - Key present (even empty string): user explicitly said "no extra context needed" → allow flush
+ */
+export function hasExtraContext(meta: HindsightMeta | null): boolean {
+  return meta !== null && "extraContext" in meta;
+}
+
+/**
  * Checks the latest hindsight-meta entry for a retained field.
  * If no metadata entry exists or retained is undefined, falls back
  * to the retainSessionsByDefault config value.

--- a/src/retention.ts
+++ b/src/retention.ts
@@ -2,10 +2,15 @@
  * Retention handling for pi message events.
  */
 
+/** Message shown when a flush is blocked because extra context is not set. */
+export const FLUSH_BLOCKED_NO_EXTRA_CONTEXT =
+  "Hindsight flush blocked: extra context not set. Use /hindsight set-extra-context or the hindsight_set_extra_context tool to set extraction caveats before flushing.";
+
 import type { MemoryItemInput } from "@vectorize-io/hindsight-client";
 import type { HindsightClientWrapper } from "./client";
 import type { HindsightConfig } from "./config";
 import { expandSessionObservationScopes } from "./config";
+import { buildContextFromSessionName } from "./document";
 import { getHindsightMeta } from "./meta";
 import type { ToolQueueEntry } from "./queue";
 import {
@@ -15,7 +20,7 @@ import {
   readAutoQueue,
   readToolQueue,
 } from "./queue";
-import { getBasedir, getProjectName, truncate } from "./utils";
+import { getBasedir, getProjectName } from "./utils";
 
 /**
  * Queue a tool retain entry with complete tags.
@@ -103,10 +108,15 @@ export async function flushAutoQueue(
     ...sessionTags,
   ];
 
-  // Build context
-  const context = truncate(
-    config.hindsightContextPrefix + sessionName,
-    config.hindsightContextMaxLength
+  // Build context using shared function for parity with document.ts.
+  // The session name is derived and truncated by getSessionDisplayName()
+  // (using hindsightContextMaxLength) before being passed here.
+  // buildContextFromSessionName only assembles prefix + name + extraContext.
+  const extraContext = meta?.extraContext;
+  const context = buildContextFromSessionName(
+    config.hindsightContextPrefix,
+    sessionName,
+    extraContext
   );
 
   // Concatenate all entries into single content array

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -8,7 +8,7 @@ import type { Budget, RecallResponse, ReflectResponse } from "@vectorize-io/hind
 import { type Static, Type } from "typebox";
 import type { HindsightClientWrapper } from "./client";
 import type { HindsightConfig, MemoryType, ToolName } from "./config";
-import { getHindsightMeta, shouldSessionBeRetained } from "./meta";
+import { buildMetaUpdate, getHindsightMeta, shouldSessionBeRetained } from "./meta";
 import { queueToolRetain } from "./retention";
 import { extractParentSessionId } from "./utils";
 
@@ -57,6 +57,12 @@ interface ReflectDetails {
   response?: ReflectResponse;
 }
 
+interface ExtraContextDetails {
+  success: boolean;
+  extraContext?: string;
+  error?: string;
+}
+
 /**
  * Check if a specific tool is enabled based on config.toolsEnabled.
  * - `true` (default): all tools enabled
@@ -79,6 +85,115 @@ export function registerTools(
   config: HindsightConfig,
   client: HindsightClientWrapper | null
 ): void {
+  // Register hindsight_set_extra_context when enabled.
+  // Gated by toolsEnabled like all other tools. Can be included in the array
+  // as "set_extra_context". The /hindsight set-extra-context slash command still
+  // works regardless of this setting.
+  if (isToolEnabled(config, "set_extra_context")) {
+    pi.registerTool({
+      name: "hindsight_set_extra_context",
+      label: "Hindsight Extra Context",
+      description:
+        "Set extra context/caveats for memory extraction. Use when the session involves content that could be misclassified when split into chunks.",
+      parameters: Type.Object({
+        text: Type.String({
+          description:
+            "The extra context. Replaces any existing value. Example: 'This session involves reading Dune; characters are not the user and information is not factual.'",
+        }),
+      }),
+
+      renderResult(result, _options, theme, context) {
+        const text = (context.lastComponent as Text) ?? new Text("", 0, 0);
+        const details = result.details as ExtraContextDetails;
+        if (details.success) {
+          if (details.extraContext) {
+            text.setText(theme.fg("success", `✓ Extra context set: ${details.extraContext}`));
+          } else {
+            text.setText(theme.fg("success", "✓ No extra context needed (flush guard satisfied)"));
+          }
+        } else {
+          text.setText(theme.fg("error", `✗ ${details.error ?? "Failed to set extra context"}`));
+        }
+        return text;
+      },
+
+      async execute(
+        _toolCallId,
+        params,
+        _signal,
+        _onUpdate,
+        ctx
+      ): Promise<AgentToolResult<ExtraContextDetails>> {
+        const entries = ctx.sessionManager.getEntries();
+        const existingMeta = getHindsightMeta(entries);
+
+        const extraContext = params.text.trim();
+        // Always store extraContext (even empty string) so the flush guard
+        // can distinguish "explicitly set to empty" from "never set".
+        const meta = buildMetaUpdate(existingMeta, { extraContext });
+
+        pi.appendEntry("hindsight-meta", meta);
+
+        const message = extraContext
+          ? "Extra context set."
+          : "No extra context needed (flush guard satisfied).";
+
+        return {
+          content: [{ type: "text", text: message }],
+          details: { success: true, extraContext },
+        };
+      },
+    });
+  }
+
+  if (isToolEnabled(config, "get_extra_context")) {
+    pi.registerTool({
+      name: "hindsight_get_extra_context",
+      label: "Hindsight Get Extra Context",
+      description: "Get the current extra context set for this session.",
+      parameters: Type.Object({}),
+
+      renderResult(result, _options, theme, context) {
+        const text = (context.lastComponent as Text) ?? new Text("", 0, 0);
+        const details = result.details as ExtraContextDetails;
+        if (details.success) {
+          if (details.extraContext) {
+            text.setText(theme.fg("success", `✓ Extra context: ${details.extraContext}`));
+          } else if (details.extraContext === "") {
+            text.setText(theme.fg("success", "✓ No extra context needed (flush guard satisfied)"));
+          } else {
+            text.setText(theme.fg("success", "✓ No extra context set"));
+          }
+        } else {
+          text.setText(theme.fg("error", `✗ ${details.error ?? "Failed to get extra context"}`));
+        }
+        return text;
+      },
+
+      async execute(
+        _toolCallId,
+        _params,
+        _signal,
+        _onUpdate,
+        ctx
+      ): Promise<AgentToolResult<ExtraContextDetails>> {
+        const entries = ctx.sessionManager.getEntries();
+        const existingMeta = getHindsightMeta(entries);
+        const extraContext = existingMeta?.extraContext;
+
+        const message =
+          extraContext !== undefined
+            ? extraContext || "No extra context needed (flush guard satisfied)"
+            : "No extra context set";
+
+        return {
+          content: [{ type: "text", text: message }],
+          details: { success: true, extraContext },
+        };
+      },
+    });
+  }
+
   // Register hindsight_retain if enabled
   if (isToolEnabled(config, "retain")) {
     // hindsight_retain - always available, just queues to disk

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -107,26 +107,56 @@ export function getProjectName(cwd: string): string {
 }
 
 /**
- * Get the display name for a session.
- * Returns manual title if set, otherwise extracts text from first user message.
- * Truncates to 100 characters to avoid overly long names.
+ * Derive the session display name from an explicit name or first user message.
+ *
+ * Returns the explicit name if set, otherwise extracts the first user message
+ * and truncates it to `maxLength`. Returns "Untitled" if neither is available.
+ *
+ * This is the single source of truth for session name derivation + truncation.
+ * Both the runtime flush path and the parsing path should use this function
+ * (or its wrapper `getSessionDisplayName`) to ensure consistent context strings.
  */
-export function getSessionDisplayName(
-  getSessionName: () => string | undefined,
-  getEntries: () => Array<{ type: string; message?: { role?: string; content?: unknown } }>
+export function deriveSessionName(
+  explicitName: string | undefined,
+  entries: Array<{ type: string; message?: { role?: string; content?: unknown } }>,
+  maxLength: number = 100
 ): string {
   // Try manual title first
-  const name = getSessionName();
-  if (name) return name;
+  if (explicitName) return explicitName;
 
   // Fall back to first user message
-  const entries = getEntries();
   for (const entry of entries) {
     if (entry.type === "message" && entry.message?.role === "user") {
       const text = extractTextFromContent(entry.message.content);
-      if (text) return truncate(text, 100);
+      if (text) return truncate(text, maxLength);
     }
   }
 
   return "Untitled";
+}
+
+/**
+ * Max length available for the session-name portion of the context string.
+ *
+ * This is `hindsightContextMaxLength - hindsightContextPrefix.length`, so that the
+ * total `prefix + name` fits within `hindsightContextMaxLength`.
+ * Guards against prefix longer than the configured max (returns 0 in that case).
+ */
+export function getContextNameMaxLength(config: {
+  hindsightContextMaxLength: number;
+  hindsightContextPrefix: string;
+}): number {
+  return Math.max(0, config.hindsightContextMaxLength - config.hindsightContextPrefix.length);
+}
+
+/**
+ * Convenience wrapper around {@link deriveSessionName} that takes closures
+ * (for use with pi's session manager API).
+ */
+export function getSessionDisplayName(
+  getSessionName: () => string | undefined,
+  getEntries: () => Array<{ type: string; message?: { role?: string; content?: unknown } }>,
+  maxLength: number = 100
+): string {
+  return deriveSessionName(getSessionName(), getEntries(), maxLength);
 }

--- a/tests/bootstrap.test.ts
+++ b/tests/bootstrap.test.ts
@@ -135,7 +135,7 @@ describe("real entrypoint bootstrap", () => {
       "before_agent_start",
       "session_before_switch",
       "session_before_fork",
-      "session_compact",
+      "session_before_compact",
       "session_shutdown",
     ];
 
@@ -947,14 +947,14 @@ describe("real entrypoint bootstrap", () => {
     deleteAutoQueue(BOOTSTRAP_SESSION);
   });
 
-  it("session_compact handler skips flush when flushOnCompact is false", async () => {
+  it("session_before_compact handler skips flush when flushOnCompact is false", async () => {
     activeConfig = { ...testConfig, flushOnCompact: false };
 
     const pi = createMockPi();
     const extension = await import("../src/index");
     extension.default(pi);
 
-    const handler = pi.handlers.get("session_compact")!;
+    const handler = pi.handlers.get("session_before_compact")!;
     const ctx = createMockContext({ _sessionId: BOOTSTRAP_SESSION });
 
     const { enqueueAutoMessage, deleteAutoQueue, readAutoQueue } =
@@ -965,21 +965,21 @@ describe("real entrypoint bootstrap", () => {
       store_method: "auto",
     });
 
-    await handler({ type: "session_compact" }, ctx);
+    await handler({ type: "session_before_compact" }, ctx);
 
     // Queue should still be intact — flushOnCompact is false
     expect(readAutoQueue(BOOTSTRAP_SESSION)).toHaveLength(1);
     deleteAutoQueue(BOOTSTRAP_SESSION);
   });
 
-  it("session_compact handler flushes when flushOnCompact is true", async () => {
+  it("session_before_compact handler flushes when flushOnCompact is true", async () => {
     activeConfig = { ...testConfig, flushOnCompact: true };
 
     const pi = createMockPi();
     const extension = await import("../src/index");
     extension.default(pi);
 
-    const handler = pi.handlers.get("session_compact")!;
+    const handler = pi.handlers.get("session_before_compact")!;
     const ctx = createMockContext({ _sessionId: BOOTSTRAP_SESSION });
 
     const { enqueueAutoMessage, deleteAutoQueue, readAutoQueue } =
@@ -990,7 +990,7 @@ describe("real entrypoint bootstrap", () => {
       store_method: "auto",
     });
 
-    await handler({ type: "session_compact" }, ctx);
+    await handler({ type: "session_before_compact" }, ctx);
 
     expect(readAutoQueue(BOOTSTRAP_SESSION)).toHaveLength(0);
     deleteAutoQueue(BOOTSTRAP_SESSION);
@@ -2480,7 +2480,7 @@ describe("real entrypoint bootstrap", () => {
     deleteAutoQueue(sessionId);
   });
 
-  it("requireExtraContextBeforeFlush: session_compact blocks flush when extra context is not set and flushOnCompact is true", async () => {
+  it("requireExtraContextBeforeFlush: session_before_compact blocks flush when extra context is not set and flushOnCompact is true", async () => {
     activeConfig = { ...testConfig, requireExtraContextBeforeFlush: true, flushOnCompact: true };
 
     const pi = createMockPi();
@@ -2496,7 +2496,7 @@ describe("real entrypoint bootstrap", () => {
       store_method: "auto",
     });
 
-    const handler = pi.handlers.get("session_compact")!;
+    const handler = pi.handlers.get("session_before_compact")!;
     const ctx = createMockContext({
       _sessionId: sessionId,
       sessionManager: {
@@ -2505,7 +2505,7 @@ describe("real entrypoint bootstrap", () => {
       },
     });
 
-    await handler({ type: "session_compact" }, ctx);
+    await handler({ type: "session_before_compact" }, ctx);
 
     // Queue should still be intact — flush was blocked
     expect(readAutoQueue(sessionId)).toHaveLength(1);

--- a/tests/bootstrap.test.ts
+++ b/tests/bootstrap.test.ts
@@ -2112,4 +2112,403 @@ describe("real entrypoint bootstrap", () => {
     // setActiveTools should NOT have been called — retain tool isn't registered
     expect(pi.setActiveToolsCalls.length).toBe(0);
   });
+
+  // ============================================
+  // requireExtraContextBeforeFlush integration tests
+  // ============================================
+
+  it("requireExtraContextBeforeFlush: session_before_switch blocks flush when extra context is not set", async () => {
+    activeConfig = { ...testConfig, requireExtraContextBeforeFlush: true };
+
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+
+    const sessionId = BOOTSTRAP_SESSION;
+    const { enqueueAutoMessage, deleteAutoQueue, readAutoQueue } =
+      require("../src/queue") as typeof import("../src/queue");
+    deleteAutoQueue(sessionId);
+    enqueueAutoMessage(sessionId, {
+      entry: { message: { role: "user", content: [{ type: "text", text: "Hello" }] } },
+      store_method: "auto",
+    });
+    expect(readAutoQueue(sessionId)).toHaveLength(1);
+
+    const handler = pi.handlers.get("session_before_switch")!;
+    const ctx = createMockContext({
+      _sessionId: sessionId,
+      sessionManager: {
+        ...createMockContext({ _sessionId: sessionId }).sessionManager,
+        getEntries: mock(() => []),
+      },
+    });
+
+    await handler({ type: "session_before_switch" }, ctx);
+
+    // Queue should still be intact — flush was blocked
+    expect(readAutoQueue(sessionId)).toHaveLength(1);
+    deleteAutoQueue(sessionId);
+  });
+
+  it("requireExtraContextBeforeFlush: session_shutdown blocks flush when extra context is not set", async () => {
+    activeConfig = { ...testConfig, requireExtraContextBeforeFlush: true };
+
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+
+    const sessionId = BOOTSTRAP_SESSION;
+    const { enqueueAutoMessage, deleteAutoQueue, readAutoQueue } =
+      require("../src/queue") as typeof import("../src/queue");
+    deleteAutoQueue(sessionId);
+    enqueueAutoMessage(sessionId, {
+      entry: { message: { role: "user", content: [{ type: "text", text: "Hello" }] } },
+      store_method: "auto",
+    });
+
+    const handler = pi.handlers.get("session_shutdown")!;
+    const ctx = createMockContext({
+      _sessionId: sessionId,
+      sessionManager: {
+        ...createMockContext({ _sessionId: sessionId }).sessionManager,
+        getEntries: mock(() => []),
+      },
+    });
+
+    await handler({ type: "session_shutdown" }, ctx);
+
+    // Queue should still be intact — flush was blocked
+    expect(readAutoQueue(sessionId)).toHaveLength(1);
+    deleteAutoQueue(sessionId);
+  });
+
+  it("requireExtraContextBeforeFlush: flush proceeds when extra context is set", async () => {
+    activeConfig = { ...testConfig, requireExtraContextBeforeFlush: true };
+
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+
+    const sessionId = BOOTSTRAP_SESSION;
+    const { enqueueAutoMessage, deleteAutoQueue, readAutoQueue } =
+      require("../src/queue") as typeof import("../src/queue");
+    deleteAutoQueue(sessionId);
+    enqueueAutoMessage(sessionId, {
+      entry: { message: { role: "user", content: [{ type: "text", text: "Hello" }] } },
+      store_method: "auto",
+    });
+
+    const handler = pi.handlers.get("session_before_switch")!;
+    // Entries include extra context in metadata
+    const ctx = createMockContext({
+      _sessionId: sessionId,
+      sessionManager: {
+        ...createMockContext({ _sessionId: sessionId }).sessionManager,
+        getEntries: mock(() => [
+          {
+            type: "custom",
+            customType: "hindsight-meta",
+            data: { retained: true, extraContext: "Fiction session" },
+          },
+        ]),
+      },
+    });
+
+    await handler({ type: "session_before_switch" }, ctx);
+
+    // Queue should be flushed — extra context was set
+    expect(readAutoQueue(sessionId)).toHaveLength(0);
+    deleteAutoQueue(sessionId);
+  });
+
+  it("requireExtraContextBeforeFlush: parse-and-upsert-session subcommand blocks when extra context is not set", async () => {
+    activeConfig = { ...testConfig, requireExtraContextBeforeFlush: true };
+
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+
+    const sessionId = BOOTSTRAP_SESSION;
+    const { deleteAutoQueue, deleteToolQueue } =
+      require("../src/queue") as typeof import("../src/queue");
+    deleteAutoQueue(sessionId);
+    deleteToolQueue(sessionId);
+
+    const commandHandler = (
+      pi.commands.get("hindsight") as {
+        handler: (args: string, ctx: ExtensionContext) => Promise<void>;
+      }
+    ).handler;
+
+    const { writeSessionFile, withTempDir } = await import("./fixtures");
+    await withTempDir(async (tmpDir) => {
+      const sessionPath = writeSessionFile(tmpDir, sessionId);
+      const ctx = createMockContext({
+        _sessionId: sessionId,
+        sessionManager: {
+          ...createMockContext({ _sessionId: sessionId }).sessionManager,
+          getSessionFile: mock(() => sessionPath),
+          getEntries: mock(() => []),
+        },
+      });
+
+      await commandHandler("parse-and-upsert-session", ctx);
+
+      const notification = (ctx as unknown as { ui: { notify: ReturnType<typeof mock> } }).ui.notify
+        .mock.calls;
+      const lastCall = notification[notification.length - 1]!;
+      expect(lastCall[0]).toContain("extra context not set");
+      expect(lastCall[1]).toBe("warning");
+    });
+
+    deleteAutoQueue(sessionId);
+    deleteToolQueue(sessionId);
+  });
+
+  it("requireExtraContextBeforeFlush: parse-and-upsert-session subcommand proceeds when extra context is set", async () => {
+    activeConfig = { ...testConfig, requireExtraContextBeforeFlush: true };
+
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+
+    const sessionId = BOOTSTRAP_SESSION;
+    const { deleteAutoQueue, deleteToolQueue } =
+      require("../src/queue") as typeof import("../src/queue");
+    deleteAutoQueue(sessionId);
+    deleteToolQueue(sessionId);
+
+    const commandHandler = (
+      pi.commands.get("hindsight") as {
+        handler: (args: string, ctx: ExtensionContext) => Promise<void>;
+      }
+    ).handler;
+
+    const { writeSessionFile, withTempDir } = await import("./fixtures");
+    await withTempDir(async (tmpDir) => {
+      const sessionPath = writeSessionFile(tmpDir, sessionId);
+      const ctx = createMockContext({
+        _sessionId: sessionId,
+        sessionManager: {
+          ...createMockContext({ _sessionId: sessionId }).sessionManager,
+          getSessionFile: mock(() => sessionPath),
+          getEntries: mock(() => [
+            {
+              type: "custom",
+              customType: "hindsight-meta",
+              data: { retained: true, extraContext: "Fiction session" },
+            },
+          ]),
+        },
+      });
+
+      await commandHandler("parse-and-upsert-session", ctx);
+
+      const notification = (ctx as unknown as { ui: { notify: ReturnType<typeof mock> } }).ui.notify
+        .mock.calls;
+      const lastCall = notification[notification.length - 1]!;
+      expect(lastCall[0]).toContain("Parsed and upserted");
+    });
+
+    deleteAutoQueue(sessionId);
+    deleteToolQueue(sessionId);
+  });
+
+  it("requireExtraContextBeforeFlush: flush subcommand blocks when extra context is not set", async () => {
+    activeConfig = { ...testConfig, requireExtraContextBeforeFlush: true };
+
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+
+    const sessionId = BOOTSTRAP_SESSION;
+    const { enqueueAutoMessage, deleteAutoQueue, deleteToolQueue, readAutoQueue } =
+      require("../src/queue") as typeof import("../src/queue");
+    deleteAutoQueue(sessionId);
+    deleteToolQueue(sessionId);
+    enqueueAutoMessage(sessionId, {
+      entry: { message: { role: "user", content: [{ type: "text", text: "Hello" }] } },
+      store_method: "auto",
+    });
+
+    const commandHandler = (
+      pi.commands.get("hindsight") as {
+        handler: (args: string, ctx: ExtensionContext) => Promise<void>;
+      }
+    ).handler;
+
+    const ctx = createMockContext({
+      _sessionId: sessionId,
+      sessionManager: {
+        ...createMockContext({ _sessionId: sessionId }).sessionManager,
+        getEntries: mock(() => []),
+      },
+    });
+
+    await commandHandler("flush", ctx);
+
+    const notification = (ctx as unknown as { ui: { notify: ReturnType<typeof mock> } }).ui.notify
+      .mock.calls;
+    const lastCall = notification[notification.length - 1]!;
+    expect(lastCall[0]).toContain("extra context not set");
+    expect(lastCall[1]).toBe("warning");
+    // Queue should still be intact
+    expect(readAutoQueue(sessionId)).toHaveLength(1);
+
+    deleteAutoQueue(sessionId);
+    deleteToolQueue(sessionId);
+  });
+
+  it("requireExtraContextBeforeFlush: flush subcommand proceeds when extra context is set", async () => {
+    activeConfig = { ...testConfig, requireExtraContextBeforeFlush: true };
+
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+
+    const sessionId = BOOTSTRAP_SESSION;
+    const { enqueueAutoMessage, deleteAutoQueue, deleteToolQueue, readAutoQueue } =
+      require("../src/queue") as typeof import("../src/queue");
+    deleteAutoQueue(sessionId);
+    deleteToolQueue(sessionId);
+    enqueueAutoMessage(sessionId, {
+      entry: { message: { role: "user", content: [{ type: "text", text: "Hello" }] } },
+      store_method: "auto",
+    });
+
+    const commandHandler = (
+      pi.commands.get("hindsight") as {
+        handler: (args: string, ctx: ExtensionContext) => Promise<void>;
+      }
+    ).handler;
+
+    const ctx = createMockContext({
+      _sessionId: sessionId,
+      sessionManager: {
+        ...createMockContext({ _sessionId: sessionId }).sessionManager,
+        getEntries: mock(() => [
+          {
+            type: "custom",
+            customType: "hindsight-meta",
+            data: { retained: true, extraContext: "Fiction session" },
+          },
+        ]),
+      },
+    });
+
+    await commandHandler("flush", ctx);
+
+    const notification = (ctx as unknown as { ui: { notify: ReturnType<typeof mock> } }).ui.notify
+      .mock.calls;
+    const lastCall = notification[notification.length - 1]!;
+    expect(lastCall[0]).toContain("Flushed");
+    // Queue should be flushed
+    expect(readAutoQueue(sessionId)).toHaveLength(0);
+
+    deleteAutoQueue(sessionId);
+    deleteToolQueue(sessionId);
+  });
+
+  it("requireExtraContextBeforeFlush: flush proceeds when extra context is explicitly set to empty string", async () => {
+    activeConfig = { ...testConfig, requireExtraContextBeforeFlush: true };
+
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+
+    const sessionId = BOOTSTRAP_SESSION;
+    const { enqueueAutoMessage, deleteAutoQueue, readAutoQueue } =
+      require("../src/queue") as typeof import("../src/queue");
+    deleteAutoQueue(sessionId);
+    enqueueAutoMessage(sessionId, {
+      entry: { message: { role: "user", content: [{ type: "text", text: "Hello" }] } },
+      store_method: "auto",
+    });
+
+    const handler = pi.handlers.get("session_before_switch")!;
+    // Entries include extraContext set to empty string ("I don't need extra context")
+    const ctx = createMockContext({
+      _sessionId: sessionId,
+      sessionManager: {
+        ...createMockContext({ _sessionId: sessionId }).sessionManager,
+        getEntries: mock(() => [
+          {
+            type: "custom",
+            customType: "hindsight-meta",
+            data: { retained: true, extraContext: "" },
+          },
+        ]),
+      },
+    });
+
+    await handler({ type: "session_before_switch" }, ctx);
+
+    // Queue should be flushed — explicit empty string satisfies the guard
+    expect(readAutoQueue(sessionId)).toHaveLength(0);
+    deleteAutoQueue(sessionId);
+  });
+
+  it("requireExtraContextBeforeFlush: session_before_fork blocks flush when extra context is not set", async () => {
+    activeConfig = { ...testConfig, requireExtraContextBeforeFlush: true };
+
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+
+    const sessionId = BOOTSTRAP_SESSION;
+    const { enqueueAutoMessage, deleteAutoQueue, readAutoQueue } =
+      require("../src/queue") as typeof import("../src/queue");
+    deleteAutoQueue(sessionId);
+    enqueueAutoMessage(sessionId, {
+      entry: { message: { role: "user", content: [{ type: "text", text: "Hello" }] } },
+      store_method: "auto",
+    });
+
+    const handler = pi.handlers.get("session_before_fork")!;
+    const ctx = createMockContext({
+      _sessionId: sessionId,
+      sessionManager: {
+        ...createMockContext({ _sessionId: sessionId }).sessionManager,
+        getEntries: mock(() => []),
+      },
+    });
+
+    await handler({ type: "session_before_fork" }, ctx);
+
+    // Queue should still be intact — flush was blocked
+    expect(readAutoQueue(sessionId)).toHaveLength(1);
+    deleteAutoQueue(sessionId);
+  });
+
+  it("requireExtraContextBeforeFlush: session_compact blocks flush when extra context is not set and flushOnCompact is true", async () => {
+    activeConfig = { ...testConfig, requireExtraContextBeforeFlush: true, flushOnCompact: true };
+
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+
+    const sessionId = BOOTSTRAP_SESSION;
+    const { enqueueAutoMessage, deleteAutoQueue, readAutoQueue } =
+      require("../src/queue") as typeof import("../src/queue");
+    deleteAutoQueue(sessionId);
+    enqueueAutoMessage(sessionId, {
+      entry: { message: { role: "user", content: [{ type: "text", text: "Hello" }] } },
+      store_method: "auto",
+    });
+
+    const handler = pi.handlers.get("session_compact")!;
+    const ctx = createMockContext({
+      _sessionId: sessionId,
+      sessionManager: {
+        ...createMockContext({ _sessionId: sessionId }).sessionManager,
+        getEntries: mock(() => []),
+      },
+    });
+
+    await handler({ type: "session_compact" }, ctx);
+
+    // Queue should still be intact — flush was blocked
+    expect(readAutoQueue(sessionId)).toHaveLength(1);
+    deleteAutoQueue(sessionId);
+  });
 });

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -626,6 +626,76 @@ describe("registerCommands", () => {
       await getHandler()("toggle-retain", makeCtx());
       expect(appendedEntries[0]?.data).toEqual({ retained: true });
     });
+
+    it("blocks toggling on when requireExtraContextBeforeFlush is true and extra context not set", async () => {
+      confirmResult = true;
+      sessionEntries = [
+        { type: "custom", customType: "hindsight-meta", data: { retained: false } },
+      ];
+      register({ ...statusTestConfig, requireExtraContextBeforeFlush: true });
+      await getHandler()("toggle-retain", makeCtx());
+      expect(appendedEntries).toHaveLength(0);
+      expect(lastNotification?.message).toContain("extra context not set");
+      expect(lastNotification?.type).toBe("warning");
+    });
+
+    it("allows toggling on when requireExtraContextBeforeFlush is true and extra context is set", async () => {
+      confirmResult = true;
+      sessionEntries = [
+        {
+          type: "custom",
+          customType: "hindsight-meta",
+          data: { retained: false, extraContext: "fiction" },
+        },
+      ];
+      register({ ...statusTestConfig, requireExtraContextBeforeFlush: true });
+      await getHandler()("toggle-retain", makeCtx());
+      expect(appendedEntries).toHaveLength(1);
+      expect(appendedEntries[0]?.data).toEqual({ retained: true, extraContext: "fiction" });
+    });
+
+    it("allows toggling on when requireExtraContextBeforeFlush is true and extra context is empty string", async () => {
+      confirmResult = true;
+      sessionEntries = [
+        {
+          type: "custom",
+          customType: "hindsight-meta",
+          data: { retained: false, extraContext: "" },
+        },
+      ];
+      register({ ...statusTestConfig, requireExtraContextBeforeFlush: true });
+      await getHandler()("toggle-retain", makeCtx());
+      expect(appendedEntries).toHaveLength(1);
+      expect(appendedEntries[0]?.data).toEqual({ retained: true, extraContext: "" });
+    });
+
+    it("blocks toggling on when requireExtraContextBeforeFlush is true and no meta exists at all", async () => {
+      confirmResult = true;
+      sessionEntries = []; // no hindsight-meta entries
+      register({
+        ...statusTestConfig,
+        requireExtraContextBeforeFlush: true,
+        retainSessionsByDefault: false,
+      });
+      await getHandler()("toggle-retain", makeCtx());
+      expect(appendedEntries).toHaveLength(0);
+      expect(lastNotification?.message).toContain("extra context not set");
+    });
+
+    it("blocks toggling on when requireExtraContextBeforeFlush is true and meta has no extraContext key", async () => {
+      confirmResult = true;
+      sessionEntries = [
+        {
+          type: "custom",
+          customType: "hindsight-meta",
+          data: { retained: false, tags: ["topic:ai"] },
+        },
+      ];
+      register({ ...statusTestConfig, requireExtraContextBeforeFlush: true });
+      await getHandler()("toggle-retain", makeCtx());
+      expect(appendedEntries).toHaveLength(0);
+      expect(lastNotification?.message).toContain("extra context not set");
+    });
   });
 
   describe("tag subcommand", () => {
@@ -721,6 +791,55 @@ describe("registerCommands", () => {
       await getHandler()("remove-tag any", makeCtx());
       expect(lastNotification?.message).toContain('Tag "any" not found');
       expect(appendedEntries).toHaveLength(0);
+    });
+  });
+
+  describe("set-extra-context subcommand", () => {
+    it("sets extra context with text args", async () => {
+      register();
+      await getHandler()("set-extra-context This is fiction", makeCtx());
+      expect(lastNotification?.message).toContain("Extra context set");
+      expect(appendedEntries).toHaveLength(1);
+      expect(appendedEntries[0]?.customType).toBe("hindsight-meta");
+      expect(appendedEntries[0]?.data).toEqual({ extraContext: "This is fiction" });
+    });
+
+    it("sets extra context to empty string (satisfies flush guard)", async () => {
+      register();
+      await getHandler()("set-extra-context", makeCtx());
+      expect(lastNotification?.message).toContain("No extra context needed");
+      expect(appendedEntries).toHaveLength(1);
+      expect(appendedEntries[0]?.data).toEqual({ extraContext: "" });
+    });
+
+    it("preserves existing retained state when setting extra context", async () => {
+      sessionEntries = [
+        { type: "custom", customType: "hindsight-meta", data: { retained: false } },
+      ];
+      register();
+      await getHandler()("set-extra-context fiction session", makeCtx());
+      expect(appendedEntries[0]?.data).toEqual({
+        retained: false,
+        extraContext: "fiction session",
+      });
+    });
+
+    it("preserves existing tags when setting extra context", async () => {
+      sessionEntries = [
+        { type: "custom", customType: "hindsight-meta", data: { tags: ["topic:ai"] } },
+      ];
+      register();
+      await getHandler()("set-extra-context test", makeCtx());
+      expect(appendedEntries[0]?.data).toEqual({ tags: ["topic:ai"], extraContext: "test" });
+    });
+
+    it("replaces existing extra context", async () => {
+      sessionEntries = [
+        { type: "custom", customType: "hindsight-meta", data: { extraContext: "old" } },
+      ];
+      register();
+      await getHandler()("set-extra-context new context", makeCtx());
+      expect(appendedEntries[0]?.data).toEqual({ extraContext: "new context" });
     });
   });
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -55,6 +55,7 @@ const validConfig: HindsightConfig = {
   observationScopes: [["{session}"]] as string[][],
   statusHealthy: "🧠",
   retainSessionsByDefault: true,
+  requireExtraContextBeforeFlush: false,
   statusUnhealthy: "🤯",
 };
 
@@ -1875,6 +1876,29 @@ describe("loadConfig", () => {
     const { config, warning } = loadConfig(TEST_DIR);
     expect(config.retainSessionsByDefault).toBe(true); // Falls back to default
     expect(warning).toContain("Invalid boolean value");
+  });
+
+  // requireExtraContextBeforeFlush tests
+  it("requireExtraContextBeforeFlush defaults to false", () => {
+    const { config } = loadConfig(TEST_DIR);
+    expect(config.requireExtraContextBeforeFlush).toBe(false);
+  });
+
+  it("requireExtraContextBeforeFlush can be set via config file", () => {
+    writeFileSync(
+      join(TEST_DIR, "config.jsonc"),
+      JSON.stringify({ requireExtraContextBeforeFlush: true })
+    );
+
+    const { config } = loadConfig(TEST_DIR);
+    expect(config.requireExtraContextBeforeFlush).toBe(true);
+  });
+
+  it("requireExtraContextBeforeFlush can be set via PI_HINDSIGHT_REQUIRE_EXTRA_CONTEXT_BEFORE_FLUSH env var", () => {
+    process.env.PI_HINDSIGHT_REQUIRE_EXTRA_CONTEXT_BEFORE_FLUSH = "true";
+
+    const { config } = loadConfig(TEST_DIR);
+    expect(config.requireExtraContextBeforeFlush).toBe(true);
   });
 
   // toolFilter tests

--- a/tests/document.test.ts
+++ b/tests/document.test.ts
@@ -699,7 +699,7 @@ describe("hindsight context", () => {
     expect(context).toBe("pi: Build me a homepage");
   });
 
-  it("truncates long session name", () => {
+  it("does not truncate explicit session name", () => {
     const longName = "A".repeat(200);
     const path = createSessionFile(
       "context-long-name.jsonl",
@@ -714,8 +714,10 @@ describe("hindsight context", () => {
 
     const context = getHindsightContext(path, config, longName);
 
-    expect(context.length).toBe(50);
-    expect(context.endsWith("…")).toBe(true);
+    // Explicit session names are not truncated — hindsightContextMaxLength only applies
+    // to auto-derived names from the first user message
+    expect(context).toBe(`${config.hindsightContextPrefix}${longName}`);
+    expect(context.length).toBe(204); // "pi: " (4) + 200 A's
   });
 
   it("truncates long context from first message", () => {
@@ -741,7 +743,78 @@ describe("hindsight context", () => {
 
     const context = getHindsightContext(path, defaultConfig);
 
-    expect(context).toBe("pi: pi session");
+    expect(context).toBe("pi: Untitled");
+  });
+
+  it("appends extra context after session name with newline separator", () => {
+    const path = createSessionFile("context-extra.jsonl", { id: "context-extra-session" }, []);
+
+    const context = getHindsightContext(
+      path,
+      defaultConfig,
+      "My Session",
+      "This is fiction; characters are not the user"
+    );
+
+    expect(context).toBe("pi: My Session\nThis is fiction; characters are not the user");
+  });
+
+  it("appends extra context after first user message fallback", () => {
+    const path = createSessionFile(
+      "context-extra-fallback.jsonl",
+      { id: "context-extra-fallback-session" },
+      [userEntry("u1", null, "Hello world")]
+    );
+
+    const context = getHindsightContext(path, defaultConfig, undefined, "Fiction session");
+
+    expect(context).toBe("pi: Hello world\nFiction session");
+  });
+
+  it("truncates first user message fallback but not extra context", () => {
+    const longText = "A".repeat(200);
+    const path = createSessionFile(
+      "context-extra-truncate.jsonl",
+      { id: "context-extra-truncate-session" },
+      [userEntry("u1", null, longText)]
+    );
+
+    const config: HindsightConfig = {
+      ...defaultConfig,
+      hindsightContextMaxLength: 50,
+    };
+
+    const extraContext =
+      "This is a very long extra context that should not be truncated at all even though it exceeds the max length";
+    const context = getHindsightContext(path, config, undefined, extraContext);
+
+    // Base part is truncated, extra context is appended in full
+    expect(context).toContain(extraContext);
+    expect(context.startsWith("pi: ")).toBe(true);
+  });
+
+  it("returns base context unchanged when extra context is empty string", () => {
+    const path = createSessionFile(
+      "context-extra-empty.jsonl",
+      { id: "context-extra-empty-session" },
+      []
+    );
+
+    const context = getHindsightContext(path, defaultConfig, "My Session", "");
+
+    expect(context).toBe("pi: My Session");
+  });
+
+  it("returns base context unchanged when extra context is undefined", () => {
+    const path = createSessionFile(
+      "context-extra-undef.jsonl",
+      { id: "context-extra-undef-session" },
+      []
+    );
+
+    const context = getHindsightContext(path, defaultConfig, "My Session", undefined);
+
+    expect(context).toBe("pi: My Session");
   });
 });
 

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -49,6 +49,7 @@ export const testConfig: HindsightConfig = {
   observationScopes: [["{session}"]] as string[][],
   statusHealthy: "🧠",
   retainSessionsByDefault: true,
+  requireExtraContextBeforeFlush: false,
   statusUnhealthy: "🤯",
 };
 
@@ -243,6 +244,7 @@ export const HINDSIGHT_ENV_KEYS = [
   "PI_HINDSIGHT_STATUS_UNHEALTHY",
   "PI_HINDSIGHT_OBSERVATION_SCOPES",
   "PI_HINDSIGHT_RETAIN_SESSIONS_BY_DEFAULT",
+  "PI_HINDSIGHT_REQUIRE_EXTRA_CONTEXT_BEFORE_FLUSH",
   "PI_HINDSIGHT_TOOL_FILTER",
   "PI_HINDSIGHT_PROJECT_NAME",
 ];

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -3,7 +3,12 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import { getHindsightMeta, shouldSessionBeRetained } from "../src/meta";
+import {
+  buildMetaUpdate,
+  getHindsightMeta,
+  hasExtraContext,
+  shouldSessionBeRetained,
+} from "../src/meta";
 
 type MetaEntry = Parameters<typeof getHindsightMeta>[0][number];
 
@@ -49,6 +54,39 @@ describe("getHindsightMeta", () => {
     ];
     expect(getHindsightMeta(entries)).toEqual({ tags: ["topic:ai"] });
   });
+
+  it("returns meta with extraContext", () => {
+    const entries: MetaEntry[] = [
+      {
+        type: "custom",
+        customType: "hindsight-meta",
+        data: { retained: true, extraContext: "This is fiction" },
+      },
+    ];
+    expect(getHindsightMeta(entries)).toEqual({
+      retained: true,
+      extraContext: "This is fiction",
+    });
+  });
+
+  it("returns latest meta with extraContext", () => {
+    const entries: MetaEntry[] = [
+      {
+        type: "custom",
+        customType: "hindsight-meta",
+        data: { retained: true, extraContext: "old context" },
+      },
+      {
+        type: "custom",
+        customType: "hindsight-meta",
+        data: { retained: true, extraContext: "new context" },
+      },
+    ];
+    expect(getHindsightMeta(entries)).toEqual({
+      retained: true,
+      extraContext: "new context",
+    });
+  });
 });
 
 describe("shouldSessionBeRetained", () => {
@@ -87,5 +125,113 @@ describe("shouldSessionBeRetained", () => {
       { type: "custom", customType: "hindsight-meta", data: { retained: false } },
     ];
     expect(shouldSessionBeRetained(entries, { retainSessionsByDefault: true })).toBe(false);
+  });
+});
+
+describe("hasExtraContext", () => {
+  it("returns false for null meta", () => {
+    expect(hasExtraContext(null)).toBe(false);
+  });
+
+  it("returns false when key is absent", () => {
+    expect(hasExtraContext({ retained: true })).toBe(false);
+  });
+
+  it("returns false when only tags are set", () => {
+    expect(hasExtraContext({ retained: true, tags: ["test"] })).toBe(false);
+  });
+
+  it("returns true for non-empty string", () => {
+    expect(hasExtraContext({ extraContext: "Fiction session" })).toBe(true);
+  });
+
+  it("returns true for empty string (explicitly set to empty — satisfies flush guard)", () => {
+    expect(hasExtraContext({ extraContext: "" })).toBe(true);
+  });
+
+  it("returns true for empty string alongside other fields", () => {
+    expect(hasExtraContext({ retained: true, extraContext: "" })).toBe(true);
+  });
+});
+
+describe("buildMetaUpdate", () => {
+  it("sets retained from updates when no existing meta", () => {
+    expect(buildMetaUpdate(null, { retained: true })).toEqual({ retained: true });
+  });
+
+  it("sets retained: false from updates when no existing meta", () => {
+    expect(buildMetaUpdate(null, { retained: false })).toEqual({ retained: false });
+  });
+
+  it("preserves existing fields not overridden", () => {
+    expect(buildMetaUpdate({ retained: true, tags: ["x"] }, { extraContext: "foo" })).toEqual({
+      retained: true,
+      tags: ["x"],
+      extraContext: "foo",
+    });
+  });
+
+  it("drops tags when updates has empty array", () => {
+    expect(buildMetaUpdate({ retained: true, tags: ["x"] }, { tags: [] })).toEqual({
+      retained: true,
+    });
+  });
+
+  it("stores empty string extraContext (satisfies flush guard)", () => {
+    expect(buildMetaUpdate(null, { extraContext: "" })).toEqual({ extraContext: "" });
+  });
+
+  it("preserves existing retained and tags when setting extraContext", () => {
+    expect(
+      buildMetaUpdate({ retained: false, tags: ["a", "b"] }, { extraContext: "fiction" })
+    ).toEqual({ retained: false, tags: ["a", "b"], extraContext: "fiction" });
+  });
+
+  it("preserves existing extraContext when updating tags", () => {
+    expect(buildMetaUpdate({ retained: true, extraContext: "old" }, { tags: ["new"] })).toEqual({
+      retained: true,
+      extraContext: "old",
+      tags: ["new"],
+    });
+  });
+
+  it("returns empty object when no existing meta and no updates set", () => {
+    expect(buildMetaUpdate(null, {})).toEqual({});
+  });
+
+  it("overrides retained from existing with update", () => {
+    expect(buildMetaUpdate({ retained: true }, { retained: false })).toEqual({ retained: false });
+  });
+
+  it("overrides extraContext from existing with update", () => {
+    expect(buildMetaUpdate({ extraContext: "old" }, { extraContext: "new" })).toEqual({
+      extraContext: "new",
+    });
+  });
+
+  it("replaces tags from existing with update tags", () => {
+    expect(buildMetaUpdate({ tags: ["old"] }, { tags: ["a", "b"] })).toEqual({
+      tags: ["a", "b"],
+    });
+  });
+
+  it("carries forward existing retained when updates has no retained", () => {
+    expect(buildMetaUpdate({ retained: true }, { tags: ["x"] })).toEqual({
+      retained: true,
+      tags: ["x"],
+    });
+  });
+
+  it("carries forward existing extraContext when updates has no extraContext", () => {
+    expect(buildMetaUpdate({ extraContext: "fiction" }, { retained: false })).toEqual({
+      retained: false,
+      extraContext: "fiction",
+    });
+  });
+
+  it("drops tags when existing has tags but updates has empty array", () => {
+    expect(buildMetaUpdate({ retained: true, tags: ["x"] }, { tags: [], retained: true })).toEqual({
+      retained: true,
+    });
   });
 });

--- a/tests/retention.test.ts
+++ b/tests/retention.test.ts
@@ -895,4 +895,69 @@ describe("observationScopes", () => {
     const retainCall = mockWrapper.retainCalls[0] as { observationScopes?: unknown };
     expect(retainCall.observationScopes).toEqual([["cwd:/home/user/project"], ["user:alice"]]);
   });
+
+  it("includes extra context in flushed context string", async () => {
+    enqueueAutoMessage(TEST_SESSION_ID, {
+      entry: { message: { role: "user", content: "Hello" } },
+      store_method: "auto",
+    });
+
+    const mockWrapper = createMockWrapper();
+    const entries = [
+      {
+        type: "custom",
+        customType: "hindsight-meta",
+        data: { retained: true, extraContext: "This session involves reading fiction" },
+      },
+    ];
+    await flushAutoQueue(
+      TEST_SESSION_ID,
+      "Fiction Session",
+      "2024-01-01T00:00:00Z",
+      "/home/user",
+      undefined,
+      defaultConfig,
+      mockWrapper as unknown as HindsightClientWrapper,
+      undefined,
+      entries
+    );
+
+    expect(mockWrapper.retainCalls).toHaveLength(1);
+    const retainCall = mockWrapper.retainCalls[0] as { context?: string };
+    expect(retainCall.context).toContain("Fiction Session");
+    expect(retainCall.context).toContain("This session involves reading fiction");
+    // Extra context is appended after session name with newline separator
+    expect(retainCall.context).toBe("pi: Fiction Session\nThis session involves reading fiction");
+  });
+
+  it("does not append newline when no extra context", async () => {
+    enqueueAutoMessage(TEST_SESSION_ID, {
+      entry: { message: { role: "user", content: "Hello" } },
+      store_method: "auto",
+    });
+
+    const mockWrapper = createMockWrapper();
+    const entries = [
+      {
+        type: "custom",
+        customType: "hindsight-meta",
+        data: { retained: true },
+      },
+    ];
+    await flushAutoQueue(
+      TEST_SESSION_ID,
+      "Plain Session",
+      "2024-01-01T00:00:00Z",
+      "/home/user",
+      undefined,
+      defaultConfig,
+      mockWrapper as unknown as HindsightClientWrapper,
+      undefined,
+      entries
+    );
+
+    expect(mockWrapper.retainCalls).toHaveLength(1);
+    const retainCall = mockWrapper.retainCalls[0] as { context?: string };
+    expect(retainCall.context).toBe("pi: Plain Session");
+  });
 });

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -43,12 +43,15 @@ function createMockPi(): ExtensionAPI & {
   tools: ToolDef[];
   activeToolNames: string[] | null;
   setActiveToolsCalls: string[][];
+  appendedEntries: { customType: string; data?: unknown }[];
 } {
   const tools: ToolDef[] = [];
+  const appendedEntries: { customType: string; data?: unknown }[] = [];
   // Use a mutable object so the closure-based getActiveTools/setActiveTools share state
   const state = { activeToolNames: null as string[] | null, setActiveToolsCalls: [] as string[][] };
   return {
     tools,
+    appendedEntries,
     get activeToolNames() {
       return state.activeToolNames;
     },
@@ -57,6 +60,9 @@ function createMockPi(): ExtensionAPI & {
     },
     registerTool: mock((tool: ToolDef) => {
       tools.push(tool);
+    }),
+    appendEntry: mock((customType: string, data?: unknown) => {
+      appendedEntries.push({ customType, data });
     }),
     getActiveTools: mock(() => {
       if (state.activeToolNames === null) {
@@ -72,6 +78,7 @@ function createMockPi(): ExtensionAPI & {
     tools: ToolDef[];
     activeToolNames: string[] | null;
     setActiveToolsCalls: string[][];
+    appendedEntries: { customType: string; data?: unknown }[];
   };
 }
 
@@ -118,7 +125,7 @@ afterEach(() => {
 // network requests and properly forward AbortSignal to the client.
 
 describe("registerTools", () => {
-  it("does not register any tools when toolsEnabled is false", () => {
+  it("registers no tools when toolsEnabled is false", () => {
     const pi = createMockPi();
     const config = { ...testConfig, toolsEnabled: false as const };
     registerTools(pi, config, createMockClient());
@@ -152,10 +159,11 @@ describe("registerTools", () => {
     expect(pi.tools.some((t: ToolDef) => t.name === "hindsight_retain")).toBe(true);
     expect(pi.tools.some((t: ToolDef) => t.name === "hindsight_recall")).toBe(true);
     expect(pi.tools.some((t: ToolDef) => t.name === "hindsight_reflect")).toBe(false);
-    expect(pi.tools).toHaveLength(2);
+    expect(pi.tools.some((t: ToolDef) => t.name === "hindsight_set_extra_context")).toBe(false);
+    expect(pi.tools).toHaveLength(2); // retain + recall
   });
 
-  it("registers only retain when toolsEnabled is ['retain', 'recall'] and client is null", () => {
+  it("registers only hindsight_retain when toolsEnabled is ['retain', 'recall'] and client is null", () => {
     const pi = createMockPi();
     const config = { ...testConfig, toolsEnabled: ["retain", "recall"] as ["retain", "recall"] };
     registerTools(pi, config, null);
@@ -171,7 +179,7 @@ describe("registerTools", () => {
     expect(pi.tools).toHaveLength(0);
   });
 
-  it("registers only recall when toolsEnabled is ['recall'] with client", () => {
+  it("registers only hindsight_recall when toolsEnabled is ['recall'] with client", () => {
     const pi = createMockPi();
     const config = { ...testConfig, toolsEnabled: ["recall"] as ["recall"] };
     registerTools(pi, config, createMockClient());
@@ -179,6 +187,27 @@ describe("registerTools", () => {
     expect(pi.tools.some((t: ToolDef) => t.name === "hindsight_recall")).toBe(true);
     expect(pi.tools.some((t: ToolDef) => t.name === "hindsight_reflect")).toBe(false);
     expect(pi.tools).toHaveLength(1);
+  });
+
+  it("registers hindsight_set_extra_context when toolsEnabled is true", () => {
+    const pi = createMockPi();
+    registerTools(pi, testConfig, createMockClient());
+    expect(pi.tools.some((t: ToolDef) => t.name === "hindsight_set_extra_context")).toBe(true);
+  });
+
+  it("registers hindsight_set_extra_context when 'set_extra_context' is in toolsEnabled array", () => {
+    const pi = createMockPi();
+    const config = { ...testConfig, toolsEnabled: ["set_extra_context"] as ["set_extra_context"] };
+    registerTools(pi, config, null);
+    expect(pi.tools.some((t: ToolDef) => t.name === "hindsight_set_extra_context")).toBe(true);
+    expect(pi.tools).toHaveLength(1);
+  });
+
+  it("does not register hindsight_set_extra_context when not in toolsEnabled array", () => {
+    const pi = createMockPi();
+    const config = { ...testConfig, toolsEnabled: ["retain"] as ["retain"] };
+    registerTools(pi, config, null);
+    expect(pi.tools.some((t: ToolDef) => t.name === "hindsight_set_extra_context")).toBe(false);
   });
 });
 
@@ -791,12 +820,16 @@ describe("isToolEnabled", () => {
     expect(isToolEnabled({ ...testConfig, toolsEnabled: true }, "retain")).toBe(true);
     expect(isToolEnabled({ ...testConfig, toolsEnabled: true }, "recall")).toBe(true);
     expect(isToolEnabled({ ...testConfig, toolsEnabled: true }, "reflect")).toBe(true);
+    expect(isToolEnabled({ ...testConfig, toolsEnabled: true }, "set_extra_context")).toBe(true);
+    expect(isToolEnabled({ ...testConfig, toolsEnabled: true }, "get_extra_context")).toBe(true);
   });
 
   it("returns false when toolsEnabled is false", () => {
     expect(isToolEnabled({ ...testConfig, toolsEnabled: false }, "retain")).toBe(false);
     expect(isToolEnabled({ ...testConfig, toolsEnabled: false }, "recall")).toBe(false);
     expect(isToolEnabled({ ...testConfig, toolsEnabled: false }, "reflect")).toBe(false);
+    expect(isToolEnabled({ ...testConfig, toolsEnabled: false }, "set_extra_context")).toBe(false);
+    expect(isToolEnabled({ ...testConfig, toolsEnabled: false }, "get_extra_context")).toBe(false);
   });
 
   it("returns true only for tools listed in the array", () => {
@@ -817,5 +850,183 @@ describe("isToolEnabled", () => {
     const config = { ...testConfig, toolsEnabled: ["recall"] as ["recall"] };
     expect(isToolEnabled(config, "retain")).toBe(false);
     expect(isToolEnabled(config, "reflect")).toBe(false);
+    expect(isToolEnabled(config, "set_extra_context")).toBe(false);
+  });
+
+  it("returns true for set_extra_context when in array", () => {
+    const config = { ...testConfig, toolsEnabled: ["set_extra_context"] as ["set_extra_context"] };
+    expect(isToolEnabled(config, "set_extra_context")).toBe(true);
+    expect(isToolEnabled(config, "retain")).toBe(false);
+  });
+});
+
+// ============================================
+// hindsight_set_extra_context tests
+// ============================================
+
+describe("hindsight_set_extra_context", () => {
+  it("is not registered when toolsEnabled is false", () => {
+    const pi = createMockPi();
+    const config = { ...testConfig, toolsEnabled: false as const };
+    registerTools(pi, config, createMockClient());
+    expect(pi.tools.some((t: ToolDef) => t.name === "hindsight_set_extra_context")).toBe(false);
+  });
+
+  it("sets extraContext in session metadata", async () => {
+    const pi = createMockPi();
+    registerTools(pi, testConfig, createMockClient());
+    const tool = pi.tools.find((t: ToolDef) => t.name === "hindsight_set_extra_context");
+    const ctx = createMockContext();
+
+    const result = (await tool!.execute(
+      "tc1",
+      { text: "This session involves reading a fiction book" },
+      undefined,
+      undefined,
+      ctx
+    )) as { content: Array<{ type: string; text: string }>; details: { success: boolean } };
+
+    expect(result.details.success).toBe(true);
+    expect(result.content[0]?.text).toContain("Extra context set");
+
+    // Verify the metadata was appended
+    const lastEntry = pi.appendedEntries[pi.appendedEntries.length - 1];
+    expect(lastEntry?.customType).toBe("hindsight-meta");
+    expect((lastEntry?.data as Record<string, unknown>)?.extraContext).toBe(
+      "This session involves reading a fiction book"
+    );
+  });
+
+  it("stores empty extraContext when text is empty (satisfies flush guard)", async () => {
+    const pi = createMockPi();
+    registerTools(pi, testConfig, createMockClient());
+    const tool = pi.tools.find((t: ToolDef) => t.name === "hindsight_set_extra_context");
+    const ctx = createMockContext();
+
+    const result = (await tool!.execute("tc1", { text: "" }, undefined, undefined, ctx)) as {
+      content: Array<{ type: string; text: string }>;
+      details: { success: boolean };
+    };
+
+    expect(result.details.success).toBe(true);
+    expect(result.content[0]?.text).toContain("No extra context needed");
+
+    // Verify the metadata was appended with extraContext: "" (empty string signals "no extra context needed",
+    // distinct from not having the key at all — this satisfies the flush guard)
+    const lastEntry = pi.appendedEntries[pi.appendedEntries.length - 1];
+    expect(lastEntry?.customType).toBe("hindsight-meta");
+    expect((lastEntry?.data as Record<string, unknown>)?.extraContext).toBe("");
+  });
+
+  it("preserves existing retained state and tags when setting extraContext", async () => {
+    const pi = createMockPi();
+    registerTools(pi, testConfig, createMockClient());
+    const tool = pi.tools.find((t: ToolDef) => t.name === "hindsight_set_extra_context");
+    const ctx = createMockContext({
+      sessionManager: {
+        getSessionId: mock(() => TEST_SESSION_ID),
+        getEntries: mock(() => [
+          {
+            type: "custom",
+            customType: "hindsight-meta",
+            data: { retained: true, tags: ["topic:ai"], extraContext: "old context" },
+          },
+        ]),
+        getHeader: mock(() => ({ id: TEST_SESSION_ID })),
+      },
+    });
+
+    await tool!.execute("tc1", { text: "new context" }, undefined, undefined, ctx);
+
+    const lastEntry = pi.appendedEntries[pi.appendedEntries.length - 1];
+    const data = lastEntry?.data as Record<string, unknown>;
+    expect(data.retained).toBe(true);
+    expect(data.tags).toEqual(["topic:ai"]);
+    expect(data.extraContext).toBe("new context");
+  });
+});
+
+// ============================================
+// hindsight_get_extra_context tests
+// ============================================
+
+describe("hindsight_get_extra_context", () => {
+  it("is not registered when toolsEnabled is false", () => {
+    const pi = createMockPi();
+    const config = { ...testConfig, toolsEnabled: false as const };
+    registerTools(pi, config, createMockClient());
+    expect(pi.tools.some((t: ToolDef) => t.name === "hindsight_get_extra_context")).toBe(false);
+  });
+
+  it("returns extra context when set", async () => {
+    const pi = createMockPi();
+    registerTools(pi, testConfig, createMockClient());
+    const tool = pi.tools.find((t: ToolDef) => t.name === "hindsight_get_extra_context");
+    const ctx = createMockContext({
+      sessionManager: {
+        getSessionId: mock(() => TEST_SESSION_ID),
+        getEntries: mock(() => [
+          {
+            type: "custom",
+            customType: "hindsight-meta",
+            data: { extraContext: "This is fiction" },
+          },
+        ]),
+        getHeader: mock(() => ({ id: TEST_SESSION_ID })),
+      },
+    });
+
+    const result = (await tool!.execute("tc1", {}, undefined, undefined, ctx)) as {
+      content: Array<{ type: string; text: string }>;
+      details: { success: boolean; extraContext?: string };
+    };
+
+    expect(result.details.success).toBe(true);
+    expect(result.details.extraContext).toBe("This is fiction");
+    expect(result.content[0]?.text).toContain("This is fiction");
+  });
+
+  it("returns no extra context set when not set", async () => {
+    const pi = createMockPi();
+    registerTools(pi, testConfig, createMockClient());
+    const tool = pi.tools.find((t: ToolDef) => t.name === "hindsight_get_extra_context");
+    const ctx = createMockContext();
+
+    const result = (await tool!.execute("tc1", {}, undefined, undefined, ctx)) as {
+      content: Array<{ type: string; text: string }>;
+      details: { success: boolean; extraContext?: string };
+    };
+
+    expect(result.details.success).toBe(true);
+    expect(result.details.extraContext).toBeUndefined();
+    expect(result.content[0]?.text).toContain("No extra context set");
+  });
+
+  it("returns empty string context with flush guard message", async () => {
+    const pi = createMockPi();
+    registerTools(pi, testConfig, createMockClient());
+    const tool = pi.tools.find((t: ToolDef) => t.name === "hindsight_get_extra_context");
+    const ctx = createMockContext({
+      sessionManager: {
+        getSessionId: mock(() => TEST_SESSION_ID),
+        getEntries: mock(() => [
+          {
+            type: "custom",
+            customType: "hindsight-meta",
+            data: { extraContext: "" },
+          },
+        ]),
+        getHeader: mock(() => ({ id: TEST_SESSION_ID })),
+      },
+    });
+
+    const result = (await tool!.execute("tc1", {}, undefined, undefined, ctx)) as {
+      content: Array<{ type: string; text: string }>;
+      details: { success: boolean; extraContext?: string };
+    };
+
+    expect(result.details.success).toBe(true);
+    expect(result.details.extraContext).toBe("");
+    expect(result.content[0]?.text).toContain("flush guard satisfied");
   });
 });


### PR DESCRIPTION
Add an extra context field to session metadata that is appended to the Hindsight context string (after session name) to provide caveats for extraction. This helps Hindsight correctly classify content in sessions involving fiction, external articles, or other content that could be misclassified when chunked.

- Add `requireExtraContextBeforeFlush` config option (default: false) that blocks auto-flush and manual flush until extra context is set
- Add `hindsight_set_extra_context` tool (gated by `set_extra_context` in toolsEnabled) to let LLMs set extraction caveats
- Add `hindsight_get_extra_context` tool (gated by `get_extra_context` in toolsEnabled) to check current extra context
- Add `/hindsight set-extra-context` slash command
- Block `toggle-retain` from enabling retention when flush guard is active and extra context hasn't been set
- Add extraContext to document context via `appendExtraContext` / `buildContextFromSessionName` (shared by runtime and parsing paths)
- Stop truncating explicit session names in context field (only auto-derived names from first user message are truncated)
- Fix pre-existing docs bug: remove nonexistent `queue-status` command from reference table

# testing
context blocking
- [X] manual flush shows warning
- [X] compact flush shows warning
- [X] /new shows warning
- [X] /resume shows warning
- [X] /quit shows warning
- [X] toggling retain on blocked
- [X] /reload
- [X] /fork
- [X] /clone

setting context
- [X] try manually
- [X] try manually clearing/setting empty
- [X] try setting and getting with tool
- [X] check shows in hindsight status
- [ ] check document in hindsight for both
- [  ] newlines?
