### PR TITLE
refactor(index): remove successful startup log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Pending
 
+### Changes
+
+- Removed the noisy `pi-hindsight initialized` startup log from `src/index.ts`. Warning, error, and disabled-mode messages are still emitted. Reduces console noise on successful startup.
+
 ### Documentation
 
 - Recommend 50/72 commit message wrapping in `AGENTS.md`; commitlint config enforces 72/72 (subject and body line length).

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,6 @@ export default function (pi: ExtensionAPI) {
     }
   } else {
     client = new HindsightClientWrapper(config);
-    console.log("pi-hindsight initialized");
   }
 
   // Set status bar indicator based on health


### PR DESCRIPTION
Remove the `pi-hindsight initialized` console.log emitted on successful validation. Warning, error, and disabled-mode messages remain intact.