### PR TITLE
chore(commitlint): enforce 72/72 message line length

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,6 @@
 # Agent Instructions for pi-hindsight
 - Use conventional commit messages, always include a scope
+- Prefer keeping commit subjects under ~50 chars and body lines at ~72 chars; commitlint enforces 72/72
 - Update CHANGELOG.md under the Pending section for any user-facing or internal changes
 - Do not use import aliases unless there is genuine naming conflict
 - The function that has enough context to produce the most accurate, non-duplicated user message should notify. Lower layers should return enough information to make that possible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Pending
 
+### Documentation
+
+- Recommend 50/72 commit message wrapping in `AGENTS.md`; commitlint config enforces 72/72 (subject and body line length).
+
 ## 0.4.0
 
 ### Features

--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
       },
       "peerDependencies": {
         "@earendil-works/pi-coding-agent": "*",
+        "@earendil-works/pi-tui": "*",
       },
     },
   },

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,7 @@
 export default {
   extends: ["@commitlint/config-conventional"],
+  rules: {
+    "header-max-length": [2, "always", 72],
+    "body-max-line-length": [2, "always", 72],
+  },
 };


### PR DESCRIPTION
Recommend 50/72 commit message wrapping in AGENTS.md and clarify that commitlint enforces 72/72. Add explicit header-max-length and body-max-line-length rules (error) at 72 in commitlint.config.js.