### PR TITLE
feat(flush-config): add project-local overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Pending
 
+### Features
+
+- **Project-local flush config** — Added optional cwd-local project-name overrides for flushing via `<cwd>/.pi/epimetheus/flush-config.jsonc|.json` (`.jsonc` wins; no ancestor walk). The schema currently supports only `projectName`. Sessions started with a valid project-local config are marked to keep using it; marked sessions and sessions with an invalid present config fail closed instead of silently falling back. Unmarked sessions continue with the default project-name derivation.
+- **`/hindsight detach-flush-config`** — Added a recovery command to stop requiring the project-local flush config for the current session and re-flush with the cwd-derived project name.
+- **Flush-config diagnostics** — `/hindsight config` now reports the session cwd, metadata flag, config-file presence, resolved/default project names, and whether flushing is blocked.
+- **Default project names now prefer the git common dir** — Unmarked sessions derive project names as git common dir → `basename(cwd)`, so worktrees share the main repo name. Project-name environment-variable overrides were removed because they do not follow Pi session switching.
+
+### Fixed
+
+- **Degraded mode is more consistent** — Config/server/startup failures and active-session project-local flush-config failures block operational tools, queue writes, network work, and operational slash commands while keeping diagnostics, display controls, recall rendering/filtering, and recovery commands available. `enabled: false` remains a full global kill switch.
+
+### Internal
+
+- Added a centralized flush-config resolver and integrated flush-aware project-name resolution into session and tool flush paths.
+- Updated session parsing/upsert paths to use pre-resolved project names and restore pending claims on fail-closed flush-config errors.
+- Expanded test fixtures for realistic session cwd and project-local flush-config metadata cases.
+
+### Documentation
+
+- Documented project-local flush config, resolution order, fail-closed behavior, and `/hindsight detach-flush-config` in `docs/reference.md`.
+- Added `docs/architecture/config.md` and moved ingestion architecture docs to `docs/architecture/ingestion.md`.
+
 ## 0.5.0
 
 ### Breaking Changes
@@ -78,7 +100,7 @@ User note:
 
 ### Documentation
 
-- Added `docs/ARCHITECTURE.md` documenting the queue protocol, claim/recovery flow, live session state, parsed artifacts, and normal flush authority model.
+- Added `docs/architecture/ingestion.md` documenting the queue protocol, claim/recovery flow, live session state, parsed artifacts, and normal flush authority model.
 
 ### Internal
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ Status: I would call this beta level software, though I am focusing on stability
 - [Local Quickstart](#local-quickstart)
 - [Configuration](#configuration)
   - [Example Configuration](#example-configuration)
+- [Project-local Settings](#project-local-settings)
 - [Recommended User Best Practices](#recommended-user-best-practices)
 - [Caveats](#caveats)
 - [FAQ](#faq)
 
 See [Reference](docs/reference.md) for detailed configuration, tools, commands, and operational details.
+See [Architecture](docs/architecture/ingestion.md) and [Config Architecture](docs/architecture/config.md) for implementation design notes.
 See [Comparison](docs/comparison.md) for how this plugin compares to others and the design decisions behind it.
 
 # Key Features
@@ -58,7 +60,7 @@ Additionally:
 - Avoids breaking prompt caching - recall messages are appended at the end of the context for a single turn only; the canonical conversation history (which determines cache validity) grows normally with each turn, so caching should work as expected
 - Marks sessions as dirty on `message_end` so content is retained even if Hindsight is temporarily down; pending markers persist until the next successful flush
 - Properly handles forking when ingesting full sessions: forks will not duplicate parent content and will only contain new content
-- Provides automatic tags: session id, parent session id, cwd, basedir (cwd basename), project (configurable name, falls back to basedir), store method (tool or auto), and any configured tags like `harness:pi` (default)
+- Provides automatic tags: session id, parent session id, cwd, basedir (cwd basename), project (derived per session), store method (tool or auto), and any configured tags like `harness:pi` (default)
 - Allows choosing what content to retain and stripping unnecessary fields to reduce tokens/cost
 
 # Local Quickstart
@@ -151,6 +153,11 @@ Configuration is stored in `<getAgentDir()>/epimetheus/config.json` or `config.j
   // "requireExtraContextBeforeFlush": true,
 }
 ```
+
+# Project-local Settings
+Project-local settings live under a project cwd instead of the global epimetheus config. Currently, the only supported project-local setting is a flush config `projectName` override. See [Project-local Settings](docs/reference.md#project-local-settings) for more details.
+
+If you need other project-local settings, please open an issue describing the setting and why it needs to vary by project.
 
 # Recommended User Best Practices
 ## Initially

--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -1,0 +1,115 @@
+# Config Architecture
+
+This document explains the high-level configuration and readiness flow. For the full setting reference, see [Reference](../reference.md).
+
+## Goals
+
+Config handling is designed to fail closed for writes while keeping enough of the extension alive for diagnosis and safe cleanup.
+
+- Invalid or unsafe config must not retain to the wrong bank, server, project name, or tag set.
+- Existing `hindsight-recall` messages should not leak into model context just because config is broken.
+- Users should still be able to inspect what is wrong and recover without hand-editing session files where possible.
+
+## Modes
+
+### Globally disabled mode (`enabled: false`)
+
+`enabled: false` is a global kill switch, not the same thing as degraded mode. In this mode epimetheus does not register slash commands, tools, a client, or operational lifecycle handlers.
+
+The only behavior kept is lightweight session hygiene:
+
+- existing `hindsight-recall` messages are filtered from LLM context;
+- the recall renderer still hides or displays old persisted recalls according to display settings.
+
+### Degraded mode
+
+Degraded mode is the single fail-closed operational state for any condition that makes Hindsight unsafe or unavailable while the extension remains enabled. It is not only a startup state: epimetheus can become operational after a successful check, then later re-enter degraded mode if a subsequent session start observes an unhealthy/incompatible server or an invalid project-local flush config for the current session.
+
+Conditions that enter or re-enter degraded mode include:
+
+- invalid global config;
+- unreachable Hindsight server;
+- incompatible or unavailable server version;
+- the current session's project-local flush config is required but missing/invalid;
+- the current session's project-local flush config exists but does not contain a valid non-empty `projectName`.
+
+All degraded causes have the same behavior: operational tools, retention, recall, flushes, queue writes, and network work are blocked. This applies both before the first successful startup and after a previously operational session later becomes unsafe. This prevents retaining under a wrong destination, server, project identity, or tag set.
+
+Lightweight diagnostics and recovery remain available:
+
+- `/hindsight status`
+- `/hindsight config`
+- `/hindsight toggle-display`
+- `/hindsight detach-flush-config`
+- old `hindsight-recall` filtering/rendering
+
+`/hindsight detach-flush-config` is a recovery command, not an operational command: it can clear a project-local flush-config requirement for the current session, but it does not make the extension operational if another degraded-mode cause still applies.
+
+## Global config
+
+The global extension config lives under `<getAgentDir()>/epimetheus/config.jsonc` or `config.json`. When both files exist, `config.jsonc` has priority over `config.json`. Environment variables override global file/default values.
+
+Global config owns the Hindsight destination and ingestion policy: API URL/key, bank ID, retained content shape, stripping, constant tags, observation scopes, tools, auto-retain/recall/flush behavior, and status/display defaults.
+
+## Project Local Configuration
+Project-local config is intentionally not a general overlay for all settings. Settings that affect where or how data is flushed remain global for now to avoid surprising cross-session behavior.
+
+The current recommended way to work with different banks for totally isolated work, for example, is to have a separate pi wrapper script for each use case that sets the configuration environment variables. For work like this, it is probably better for you to use a separate session directory or possibly even a totally different pi coding agent directory.
+
+### Project-local flush config
+
+Project-local flush config is only for a session-specific project-name override used during flushing.
+
+
+File location is cwd-local only. When both files exist, `flush-config.jsonc` has priority over `flush-config.json`:
+
+```text
+<session-cwd>/.pi/epimetheus/flush-config.jsonc
+<session-cwd>/.pi/epimetheus/flush-config.json
+```
+
+There is no ancestor walk. This keeps the model simple, avoids surprising inheritance from parent directories, and matches Pi's general behavior of not doing project-root discovery for `.pi` config. Users who need subproject identity can run Pi from that subdirectory and put a `.pi/epimetheus/flush-config.jsonc` there.
+
+Initial schema:
+
+```jsonc
+{
+  "projectName": "my-stable-project-name"
+}
+```
+
+When a session starts in a cwd with a valid flush config, epimetheus records append-only session metadata:
+
+```jsonc
+{
+  "usesProjectFlushConfig": true
+}
+```
+
+The session metadata stores only the boolean. It does not store the config path or project name. On future flushes, the project name is resolved again from the session file header `cwd`.
+
+If the latest metadata says `usesProjectFlushConfig: true`, that session requires a cwd-local flush config with a valid non-empty `projectName`. If the cwd is gone, the file is missing/invalid, or the file is valid JSON but does not specify a valid `projectName`, flushing fails closed and pending work remains queued. `/hindsight detach-flush-config` appends `usesProjectFlushConfig: false` for the current session; it does not delete the file.
+
+If the session is detached or never used project-local flush config, the default project name is derived as:
+
+1. git common-dir repo name when `<cwd>/.git` exists, so worktrees share the main repo name;
+2. `basename(cwd)`.
+
+Environment-variable project-name overrides are intentionally not part of the resolution model because they do not follow Pi session switching across directories.
+
+## Flush-time resolution
+
+Flushes use the target session file's header `cwd`, not process cwd and not necessarily the active TUI session cwd. This matters for `/hindsight flush-pending`, which may process sessions from different directories in one command.
+
+Session upserts resolve project identity at flush time. If a required project-local flush config is missing/invalid, or if a present project-local flush config is invalid for an unmarked session, the flush is blocked and pending work remains queued. Tool retain queue entries snapshot their tags and observation scopes when queued, so the current session's config must be valid before the retain tool can create entries.
+
+## Why keep lightweight mode
+
+Even when Hindsight operations are unavailable, epimetheus still protects existing sessions:
+
+- old persisted recall entries are filtered before model context;
+- old recall UI rendering remains controlled instead of showing raw custom-message data;
+- users can run diagnostics to see whether the failure is global config, project-local flush config, server reachability, or version compatibility;
+- recovery commands can detach a session from a missing/broken project-local flush config.
+
+The goal is to fail closed for writes, not to leave users blind.

--- a/docs/architecture/ingestion.md
+++ b/docs/architecture/ingestion.md
@@ -1,6 +1,6 @@
-# Architecture
+# Ingestion Architecture
 
-This document explains epimetheus' ingestion architecture: how session content, explicit tool retains, and metadata move from Pi session state into Hindsight.
+This document explains epimetheus' ingestion architecture: how session content, explicit tool retains, and metadata move from Pi session state into Hindsight. For config/readiness behavior, see [Config Architecture](config.md).
 
 ## Goals
 
@@ -270,7 +270,7 @@ Config/env-derived ingestion metadata is rebuilt whenever an upsert happens inst
 - final Hindsight context from current `hindsightContextPrefix`, session name, and extra context;
 - constant tags from current config;
 - structural tags such as `session:<id>`, `cwd:<path>`, `basedir:<name>`, `store_method:auto`, and `parent:<id>`;
-- project tag/name, including the current `EPIMETHEUS_PROJECT_NAME` override when set, otherwise derived from the session cwd;
+- project tag/name, resolved for the target session at flush time: project-local flush config `projectName` when required/present, otherwise git common-dir basename or cwd basename;
 - observation scopes from current config, with placeholders expanded using the session ID, parent session ID, session cwd, basedir, and project name;
 - entities from current config.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -22,6 +22,8 @@ Detailed configuration, tools, commands, and operational details for epimetheus.
     - [entities](#entities)
   - [observationScopes](#observationscopes)
     - [Project scope for relocatable projects](#project-scope-for-relocatable-projects)
+  - [Project-local Settings](#project-local-settings)
+    - [Project-local Flush Config](#project-local-flush-config)
   - [autoRecallTags](#autorecalltags)
   - [Project-specific Recall and Storage](#project-specific-recall-and-storage)
   - [Environment Variables](#environment-variables)
@@ -375,14 +377,14 @@ Using custom scope groups is recommended. Most users should combine a per-user s
 | `{parent}` | `parent:<parentId>` | Cross-fork observations (falls back to session ID if no parent) |
 | `{cwd}` | `cwd:<path>` | Per-directory observations |
 | `{basedir}` | `basedir:<basename>` | Per-directory-name observations |
-| `{project}` | `project:<name>` | Per-project observations (name from `EPIMETHEUS_PROJECT_NAME` or cwd basename) |
+| `{project}` | `project:<name>` | Per-project observations (git common-dir name when available, otherwise cwd basename; can override with project-local flush config `projectName`) |
 
 Placeholders must be used as standalone tags — e.g. `["{session}"]` not `["{session}:extra"]`. Non-exact placeholder usage will produce a config warning.
 
 **Choosing your scopes:**
 - **Per-session observations** (`["{session}"]`) — facts within a single session only — this is rarely useful unless you frequently resume the same session over and over. In practice, you'll get more value from:
 - **Per-user** (`["user:<me>"]`) — facts that span all your sessions/documents and memories stored manually with `hindsight_retain` tool, even across different harnesses. Add `"user:<me>"` to `constantTags` and use it as a scope. This is the most broadly useful scope.
-- **Per-project** (`["{project}"]`) — facts about a specific project, independent of directory. The project tag defaults to the cwd basename but can be overridden with `EPIMETHEUS_PROJECT_NAME`. This is ideal when a project might change directories or have multiple separate worktrees — observations stay linked to the project identity rather than a specific path. See [Project scope for relocatable projects](#project-scope-for-relocatable-projects).
+- **Per-project** (`["{project}"]`) — facts about a specific project, independent of directory. The project tag defaults to the git common-dir name when available (so worktrees get the same project name), otherwise the cwd basename. It can be overridden per project with a [project-local flush config](#project-local-flush-config). This is ideal over `{cwd}` when a project might change directories or have multiple separate worktrees — observations stay linked to the project identity rather than a specific path. See [Project scope for relocatable projects](#project-scope-for-relocatable-projects).
 - **Per-directory** (`["{cwd}"]`) — facts about a specific project/codebase, consolidated across all sessions in that directory
 - **Per-basedir** (`["{basedir}"]`) — facts scoped by directory name (basename). Less precise than `{cwd}` but works across different parent paths with the same directory name
 - **Per-harness** (`["harness:pi"]`) — facts that span all pi sessions (included as a default constant tag)
@@ -394,29 +396,22 @@ Recommended example — Per-user scope plus per-project scope:
   "constantTags": ["harness:pi", "user:<me>"],
   "observationScopes": [
     ["user:<me>"],   // observations across all your sessions
-    ["{project}"]     // observations scoped to this project (basedir or EPIMETHEUS_PROJECT_NAME)
+    ["{project}"]     // observations scoped to this project
   ]
 }
 ```
 
 This creates two consolidation passes:
 1. One for facts that span all your sessions (even across different harnesses, assuming you've also tagged those documents with `user:<me>`)
-2. One for facts specific to the current project (identified by `EPIMETHEUS_PROJECT_NAME` or the cwd basename)
+2. One for facts specific to the current project (identified by project-local flush config when used, otherwise git common-dir name or cwd basename)
 
 > **Note on duplicate observations:** When you have multiple scopes in `observationScopes`, the same underlying memories may produce duplicate observations — one per scope. For example, a project-scoped observation and a global (per-user) observation may contain overlapping information. To avoid recalling duplicates, you should filter auto-recalled observations to the scope you currently want (e.g., use `autoRecallTags: ["{project}"]` for project-specific recall or `autoRecallTags: ["user:<me>"]` for global recall). Alternatively, if you will never need to switch between scopes, you can limit `observationScopes` to just one entry.
 
 ### Project scope for relocatable projects
 
-Use `{project}` when you want observations tied to a project identity rather than a specific directory path. By default `{project}` expands to the cwd basename, so observations automatically follow the project across directory moves (e.g., `~/projects/myapp` → `~/work/myapp` — the `cwd` tag changes but the `project` tag stays the same).
+Use `{project}` when you want observations tied to a project identity rather than a specific directory path. By default `{project}` expands to the git common-dir name when available, otherwise the cwd basename, so normal git worktrees share the main repo project name automatically.
 
-You only need to set `EPIMETHEUS_PROJECT_NAME` when you have multiple directories with the same basename that should have separate observations (e.g. `~/work/myapp` vs. `~/personal/myapp`) or if you are using separate worktree folders and want the project name to be the same for both.
-
-Set `EPIMETHEUS_PROJECT_NAME` per directory in, e.g. `.env` with [direnv](https://direnv.net/) or [mise](https://mise.jdx.dev/):
-
-```envrc
-# In .env per project directory (loaded by direnv or mise):
-EPIMETHEUS_PROJECT_NAME=myapp
-```
+Use a [project-local flush config](#project-local-flush-config) when the derived project name is not the identity you want to retain under, such as when multiple unrelated directories share the same basename or when you want to rename the project identity without moving the directory.
 
 ```jsonc
 {
@@ -429,13 +424,13 @@ EPIMETHEUS_PROJECT_NAME=myapp
 ```
 
 **When to use `{project}` vs. `{cwd}` vs. `{basedir}`:**
-- `{project}` (recommended) — Observations scoped by project name (cwd basename by default). Automatically follows directory moves. Set `EPIMETHEUS_PROJECT_NAME` to disambiguate directories with the same basename or to give separate worktree directories the same project name.
+- `{project}` (recommended) — Observations scoped by project name (git common-dir name when available, otherwise cwd basename). Use project-local flush config `projectName` to override the retained project identity for a project.
 - `{cwd}` — Use when you want observations tied to an exact directory path. Different directories with the same basename produce separate observations.
 - `{basedir}` — Use when you want observations grouped by directory name regardless of parent path. All directories named `myapp` share observations.
 
-> **Note:** Since `basedir:` and `project:` tags are generated at retain time, re-parsing and re-ingesting a session (via `/hindsight parse-and-upsert-session`) will use the *current* basedir or `EPIMETHEUS_PROJECT_NAME`. This means you can change the project identity of an existing session by updating the env var and re-ingesting — useful for correcting or migrating project names after the fact. The `cwd:` tag is fixed from the session header and does not change on re-parse (unless you manually change it).
+> **Note:** Since `basedir:` and `project:` tags are generated at retain time, re-parsing and re-ingesting a session (via `/hindsight parse-and-upsert-session`) will use the current project resolution for that session. This means you can change the retained project identity of an existing session by adding or editing its project-local flush config and re-ingesting. The `cwd:` tag is fixed from the session header and does not change on re-parse (unless you manually change it).
 >
-> The `cwd:` tag and `{cwd}`/`{basedir}`/`{project}` placeholders (in both observation scopes and auto-recall tags) use the session's cwd from the session header — the directory the session was first created in.
+> The `cwd:` tag and `{cwd}`/`{basedir}`/`{project}` placeholders use the session's cwd from the session header — the directory the session was first created in.
 
 Full example with all available scopes:
 ```jsonc
@@ -444,7 +439,7 @@ Full example with all available scopes:
   "observationScopes": [
     ["user:<me>"],    // observations across all your sessions
     ["harness:pi"],   // observations across all pi sessions
-    ["{project}"],    // observations scoped to this project (EPIMETHEUS_PROJECT_NAME or basedir)
+    ["{project}"],    // observations scoped to this project
     ["{cwd}"],        // observations scoped to this exact directory path
     ["{basedir}"],    // observations scoped to this directory name
     ["{session}"],    // observations scoped to this session only (rarely needed)
@@ -459,6 +454,42 @@ export EPIMETHEUS_OBSERVATION_SCOPES='[["{session}","user:alice"],["project:foo"
 ```
 
 Note: This is currently a config-only setting and not exposed as a parameter on the `hindsight_retain` tool. The configured scope applies to all retains (both auto and tool-initiated).
+
+## Project-local Settings
+
+Project-local settings live under the project cwd instead of in the global epimetheus config. The only project-local setting currently supported is `flush-config` with `projectName`.
+
+If you need other project-local settings, please open an issue describing the setting and why it needs to vary by project.
+
+### Project-local Flush Config
+
+See [Config Architecture](architecture/config.md#project-local-flush-config) for the high-level design. This subsection is for user-facing instructions.
+
+**File location** (cwd-local only — **no ancestor walk** — `.jsonc` has priority over `.json`):
+
+- `<cwd>/.pi/epimetheus/flush-config.jsonc`
+- `<cwd>/.pi/epimetheus/flush-config.json`
+
+**Schema**:
+
+```jsonc
+{
+  "projectName": "my-stable-project-name"
+}
+```
+
+**Resolution order at flush time**:
+
+1. **If the session is marked `usesProjectFlushConfig: true`**, the cwd-local flush config file **must** exist and contain a valid non-empty `projectName`, or the flush **fails closed** — pending work is left queued and a warning is surfaced.
+2. **If the session is unmarked and a cwd-local flush config file is present but invalid**, the flush **fails closed** instead of silently falling back to a derived project name.
+3. **Otherwise**:
+   - project-local `projectName` if specified
+   - if `<cwd>/.git` exists, the git common dir is resolved so worktrees share the main repo name (e.g. `/repo` and `/repo/worktrees/foo` both → `repo`)
+   - else `basename(cwd)`
+
+When a session is started in or resumed from a directory that contains a project-local flush config with a valid non-empty `projectName`, epimetheus marks the session as using it. Future flushes for that session then require the cwd-local flush config to exist and specify a valid `projectName`; that `projectName` is used in place of the cwd-derived default. Requiring the project config afterwards is to prevent accidentally tagging as the wrong project later (e.g. moving to a new drive, recloning the projcet, etc.).
+
+`/hindsight detach-flush-config` stops the current session from requiring the cwd-local flush config. You can use this if for some reason you no longer want to override the project name for a session (e.g. resolution algorithm handles a new vc system it didn't before and the config is no longer necessary).
 
 ### autoRecallTags
 Tags to filter by during auto-recall. When set, only memories matching these tags will be recalled. Supports the same placeholder expansion as observation scopes (`{session}`, `{parent}`, `{cwd}`, `{basedir}`, `{project}`), expanded at recall time using the current session context.
@@ -567,15 +598,12 @@ Configuration options can also be set via environment variables (override config
 | `EPIMETHEUS_RETAIN_CONTENT` | `retainContent` | RetainContent (JSON) | *(see retainContent default)* |
 | `EPIMETHEUS_STRIP` | `strip` | StripConfig (JSON) | *(see strip default)* |
 | `EPIMETHEUS_TOOL_FILTER` | `toolFilter` | ToolFilter (JSON) | *(see toolFilter default)* |
-| `EPIMETHEUS_PROJECT_NAME` | *(not in config)* | string | *(falls back to cwd basename)* |
 | `EPIMETHEUS_ENTITIES` | `entities` | EntityInput[] (JSON) | `[]` |
 | `EPIMETHEUS_OBSERVATION_SCOPES` | `observationScopes` | ObservationScopes (JSON or preset string) | `null` (required) |
 | `EPIMETHEUS_STATUS_HEALTHY` | `statusHealthy` | string | `"🧠"` |
 | `EPIMETHEUS_STATUS_UNHEALTHY` | `statusUnhealthy` | string | `"🤯"` |
 | `EPIMETHEUS_DEBUG` | `debug` | boolean | `false` |
 </details>
-
-> **Note:** `EPIMETHEUS_PROJECT_NAME` is a special environment variable that controls the `project:` auto-tag and `{project}` observation scope placeholder. Unlike other env vars, it does not correspond to a config file key — it is read at tag-build time and falls back to the cwd basename if not set. This makes it ideal for setting per-directory in `.env` (with direnv or mise) to disambiguate directories that share the same basename or to give separate worktree directories the same project name so they share observations.
 
 # Additional Details
 ## Memory Fencing
@@ -629,6 +657,7 @@ All commands are under `/hindsight <subcommand>`. With no subcommand, defaults t
 | `tag <tag>` | Add a tag to the session's hindsight metadata |
 | `remove-tag <tag>` | Remove a tag from the session's hindsight metadata |
 | `set-extra-context <text>` | Set extra context for extraction caveats (appended to Hindsight context field). Call with no text to indicate no extra context is needed (satisfies the flush guard). |
+| `detach-flush-config` | Stop requiring the cwd-local flush config for this session. See [Project-local Flush Config](#project-local-flush-config). |
 | `toggle-display` | Toggle recall message visibility in UI |
 | `popup` | Pop up last recalled messages in overlay |
 | `status` | Show operational status (connection, session, recall info, queue count) |

--- a/src/commands/detach-flush-config.ts
+++ b/src/commands/detach-flush-config.ts
@@ -1,0 +1,91 @@
+/**
+ * `/hindsight detach-flush-config` subcommand.
+ *
+ * Stops the current session from requiring a cwd-local flush config. Appends a
+ * new `hindsight-meta` entry with `usesProjectFlushConfig: false` (latest
+ * metadata wins) and marks the session pending so the next flush re-runs with
+ * the cwd-derived project name (basename, or git common dir for worktrees).
+ *
+ * The cwd-local flush config file at
+ * `<cwd>/.pi/epimetheus/flush-config.jsonc|.json` is **not** deleted — only
+ * this session's requirement is removed. Other sessions (and the file itself)
+ * are untouched. Use a `cursor`/rm or `/hindsight detach-flush-config` separately
+ * on any session you want to detach.
+ */
+
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { HindsightConfig } from "../config";
+import { getHindsightMeta, shouldSessionBeRetained, updateSessionMetadata } from "../meta";
+import { touchPendingFlag } from "../queue";
+import { setActiveSessionFlushReady } from "../runtime-state";
+import { refreshToolVisibility } from "../tools";
+import type { Subcommand } from "./types";
+
+/**
+ * Create the detach-flush-config subcommand.
+ *
+ * Confirms (because future flushes may derive a different project name and
+ * thus produce different document tags / observation-scope linkage), appends
+ * `usesProjectFlushConfig: false`, marks the session pending, and makes clear
+ * the file is left in place.
+ */
+export function createDetachFlushConfigSubcommand(
+  pi: ExtensionAPI,
+  config: HindsightConfig
+): Subcommand {
+  return {
+    description:
+      "Stop requiring the cwd-local flush config for this session (does not delete the file)",
+    handler: async (_args: string, ctx: ExtensionContext) => {
+      const answer = await ctx.ui.confirm(
+        "Detach the project-local flush config?",
+        "This stops the current session from requiring a cwd-local flush config (its " +
+          "usesProjectFlushConfig metadata is set to false, latest-wins). Future flushes " +
+          "will derive the project name from the cwd (basename, or the git common dir " +
+          "for worktrees), which may differ from the flush-config projectName and change " +
+          "the document's project tag — pending work is queued for a re-flush. The flush " +
+          "config file at <cwd>/.pi/epimetheus/ is NOT deleted. Continue?"
+      );
+      if (!answer) {
+        ctx.ui.notify("Flush config not detached", "info");
+        return;
+      }
+
+      const entries = ctx.sessionManager.getEntries();
+      const sessionId = ctx.sessionManager.getSessionId();
+      const existingMeta = getHindsightMeta(entries);
+
+      await updateSessionMetadata(
+        pi,
+        sessionId,
+        entries,
+        { usesProjectFlushConfig: false },
+        config
+      );
+
+      if (sessionId) {
+        const result = touchPendingFlag(sessionId, "detach-flush-config");
+        if (!result.success) {
+          ctx.ui.notify(`Failed to queue session for re-flush: ${result.error}`, "warning");
+        }
+      }
+
+      // Detaching clears only the active-session flush-config failure. Tool
+      // visibility still depends on the unified operational-ready state, so an
+      // unrelated server/config failure keeps tools hidden.
+      setActiveSessionFlushReady(true);
+      const isRetained = shouldSessionBeRetained(entries, config);
+      refreshToolVisibility(pi, isRetained);
+
+      // Surface the prior state for context: if the session wasn't actually
+      // marked as using flush config, detaching is a no-op future-proof mark.
+      const wasMarked = existingMeta?.usesProjectFlushConfig === true;
+      ctx.ui.notify(
+        wasMarked
+          ? "Detached flush config for this session. The project name will be derived from cwd on the next flush (pending work queued). The flush-config file was NOT deleted."
+          : "Recorded usesProjectFlushConfig=false for this session (it was not flagged as using a flush config). Future flushes will derive the project name from cwd. The flush-config file was NOT deleted.",
+        "info"
+      );
+    },
+  };
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -13,18 +13,7 @@ import type { HindsightClientWrapper } from "../client";
 import type { HindsightConfig } from "../config";
 import { EXTENSION_ID } from "../constants";
 import type { RecallMessageDetails } from "../index";
-
-// Whether the not-ready warning has been shown this process. Resets on
-// /reload (module re-import) and from index.ts's test reset hook. Avoids
-// spamming the same unavailable warning on repeated blocked operational
-// commands while startup hasn't completed.
-let notReadyWarned = false;
-
-/** Reset module-level command state. Exported for tests via index.ts._resetState(). */
-export function resetNotReadyWarned(): void {
-  notReadyWarned = false;
-}
-
+import { createDetachFlushConfigSubcommand } from "./detach-flush-config";
 import {
   createExtraContextSubcommand,
   createRemoveTagSubcommand,
@@ -40,6 +29,17 @@ import {
 } from "./session";
 import { createConfigSubcommand, createStatusSubcommand } from "./status";
 import type { Subcommand } from "./types";
+
+// Whether the not-ready warning has been shown this process. Resets on
+// /reload (module re-import) and from index.ts's test reset hook. Avoids
+// spamming the same unavailable warning on repeated blocked operational
+// commands while startup hasn't completed.
+let notReadyWarned = false;
+
+/** Reset module-level command state. Exported for tests via index.ts._resetState(). */
+export function resetNotReadyWarned(): void {
+  notReadyWarned = false;
+}
 
 /**
  * Register the `/hindsight` command with all subcommands.
@@ -79,10 +79,21 @@ export function registerCommands(
   /**
    * Operational subcommands that perform writes/network or queue work. These are
    * blocked (unavailable message, no side effects) until a healthy startup has
-   * completed (`isReady()`). Diagnostic/display subcommands (`status`, `config`,
-   * `popup`, `toggle-display`, and the debug-only `active-tools`) remain
+   * completed (`isReady()`). Diagnostic/display subcommands (`status`,
+   * `config`, `toggle-display`, and the debug-only `active-tools`) remain
    * available even when not ready so users can inspect state and reason about
    * why the extension is unavailable.
+   *
+   * `detach-flush-config` is intentionally NOT operational: it is the recovery
+   * command for an active session that failed readiness because of an invalid
+   * or missing cwd-local flush config. It must remain available even in that
+   * failed state so the user can stop requiring the flush config without
+   * manually editing the session file. It only writes session metadata + a
+   * pending marker (no client/network), so running it while not ready is safe.
+   *
+   * `popup` is display-only but gated separately (see the handler): degraded
+   * mode skips auto-recall, so there is no current recall to inspect; it also
+   * requires `autoRecallEnabled`.
    */
   const OPERATIONAL_SUBCOMMANDS = new Set([
     "flush",
@@ -94,6 +105,11 @@ export function registerCommands(
     "remove-tag",
     "set-extra-context",
   ]);
+
+  // Display-only, but only meaningful when auto-recall can run and cache a
+  // current recall. Kept out of OPERATIONAL_SUBCOMMANDS so it gets a specific
+  // user-facing explanation instead of the generic operational-command warning.
+  const AUTO_RECALL_CACHE_SUBCOMMANDS = new Set(["popup"]);
 
   const subcommands: Record<string, Subcommand> = {
     flush: createFlushSubcommand(client, config),
@@ -122,6 +138,7 @@ export function registerCommands(
     tag: createTagSubcommand(pi, config),
     "remove-tag": createRemoveTagSubcommand(pi, config),
     "set-extra-context": createExtraContextSubcommand(pi, config),
+    "detach-flush-config": createDetachFlushConfigSubcommand(pi, config),
     "toggle-display": createToggleDisplaySubcommand(
       config,
       getAutoRecallDisplayOverride,
@@ -204,23 +221,48 @@ export function registerCommands(
       }
 
       // Block operational subcommands until a healthy startup completes.
-      // Diagnostic/display subcommands (status, config, popup, toggle-display,
-      // active-tools) remain available so users can inspect why the extension
-      // is unavailable.
+      // Diagnostic/display subcommands (status, config, toggle-display,
+      // active-tools, and the detach-flush-config recovery command) remain
+      // available so users can inspect why the extension is unavailable.
       if (OPERATIONAL_SUBCOMMANDS.has(subcommandName) && !isReady()) {
         // Surface the full reason once per process; subsequent blocked attempts
         // stay quiet so repeated commands while unhealthy don't spam.
         if (!notReadyWarned) {
           notReadyWarned = true;
           ctx.ui.notify(
-            `${EXTENSION_ID} is not ready (config/startup checks failed or have not run). ` +
+            `${EXTENSION_ID} is not ready (startup checks have not completed, the ` +
+              `server is unreachable/incompatible, or the active session's ` +
+              `project-local flush config is required-but-missing/invalid). ` +
               `Operational commands (flush, parse-and-upsert-session, toggle-retain, ...) ` +
-              `are unavailable until config is valid and the server is reachable/version-compatible. ` +
+              `are unavailable until startup succeeds and the active session's ` +
+              `flush config is valid or detached via \`/hindsight detach-flush-config\`. ` +
               `Run \`/hindsight status\` for details.`,
             "warning"
           );
         }
         return;
+      }
+
+      // Commands that inspect the auto-recall cache are display-only but still
+      // require operational auto-recall: degraded mode skips auto-recall, so
+      // there is no current recall to inspect. They also require
+      // `autoRecallEnabled` — without auto-recall, no recall is ever cached.
+      if (AUTO_RECALL_CACHE_SUBCOMMANDS.has(subcommandName)) {
+        if (!isReady()) {
+          ctx.ui.notify(
+            `${EXTENSION_ID} is not ready; auto-recall is skipped in degraded mode, ` +
+              `so there is no recall to inspect. Run \`/hindsight status\` for details.`,
+            "info"
+          );
+          return;
+        }
+        if (!config.autoRecallEnabled) {
+          ctx.ui.notify(
+            "Cannot pop up recall: autoRecallEnabled is false (no recall is cached).",
+            "info"
+          );
+          return;
+        }
       }
 
       await subcommand.handler(subArgs, ctx);

--- a/src/commands/meta.ts
+++ b/src/commands/meta.ts
@@ -8,7 +8,7 @@ import type { HindsightConfig } from "../config";
 import { getHindsightMeta, shouldSessionBeRetained, updateSessionMetadata } from "../meta";
 import { clearSessionQueueState, touchPendingFlag } from "../queue";
 import { parseAndUpsertSession } from "../retention";
-import { isToolEnabled, updateRetainToolVisibility } from "../tools";
+import { isToolEnabled, refreshToolVisibility } from "../tools";
 import type { Subcommand } from "./types";
 
 /**
@@ -35,7 +35,7 @@ async function enableRetention(
   await updateSessionMetadata(pi, sessionId, entries, { retained: true }, config);
 
   if (isToolEnabled(config, "retain")) {
-    updateRetainToolVisibility(pi, true);
+    refreshToolVisibility(pi, true);
   }
 
   // Create a pending marker immediately so that if the upsert fails or can't
@@ -102,7 +102,7 @@ async function disableRetention(
   await updateSessionMetadata(pi, sessionId, entries, { retained: false }, config);
 
   if (isToolEnabled(config, "retain")) {
-    updateRetainToolVisibility(pi, false);
+    refreshToolVisibility(pi, false);
   }
 
   // clear after retain disabled to avoid new tool retains coming in and being

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -5,6 +5,11 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { HindsightClientWrapper } from "../client";
 import type { HindsightConfig } from "../config";
+import {
+  findFlushConfigFile,
+  resolveFlushConfig,
+  resolveProjectNameForFlush,
+} from "../flush-config";
 import type { RecallMessageDetails } from "../index";
 import { getHindsightMeta, shouldSessionBeRetained } from "../meta";
 import { getPendingWorkCount } from "../retention";
@@ -177,6 +182,66 @@ export function createConfigSubcommand(
       } else {
         lines.push("  None");
       }
+
+      // Session-specific flush config diagnostics. These are unrelated to the
+      // global config above: they describe how the *current* session's project
+      // name will be resolved during a flush (its cwd-local flush config,
+      // metadata flag, and derived name).
+      lines.push("\n== Session-Specific Flush Config ==");
+      const header = ctx.sessionManager?.getHeader?.();
+      const sessionCwd = header?.cwd ?? ctx.cwd;
+      lines.push(`  Session cwd: ${sessionCwd ?? "(none)"}`);
+
+      const entries = ctx.sessionManager?.getEntries?.() ?? [];
+      const meta = getHindsightMeta(entries);
+      const usesFlag = meta?.usesProjectFlushConfig;
+      const flagLabel =
+        usesFlag === undefined
+          ? "(unset)"
+          : usesFlag
+            ? "true (requires cwd-local flush config)"
+            : "false (detached)";
+      lines.push(`  usesProjectFlushConfig: ${flagLabel}`);
+
+      const configPath = findFlushConfigFile(sessionCwd ?? "");
+      lines.push(`  Config file: ${configPath ?? "(missing)"}`);
+      if (configPath) {
+        const loaded = resolveFlushConfig(sessionCwd ?? "");
+        if (loaded.ok) {
+          lines.push(`  Config projectName: ${loaded.config.projectName}`);
+          for (const w of loaded.warnings) lines.push(`  warning: ${w}`);
+        } else {
+          lines.push(`  Config status: invalid — ${loaded.error}`);
+          for (const w of loaded.warnings) lines.push(`  warning: ${w}`);
+        }
+      }
+
+      // "Would proceed" uses the session's actual flag (tristate: true / false /
+      // undefined) so an unmarked session with an invalid cwd-local config is
+      // reported as blocked (matching what parseAndUpsertSession would do).
+      const resolutionMarked = resolveProjectNameForFlush(sessionCwd ?? "", usesFlag);
+      if (resolutionMarked.ok) {
+        lines.push(
+          `  Resolved project name: ${resolutionMarked.projectName} (source: ${resolutionMarked.source})`
+        );
+      } else {
+        lines.push(`  Resolved project name: (blocked) ${resolutionMarked.error}`);
+      }
+
+      // Default (detached) derivation, for comparison with the marked case.
+      const defaultResolution = resolveProjectNameForFlush(sessionCwd ?? "", false);
+      if (defaultResolution.ok) {
+        lines.push(
+          `  Default project name: ${defaultResolution.projectName} (source: ${defaultResolution.source})`
+        );
+      } else {
+        lines.push(`  Default project name: (blocked) ${defaultResolution.error}`);
+      }
+
+      const wouldProceed = resolutionMarked.ok;
+      lines.push(
+        `  Flush would proceed: ${wouldProceed ? "yes" : "no (blocked — pending left queued)"}`
+      );
 
       ctx.ui.notify(lines.join("\n"), "info");
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,20 +14,7 @@ import type {
 import { type ParseError, parse as parseJsonc, printParseErrorCode } from "jsonc-parser";
 import { prefixLog } from "./constants";
 import { getDataDir } from "./data-dir";
-
-function offsetToLineColumn(content: string, offset: number): { line: number; character: number } {
-  let line = 1;
-  let character = 1;
-  for (let i = 0; i < offset && i < content.length; i++) {
-    if (content[i] === "\n") {
-      line++;
-      character = 1;
-    } else {
-      character++;
-    }
-  }
-  return { line, character };
-}
+import { offsetToLineColumn } from "./utils";
 
 export interface RetainContent {
   assistant: ("text" | "thinking" | "toolCall")[];

--- a/src/document.ts
+++ b/src/document.ts
@@ -238,18 +238,29 @@ function buildForkedMessages(
 
 /**
  * Build tags for a document.
+ *
+ * `options.projectName`, when provided, overrides the cwd-derived project name
+ * for the `project:<name>` tag. Callers that have already resolved the project
+ * name (e.g. via `resolveProjectNameForFlush`, which is flush-config-aware)
+ * should pass it through here so documents and tool entries share the same
+ * `project:` tag. When omitted, falls back to `getProjectName(header.cwd)`.
  */
 export function buildDocumentTags(
   header: SessionHeader,
   config: HindsightConfig,
-  options?: { storeMethod?: "auto" | "tool"; sessionUserTags?: string[]; parentSessionId?: string }
+  options?: {
+    storeMethod?: "auto" | "tool";
+    sessionUserTags?: string[];
+    parentSessionId?: string;
+    projectName?: string;
+  }
 ): string[] {
   const tags = [
     ...config.constantTags,
     `session:${header.id}`,
     `cwd:${header.cwd}`,
     `basedir:${getBasedir(header.cwd)}`,
-    `project:${getProjectName(header.cwd)}`,
+    `project:${options?.projectName ?? getProjectName(header.cwd)}`,
     `store_method:${options?.storeMethod ?? "auto"}`,
   ];
 

--- a/src/flush-config.ts
+++ b/src/flush-config.ts
@@ -1,0 +1,415 @@
+/**
+ * Project-local flush config: cwd-local project-name overrides for flushing.
+ *
+ * Resolution order for a flush (see `docs/architecture/config.md`):
+ *
+ * 1. If the session is marked `usesProjectFlushConfig: true` (in its latest
+ *    `hindsight-meta` entry), the cwd-local flush config file MUST exist and
+ *    be valid at `<session header cwd>/.pi/epimetheus/flush-config.jsonc`.
+ *    Missing/invalid (or a removed cwd) → fail closed.
+ * 2. Otherwise (not marked), derive a default project name:
+ *    - if `<cwd>/.git` exists, resolve the git common dir so worktrees
+ *      share the main repo name (e.g. `/repo` and `/repo/worktrees/foo` both → `repo`)
+ *    - else `basename(cwd)`
+ *
+ * Only cwd-local config is consulted — **no ancestor walk**. The schema
+ * initially supports only `projectName`; unknown keys warn and are ignored.
+ * Invalid/missing required flush config fails closed and flushes are skipped.
+ *
+ * Default derivation (detached / unmarked-with-no-file) is git common dir →
+ * basename (see {@link ./utils.ts deriveDefaultProjectName}). Env-var overrides
+ * were removed because env vars do not track Pi session switching.
+ */
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { type ParseError, parse as parseJsonc, printParseErrorCode } from "jsonc-parser";
+import { deriveDefaultProjectName, offsetToLineColumn } from "./utils";
+
+/** The single supported flush-config schema: a stable project name. */
+export interface FlushConfig {
+  projectName: string;
+}
+
+/** Directory (relative to cwd) where the cwd-local flush config lives. */
+const FLUSH_CONFIG_DIR = join(".pi", "epimetheus");
+
+/**
+ * Where the resolved project name came from. Used by `/hindsight config`
+ * diagnostics. Not stored anywhere; latest flush resolution wins.
+ */
+export type ProjectNameSource = "flush-config" | "git" | "basename";
+
+/**
+ * Success result: the resolved project name and its source.
+ */
+export interface ProjectNameResolutionSuccess {
+  ok: true;
+  projectName: string;
+  source: ProjectNameSource;
+}
+
+/**
+ * Failure result: flush cannot proceed. The caller should leave pending work
+ * queued (do NOT clear the pending marker) and notify clearly.
+ */
+export interface ProjectNameResolutionFailure {
+  ok: false;
+  error: string;
+  /** Path of the malformed/invalid config, when one was found. */
+  configPath?: string;
+}
+
+export type ProjectNameResolution = ProjectNameResolutionSuccess | ProjectNameResolutionFailure;
+
+/**
+ * Success: a valid cwd-local flush config was loaded.
+ */
+export interface FlushConfigLoadSuccess {
+  ok: true;
+  config: FlushConfig;
+  /** Path of the loaded config file. */
+  path: string;
+  warnings: string[];
+}
+
+/**
+ * Failure: config missing, malformed, or structurally invalid.
+ */
+export interface FlushConfigLoadFailure {
+  ok: false;
+  error: string;
+  /** Path of the malformed/invalid config, when one was found on disk. */
+  path?: string;
+  warnings: string[];
+}
+
+export type FlushConfigLoadResult = FlushConfigLoadSuccess | FlushConfigLoadFailure;
+
+/**
+ * Locate the cwd-local flush config file. `.jsonc` has precedence over `.json`.
+ * No ancestor walk is performed — only the exact cwd is checked.
+ *
+ * Hardened against unreadable / non-file paths: if a candidate path exists on
+ * disk but cannot be read (e.g. it is a directory, or lacks read permission),
+ * returns `{ path, content: undefined, readError }` instead of throwing. Callers
+ * decide how to surface that (typically as a fail-closed "invalid config").
+ */
+function locateFlushConfig(cwd: string): {
+  path: string | undefined;
+  content: string | undefined;
+  /** Set when a file exists on disk but could not be read. */
+  readError?: string;
+} {
+  const candidates = [
+    join(cwd, FLUSH_CONFIG_DIR, "flush-config.jsonc"),
+    join(cwd, FLUSH_CONFIG_DIR, "flush-config.json"),
+  ];
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) continue;
+    // existsSync is true for directories too; guard against non-files so a
+    // directory named flush-config.jsonc doesn't crash readFileSync.
+    try {
+      const stat = statSync(candidate);
+      if (!stat.isFile()) {
+        return { path: candidate, content: undefined, readError: "not a regular file" };
+      }
+    } catch (e) {
+      return { path: candidate, content: undefined, readError: errMsg(e) };
+    }
+    try {
+      return { path: candidate, content: readFileSync(candidate, "utf-8") };
+    } catch (e) {
+      return { path: candidate, content: undefined, readError: errMsg(e) };
+    }
+  }
+  return { path: undefined, content: undefined };
+}
+
+/** Best-effort error-message extraction for caught values. */
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+/**
+ * Path of the cwd-local flush config file if it exists on disk (`.jsonc`
+ * preferred over `.json`). Returns `null` when neither exists. No ancestor walk.
+ *
+ * Read-only diagnostic helper for `/hindsight config`. Hardened: never throws,
+ * even if the candidate path exists but is unreadable or a non-file.
+ */
+export function findFlushConfigFile(cwd: string): string | null {
+  try {
+    return locateFlushConfig(cwd).path ?? null;
+  } catch {
+    // Defensive: locateFlushConfig is already hardened, but guard the public
+    // entrypoint against any unexpected throw so /hindsight config never crashes.
+    return null;
+  }
+}
+
+/**
+ * Load and validate the cwd-local flush config.
+ *
+ * `.jsonc` is preferred over `.json` (no ancestor walk). The schema currently
+ * supports only `projectName` (non-empty string). Unknown keys produce warnings
+ * and are ignored. Malformed JSON, missing/invalid `projectName`, a non-object
+ * document, or an unreadable/non-file path all fail closed.
+ *
+ * Hardened: never throws — read/stat errors are surfaced as `ok:false` results.
+ */
+export function resolveFlushConfig(cwd: string): FlushConfigLoadResult {
+  let located: ReturnType<typeof locateFlushConfig>;
+  try {
+    located = locateFlushConfig(cwd);
+  } catch (e) {
+    // Defensive: locateFlushConfig is hardened, but guard the public entrypoint.
+    return { ok: false, error: `could not locate flush config: ${errMsg(e)}`, warnings: [] };
+  }
+  if (located.readError) {
+    return {
+      ok: false,
+      error: `could not read flush config ${located.path}: ${located.readError}`,
+      path: located.path,
+      warnings: [],
+    };
+  }
+  const { path, content } = located;
+  if (path === undefined || content === undefined) {
+    return { ok: false, error: "no cwd-local flush-config file found", warnings: [] };
+  }
+
+  const warnings: string[] = [];
+
+  const errors: ParseError[] = [];
+  const parsed = parseJsonc(content, errors, { allowTrailingComma: true });
+  if (errors.length > 0) {
+    const details = errors
+      .map((e) => {
+        const { line, character } = offsetToLineColumn(content, e.offset);
+        return `line ${line}, character ${character}: ${printParseErrorCode(e.error)}`;
+      })
+      .join("; ");
+    return {
+      ok: false,
+      error: `flush config is not valid JSON: ${details}`,
+      path,
+      warnings,
+    };
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    const kind = parsed === null ? "null" : Array.isArray(parsed) ? "array" : typeof parsed;
+    return {
+      ok: false,
+      error: `flush config must be a JSON object (got ${kind})`,
+      path,
+      warnings,
+    };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  for (const key of Object.keys(obj)) {
+    if (key !== "projectName") {
+      warnings.push(`unknown key "${key}" ignored (only "projectName" is supported)`);
+    }
+  }
+
+  if (typeof obj.projectName !== "string") {
+    const kind =
+      obj.projectName === undefined
+        ? "missing"
+        : Array.isArray(obj.projectName)
+          ? "array"
+          : typeof obj.projectName;
+    return {
+      ok: false,
+      error: `flush config requires "projectName" to be a string (got ${kind})`,
+      path,
+      warnings,
+    };
+  }
+
+  const trimmed = obj.projectName.trim();
+  if (trimmed.length === 0) {
+    return {
+      ok: false,
+      error: `flush config "projectName" must not be empty/whitespace`,
+      path,
+      warnings,
+    };
+  }
+
+  return { ok: true, config: { projectName: trimmed }, path, warnings };
+}
+
+/**
+ * Resolve the project name to use when flushing a session whose cwd is `cwd`.
+ *
+ * `usesProjectFlushConfig` is a tristate (`true` | `false` | `undefined`):
+ * - `false` (detached): ignore the flush config entirely; default derivation
+ *   (git → basename). A cwd that no longer exists is non-fatal here.
+ * - `true`: a valid cwd-local flush config is required (fail closed when the
+ *   cwd is gone, the file is missing, or the file is invalid). The config's
+ *   `projectName` is authoritative.
+ * - `undefined` (unmarked): if a flush-config file is present on disk, it
+ *   signals user intent — a valid one is used, an invalid one fails closed
+ *   (no silent fallback). With no file present, default derivation is used.
+ *
+ * Returns a discrete failure only when the session genuinely cannot produce a
+ * trustworthy project name for an upsert. Callers should leave pending work
+ * queued on failure and notify clearly.
+ */
+export function resolveProjectNameForFlush(
+  cwd: string,
+  usesProjectFlushConfig: boolean | undefined
+): ProjectNameResolution {
+  // Detached: explicit false ignores the flush config entirely.
+  if (usesProjectFlushConfig === false) {
+    return defaultProjectName(cwd);
+  }
+
+  // `true` requires the cwd to exist.
+  if (usesProjectFlushConfig === true && !existsSync(cwd)) {
+    return {
+      ok: false,
+      error: `session is marked as using project-local flush config, but its cwd "${cwd}" no longer exists`,
+    };
+  }
+
+  const loaded = resolveFlushConfig(cwd);
+  if (loaded.ok) {
+    // Valid config present → use it (works for both `true` and `undefined`).
+    return { ok: true, projectName: loaded.config.projectName, source: "flush-config" };
+  }
+
+  // Not ok.
+  if (loaded.path !== undefined) {
+    // A file exists on disk but is invalid/unreadable → fail closed (this also
+    // covers the unmarked case so an invalid config can never silently fall back
+    // to env/git/basename and allow ingestion under a wrong project name).
+    return {
+      ok: false,
+      error: `flush config ${loaded.path} is invalid: ${loaded.error}`,
+      configPath: loaded.path,
+    };
+  }
+
+  // No file present on disk.
+  if (usesProjectFlushConfig === true) {
+    return {
+      ok: false,
+      error:
+        "session is marked as using project-local flush config, but no cwd-local flush-config file is present",
+    };
+  }
+
+  // Unmarked, no file → default derivation.
+  return defaultProjectName(cwd);
+}
+
+/**
+ * Default project-name derivation for detached / unmarked-with-no-config sessions.
+ *
+ * git common dir (so worktrees share the main repo name) → basename. A cwd
+ * that no longer exists is non-fatal here (the git check simply does not apply
+ * and basename is used as a stable fallback).
+ */
+function defaultProjectName(cwd: string): ProjectNameResolution {
+  const derived = deriveDefaultProjectName(cwd);
+  return { ok: true, projectName: derived.name, source: derived.source };
+}
+
+/**
+ * Result of evaluating the *active* session's project-local flush-config state.
+ *
+ * This drives the per-active-session readiness latch (`activeSessionFlushReady`
+ * in `runtime-state.ts`) at `session_start` time. It must agree with
+ * {@link resolveProjectNameForFlush}'s ok/fail semantics so the latch (which
+ * gates the retain tool + auto-retain) matches what a flush would actually do.
+ */
+export interface ActiveFlushState {
+  ready: boolean;
+  reason?: string;
+  /** Path of an invalid/unreadable config file found on disk, for diagnostics. */
+  configPath?: string;
+  /**
+   * True when the active session is unmarked (`usesProjectFlushConfig ===
+   * undefined`) AND a valid cwd-local flush config is present. `session_start`
+   * uses this to append `usesProjectFlushConfig: true` (latest-wins auto-mark).
+   * Not set (false) when already marked `true`, detached, or in any failing state.
+   */
+  autoMark?: boolean;
+}
+
+/**
+ * Evaluate the active session's project-local flush-config state for the
+ * `session_start` readiness gate.
+ *
+ * Rules (mirror {@link resolveProjectNameForFlush}'s tristate semantics):
+ * - `usesProjectFlushConfig === false` (detached) → always `ready:true` (the
+ *   cwd-local flush config is ignored; detach wins). No `autoMark`.
+ * - `usesProjectFlushConfig === true` (required) → ready only if the cwd
+ *   exists AND a valid flush config is present. Otherwise `ready:false`.
+ * - `usesProjectFlushConfig === undefined` (unmarked):
+ *     - valid file present → `ready:true`, `autoMark:true`.
+ *     - invalid/unreadable file present → `ready:false` (never silently fall
+ *       back to default derivation; an invalid config is an error).
+ *     - no file present → `ready:true` (default derivation applies).
+ *
+ * `existingMeta` is the latest `hindsight-meta` (or null); only its
+ * `usesProjectFlushConfig` field is consulted.
+ */
+export function evaluateActiveSessionFlushState(
+  cwd: string | undefined,
+  existingMeta: { usesProjectFlushConfig?: boolean } | null
+): ActiveFlushState {
+  const flag = existingMeta?.usesProjectFlushConfig;
+
+  // Detached wins.
+  if (flag === false) {
+    return { ready: true };
+  }
+
+  // Required (true) needs the cwd to exist.
+  if (flag === true && (!cwd || !existsSync(cwd))) {
+    return {
+      ready: false,
+      reason: `session is marked as using project-local flush config, but its cwd "${cwd}" does not exist`,
+    };
+  }
+
+  if (!cwd) {
+    // Unmarked with no cwd → default derivation (non-fatal).
+    return { ready: true };
+  }
+
+  const loaded = resolveFlushConfig(cwd);
+  if (loaded.ok) {
+    // Valid config present. Auto-mark only when unmarked (undefined); when
+    // already `true`, no auto-mark is needed.
+    return flag !== true ? { ready: true, autoMark: true } : { ready: true };
+  }
+
+  if (loaded.path !== undefined) {
+    // File exists on disk but is invalid/unreadable → fail closed (this covers
+    // both `true` and unmarked — matching resolveProjectNameForFlush exactly).
+    return {
+      ready: false,
+      reason: `flush config ${loaded.path} is invalid: ${loaded.error}`,
+      configPath: loaded.path,
+    };
+  }
+
+  // No file present on disk.
+  if (flag === true) {
+    return {
+      ready: false,
+      reason:
+        "session is marked as using project-local flush config, but no cwd-local flush-config file is present",
+    };
+  }
+
+  // Unmarked, no file → default derivation.
+  return { ready: true };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,13 +22,22 @@ import {
 import { prefixLog, STATUS_ID } from "./constants";
 import { getDataDir } from "./data-dir";
 import { getLegacyDataDir, migrateDataDir } from "./data-dir-migration";
+import { evaluateActiveSessionFlushState } from "./flush-config";
 import { getHindsightMeta, shouldSessionBeRetained, updateSessionMetadata } from "./meta";
 import { shouldRetainMessage } from "./prepare";
 import { touchPendingFlag } from "./queue";
 import { flushCurrentSession } from "./retention";
-import { isStartupReady, markStartupReady, resetStartupReady } from "./runtime-state";
-import { isToolEnabled, registerTools, updateRetainToolVisibility } from "./tools";
-import { extractParentSessionId, getProjectName, truncate } from "./utils";
+import {
+  clearStartupReady,
+  isOperationalReady,
+  markStartupReady,
+  resetActiveSessionFlushReady,
+  resetRegisteredHindsightTools,
+  resetStartupReady,
+  setActiveSessionFlushReady,
+} from "./runtime-state";
+import { refreshToolVisibility, registerTools } from "./tools";
+import { clearProjectNameCache, extractParentSessionId, getProjectName, truncate } from "./utils";
 import { getHindsightCompatibilityError } from "./version";
 
 // Runtime toggle for recall display (overrides config)
@@ -66,6 +75,9 @@ export function _resetState(): void {
   toolsRegistered = false;
   startupReadyPromise = null;
   resetStartupReady();
+  resetActiveSessionFlushReady();
+  resetRegisteredHindsightTools();
+  clearProjectNameCache();
   resetNotReadyWarned();
 }
 
@@ -253,32 +265,29 @@ export default function (pi: ExtensionAPI) {
   }
 
   /**
-   * Establish health/version readiness with single-flight.
+   * Probe server health + version and update the readiness latch. Single-flight
+   * so overlapping `session_start` callers share one probe pass.
    *
-   * If readiness is already latched, returns true without probing. Otherwise,
-   * overlapping callers share one probe; a successful probe flips startupReady
-   * one-way. Failures leave readiness false and can be retried later.
+   * Readiness is re-enterable: there is no fast-path skip when already latched.
+   * Every call probes and updates the latch (`true` on success, `false` on
+   * failure via {@link clearStartupReady}) so that a later `session_start`
+   * observing an unreachable/incompatible server re-enters the unified degraded
+   * mode (all tools hidden, auto-recall/retain/flush skipped, operational
+   * commands blocked). A subsequent healthy probe restores readiness.
    *
-   * This helper must not perform session setup. session_start owns metadata,
-   * tool registration, retain visibility, and startup flushes.
+   * This helper must not perform session setup (metadata, tools, visibility,
+   * startup flush) — that stays in `session_start`.
    */
   function ensureStartupReady(ctx: ExtensionContext): Promise<boolean> {
-    // Fast path: already latched — no probe, no shared work.
-    if (isStartupReady()) return Promise.resolve(true);
-    // Single-flight: a concurrent caller (session_start + before_agent_start
-    // overlap, or two before_agent_start events) joins the in-flight probe.
+    // Single-flight: a concurrent session_start joins the in-flight probe.
     if (startupReadyPromise) return startupReadyPromise;
 
     startupReadyPromise = (async () => {
       try {
-        if (!(await probeStartupHealth(client, ctx))) return false;
-        // One-way latch: only ever flips false → true. After one successful
-        // config + connection pass, later health failures are treated as likely
-        // transient: report them via status, but don't tear down process-global
-        // handlers/tools or disturb per-session tool visibility. Health/version
-        // is the gating concern; session init stays in `session_start`.
-        markStartupReady();
-        return true;
+        const healthy = await probeStartupHealth(client, ctx);
+        if (healthy) markStartupReady();
+        else clearStartupReady();
+        return healthy;
       } finally {
         // Clear so a failed attempt can be retried, and so a post-latch caller
         // never observes a stale resolved promise.
@@ -289,34 +298,104 @@ export default function (pi: ExtensionAPI) {
   }
 
   pi.on("session_start", async (event, ctx) => {
-    // session_start owns per-session setup. Health/version readiness is checked
-    // first; when unavailable, skip side effects. Once ready, setup still runs
-    // on every session_start so new/resumed sessions get their own metadata and
-    // retain-tool visibility even after global readiness was latched earlier.
-    const wasReady = isStartupReady();
-    if (!(await ensureStartupReady(ctx))) return;
+    // session_start owns per-session setup. Health/version readiness is probed
+    // every time (re-enterable): a failed probe re-enters the unified degraded
+    // mode (startupReady=false → isOperationalReady=false → all tools hidden,
+    // auto-recall/retain/flush skipped, operational commands blocked); a healthy
+    // probe restores readiness. setup then runs on every session_start so
+    // new/resumed sessions get their own metadata and tool visibility.
+    const probeHealthy = await ensureStartupReady(ctx);
+    if (!probeHealthy) {
+      // Server unreachable/incompatible → unified degraded mode. Status was
+      // already set unhealthy by probeStartupHealth. If tools were already
+      // registered (e.g. from a prior healthy session_start), hide ALL of them
+      // now that we've re-entered degraded mode (isOperationalReady() is false).
+      // On a first-ever failed start, no tools are registered yet — tools
+      // register lazily only on a healthy session_start, so there is nothing to
+      // hide and no setActiveTools call. activeSessionFlushReady is left as-is;
+      // the server failure is the degraded cause for this session.
+      if (toolsRegistered) {
+        refreshToolVisibility(pi, false);
+      }
+      return;
+    }
 
-    // If readiness was already latched, probe again to refresh status. A later
-    // health/version failure is reported as unhealthy, but treated as transient:
-    // do not undo readiness, tear down tools, or skip this session's
-    // metadata/visibility work. Do skip startup auto-flush below because it is
-    // automatic network work and this handler just observed an unhealthy server.
-    const currentProbeHealthy = wasReady ? await probeStartupHealth(client, ctx) : true;
+    // Validate the active session's project-local flush-config state BEFORE
+    // enabling operational behavior (retain tool visibility, auto-mark metadata,
+    // startup flush). An invalid/required-but-missing cwd-local flush config
+    // hard-fails the ACTIVE session through this degraded pathway: unhealthy
+    // status, retain tool hidden, auto-retain skipped (see message_end), and no
+    // startup flush. Diagnostic commands (/hindsight status, /hindsight
+    // config) and the recovery command (/hindsight detach-flush-config, which
+    // is NOT in OPERATIONAL_SUBCOMMANDS) remain available. The flush path
+    // (parseAndUpsertSession) re-validates freshly so flush-pending still
+    // handles other sessions and catches files that disappeared later.
+    const entries = ctx.sessionManager.getEntries();
+    const existingMeta = getHindsightMeta(entries);
+    const sessionHeader = ctx.sessionManager.getHeader();
+    const sessionCwd = sessionHeader?.cwd ?? ctx.cwd;
+    const flushState = evaluateActiveSessionFlushState(sessionCwd, existingMeta);
+
+    if (!flushState.ready) {
+      // Active session is in failed project-local flush-config state → single
+      // degraded mode: unhealthy status, ALL Hindsight tools hidden (not just
+      // retain), no auto-retain (message_end), no startup flush. Diagnostic
+      // commands (/hindsight status, /hindsight config, /hindsight toggle-display,
+      // /hindsight popup) and the recovery command (/hindsight detach-flush-config,
+      // which is NOT in OPERATIONAL_SUBCOMMANDS) remain available. The flush path
+      // (parseAndUpsertSession) re-validates freshly per target session so
+      // flush-pending still handles other sessions and catches files that
+      // disappeared later.
+      setActiveSessionFlushReady(false);
+      ctx.ui.setStatus(STATUS_ID, config.statusUnhealthy);
+      ctx.ui.notify(
+        `Hindsight active session unavailable: ${flushState.reason}. ` +
+          `All Hindsight tools are hidden and retention is disabled for this session. ` +
+          `Run \`/hindsight detach-flush-config\` to stop requiring the project-local ` +
+          `flush config, or fix ${sessionCwd ?? "<cwd>"}/.pi/epimetheus/flush-config.jsonc.`,
+        "warning"
+      );
+      // Register hindsight tools once (process-global) so they can be
+      // re-shown when the session recovers; then hide ALL of them via the
+      // unified visibility refresh (isOperationalReady() is false here, so
+      // refreshToolVisibility hides every registered hindsight_* tool).
+      if (!toolsRegistered) {
+        registerTools(pi, config, client);
+        toolsRegistered = true;
+      }
+      refreshToolVisibility(pi, false);
+      return;
+    }
+
+    // Active session flush-config OK. Mirror this in the per-session latch so
+    // message_end auto-retain and the retain tool visibility reflect the now-
+    // healthy session (a prior failed session may have left it false).
+    setActiveSessionFlushReady(true);
 
     // Auto-create session metadata if none exists, using retainSessionsByDefault
     // as the default retained state. This ensures every session has explicit
     // metadata, so toggle-retain and other commands work predictably.
-    const entries = ctx.sessionManager.getEntries();
-    const existingMeta = getHindsightMeta(entries);
+    //
+    // If a valid cwd-local flush config exists for an unmarked session,
+    // auto-mark usesProjectFlushConfig:true so future flushes require it
+    // (latest value wins, so an explicit false from /hindsight
+    // detach-flush-config survives — auto-mark only fires when the flag is
+    // still undefined).
     if (!existingMeta) {
       const sessionId = ctx.sessionManager.getSessionId();
-      await updateSessionMetadata(
-        pi,
-        sessionId,
-        entries,
-        { retained: config.retainSessionsByDefault },
-        config
-      );
+      const updates: Partial<{ retained: boolean; usesProjectFlushConfig: boolean }> = {
+        retained: config.retainSessionsByDefault,
+      };
+      if (flushState.autoMark) updates.usesProjectFlushConfig = true;
+      await updateSessionMetadata(pi, sessionId, entries, updates, config);
+    } else if (existingMeta.usesProjectFlushConfig === undefined && flushState.autoMark) {
+      // Legacy session without an explicit usesProjectFlushConfig flag. Auto-mark
+      // true without touching pending (the flag affects future flushes; the
+      // user can re-flush manually if they want retroactive tag correction).
+      // Explicit user detach (usesProjectFlushConfig:false) is preserved because
+      // latest-wins only re-marks when the flag is still undefined.
+      const sessionId = ctx.sessionManager.getSessionId();
+      await updateSessionMetadata(pi, sessionId, entries, { usesProjectFlushConfig: true }, config);
     }
 
     // Register hindsight tools once (process-global). Late registration
@@ -328,24 +407,16 @@ export default function (pi: ExtensionAPI) {
       registerTools(pi, config, client);
       toolsRegistered = true;
     }
-    // Update hindsight_retain tool visibility based on the current session's
-    // retention state. When not retained, the tool is hidden from the LLM
-    // entirely (instead of being available but failing on execution).
-    if (isToolEnabled(config, "retain")) {
-      const isRetained = shouldSessionBeRetained(entries, config);
-      updateRetainToolVisibility(pi, isRetained);
-    }
+    // Refresh tool visibility for the unified operational state + this
+    // session's retention flag. Operational here (startupReady latched and the
+    // active-session flush config just validated OK), so all registered tools
+    // are shown except hindsight_retain when the session is not retained.
+    refreshToolVisibility(pi, shouldSessionBeRetained(entries, config));
 
     // On startup, optionally flush pending work across all sessions. This is
     // reason-gated to `session_start` only — it is a best-effort cleanup of old
-    // pending sessions, not a readiness prerequisite, so `before_agent_start`'s
-    // recovery path must NOT trigger it (avoids surprising first-prompt flushes).
-    if (
-      currentProbeHealthy &&
-      event.reason === "startup" &&
-      config.autoFlushPendingOn.includes("startup") &&
-      client
-    ) {
+    // pending sessions, not a readiness prerequisite.
+    if (event.reason === "startup" && config.autoFlushPendingOn.includes("startup") && client) {
       await flushAllPending(config, client, ctx, { notifyNoWork: false, autoFlush: true });
     }
   });
@@ -366,7 +437,7 @@ export default function (pi: ExtensionAPI) {
     (value) => {
       autoRecallDisplayOverride = value;
     },
-    isStartupReady,
+    isOperationalReady,
     {
       configPath,
       envVars,
@@ -391,14 +462,16 @@ export default function (pi: ExtensionAPI) {
   pi.on("before_agent_start", async (event, ctx: ExtensionContext) => {
     if (!client || !config.autoRecallEnabled) return;
 
-    // before_agent_start can be the first lifecycle point with the user's
-    // prompt. If session_start has not latched readiness yet, check
-    // health/version on demand so first-turn recall can proceed when the server
-    // is healthy. This does not initialize the session; that remains
-    // session_start's responsibility. The extra readiness read is defensive: if
-    // another lifecycle path latched readiness while this await resolved false,
-    // don't skip an otherwise-safe first-turn recall.
-    if (!(await ensureStartupReady(ctx)) && !isStartupReady()) return;
+    // session_start is awaited before the first prompt in current Pi (interactive,
+    // print, and RPC), so by the time before_agent_start fires, startup readiness
+    // and the active session's flush-config state have already been evaluated.
+    // Only check the unified operational state here and return if degraded —
+    // never probe or mutate readiness from before_agent_start (that risks
+    // surprising first-prompt side effects and is session_start's job). If the
+    // session is degraded (server unreachable/incompatible, or required-but-
+    // missing/invalid cwd-local flush config), auto-recall is skipped for this
+    // turn; the first turn after recovery will recall.
+    if (!isOperationalReady()) return;
 
     // Use event.prompt directly — available before the user message is
     // persisted to the session (fixes first-message recall).
@@ -497,7 +570,7 @@ export default function (pi: ExtensionAPI) {
 
   // Mark sessions as dirty on message_end event
   pi.on("message_end", async (event, ctx: ExtensionContext) => {
-    if (!config.autoRetainEnabled || !isStartupReady()) return;
+    if (!config.autoRetainEnabled || !isOperationalReady()) return;
 
     const sessionId = ctx.sessionManager.getSessionId();
     if (!sessionId) {
@@ -525,7 +598,7 @@ export default function (pi: ExtensionAPI) {
 
   /** Auto-flush: suppresses transient block notifications unless debug mode is on. */
   const autoFlush = async (ctx: ExtensionContext): Promise<void> => {
-    if (!client || !isStartupReady()) return;
+    if (!client || !isOperationalReady()) return;
     const sessionId = ctx.sessionManager.getSessionId();
     const sessionPath = ctx.sessionManager.getSessionFile();
     if (!sessionId || !sessionPath) return;
@@ -661,7 +734,7 @@ export default function (pi: ExtensionAPI) {
   // semantics: success, no-work, and block/not-retained warnings are suppressed
   // unless `debug: true` (compaction is not a final-chance event like `/quit`).
   pi.on("session_compact", async (_event, ctx: ExtensionContext) => {
-    if (!config.autoFlushSessionOn.includes("compact") || !client || !isStartupReady()) return;
+    if (!config.autoFlushSessionOn.includes("compact") || !client || !isOperationalReady()) return;
     const sessionId = ctx.sessionManager.getSessionId();
     const sessionPath = ctx.sessionManager.getSessionFile();
     if (!sessionId || !sessionPath) return;
@@ -688,7 +761,7 @@ export default function (pi: ExtensionAPI) {
   //     skipped to avoid duplicate work (see config validation warning).
   pi.on("session_shutdown", async (event, ctx: ExtensionContext) => {
     if (event.reason === "new" || event.reason === "resume" || event.reason === "fork") return;
-    if (!client || !isStartupReady()) return;
+    if (!client || !isOperationalReady()) return;
     if (event.reason === "reload") {
       if (!config.autoFlushSessionOn.includes("reload")) return;
       const sessionId = ctx.sessionManager.getSessionId();

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -131,6 +131,15 @@ export interface HindsightMeta {
   tags?: string[];
   /** Extra context appended to the Hindsight context field (after session name). */
   extraContext?: string;
+  /**
+   * When true, flushes for this session require a valid cwd-local flush config
+   * (`<cwd>/.pi/epimetheus/flush-config.jsonc|.json`) and use its `projectName`.
+   * Append-only: each new hindsight-meta entry carries forward the prior value
+   * unless explicitly overridden. Latest metadata value wins. The flush config
+   * path and the resolved project name are deliberately NOT stored here — see
+   * `src/flush-config.ts` for resolution details.
+   */
+  usesProjectFlushConfig?: boolean;
 }
 
 /**
@@ -178,6 +187,14 @@ export function buildMetaUpdate(
     updates.extraContext !== undefined ? updates.extraContext : existing?.extraContext;
   if (extraContext !== undefined) {
     meta.extraContext = extraContext;
+  }
+
+  const usesProjectFlushConfig =
+    updates.usesProjectFlushConfig !== undefined
+      ? updates.usesProjectFlushConfig
+      : existing?.usesProjectFlushConfig;
+  if (usesProjectFlushConfig !== undefined) {
+    meta.usesProjectFlushConfig = usesProjectFlushConfig;
   }
 
   return meta;

--- a/src/retention.ts
+++ b/src/retention.ts
@@ -21,6 +21,7 @@ import {
   type SessionEntry,
   type SessionHeader,
 } from "./document";
+import { resolveProjectNameForFlush } from "./flush-config";
 import {
   buildMetaFile,
   FLUSH_BLOCKED_NO_EXTRA_CONTEXT,
@@ -62,16 +63,24 @@ export async function queueToolRetain(
   sessionCwd: string,
   parentSessionId: string | undefined,
   config: Pick<HindsightConfig, "constantTags" | "observationScopes">,
-  sessionUserTags: string[]
+  sessionUserTags: string[],
+  /**
+   * Pre-resolved project name to bake into tags and observation-scope
+   * placeholders. Callers with flush-config awareness (see
+   * `resolveProjectNameForFlush`) should pass this so tool retains and session
+   * flushes share the same `project:` tag. When omitted, falls back to
+   * `getProjectName(sessionCwd)` (git common dir or cwd basename).
+   */
+  projectName?: string
 ): Promise<QueueResult> {
-  const projectName = getProjectName(sessionCwd);
+  const resolvedProjectName = projectName ?? getProjectName(sessionCwd);
   // Build complete tags at queue time
   const tags = [
     ...config.constantTags,
     `session:${sessionId}`,
     `cwd:${sessionCwd}`,
     `basedir:${getBasedir(sessionCwd)}`,
-    `project:${projectName}`,
+    `project:${resolvedProjectName}`,
     `store_method:tool`,
     `parent:${parentSessionId ?? sessionId}`,
     ...(toolTags ?? []),
@@ -84,7 +93,7 @@ export async function queueToolRetain(
     sessionId,
     parentSessionId,
     sessionCwd,
-    projectName
+    resolvedProjectName
   );
 
   const entry: ToolQueueEntry = {
@@ -296,14 +305,21 @@ export async function upsertToHindsight(
   client: HindsightClientWrapper,
   params: UpsertParams,
   config: HindsightConfig,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  /**
+   * Pre-resolved project name for `{project}` observation-scope placeholder
+   * expansion. Callers with flush-config awareness should pass this so the
+   * scopes match the document tags. When omitted, falls back to
+   * `getProjectName(params.sessionCwd)` (git common dir or cwd basename).
+   */
+  projectName?: string
 ): Promise<void> {
   const expandedScopes = expandSessionObservationScopes(
     config,
     params.sessionId,
     params.parentSessionId,
     params.sessionCwd,
-    getProjectName(params.sessionCwd)
+    projectName ?? getProjectName(params.sessionCwd)
   );
 
   const result = await client.retain(
@@ -446,7 +462,12 @@ function resolveSessionFlushMetadata(
   header: SessionHeader,
   entries: SessionEntry[],
   hindsightMeta: HindsightMeta | null,
-  config: HindsightConfig
+  config: HindsightConfig,
+  /**
+   * Pre-resolved project name (flush-config-aware) for the `project:` tag.
+   * When omitted, `buildDocumentTags` falls back to `getProjectName(header.cwd)`.
+   */
+  projectName?: string
 ): {
   parentSessionId: string | undefined;
   sessionCwd: string;
@@ -461,6 +482,7 @@ function resolveSessionFlushMetadata(
   const tags = buildDocumentTags(header, config, {
     sessionUserTags: base.sessionUserTags,
     parentSessionId: base.parentSessionId,
+    projectName,
   });
   return {
     ...base,
@@ -676,8 +698,41 @@ export async function parseAndUpsertSession(
       return;
     }
 
+    // Resolve the project name flush-config-aware, so document tags and
+    // observation-scope placeholders match across the upsert. If the session
+    // is marked as using project-local flush config and that resolution fails
+    // (cwd gone, or config missing/invalid), fail closed: leave pending work
+    // queued (restoreClaim) and notify. Auto-flush notifications are suppressed
+    // like other transient block warnings unless debug or surfaceBlocks.
+    //
+    // This re-validates FRESH (independent of the active-session latch in
+    // runtime-state) so flush-pending handles non-active sessions and catches
+    // config files that disappeared or became invalid after session_start.
+    const projectNameResult = resolveProjectNameForFlush(
+      header.cwd,
+      hindsightMeta?.usesProjectFlushConfig
+    );
+    if (!projectNameResult.ok) {
+      if (claim) restoreClaim(claim);
+      if (!options?.autoFlush || debug || options?.surfaceBlocks) {
+        ctx.ui.notify(
+          `Flush blocked for session ${sessionId}: ${projectNameResult.error}. Pending work remains queued. ` +
+            `Restore the cwd-local flush config or run \`/hindsight detach-flush-config\`.`,
+          "warning"
+        );
+      }
+      return;
+    }
+    const resolvedProjectName = projectNameResult.projectName;
+
     // Resolve metadata from parsed session data (session file is authority, not live state)
-    const resolved = resolveSessionFlushMetadata(header, entries, hindsightMeta, config);
+    const resolved = resolveSessionFlushMetadata(
+      header,
+      entries,
+      hindsightMeta,
+      config,
+      resolvedProjectName
+    );
 
     // Serialize messages
     const formattedStrs = messages.map((m) => JSON.stringify(m));
@@ -708,7 +763,7 @@ export async function parseAndUpsertSession(
     );
 
     // Network call
-    await upsertToHindsight(client, upsertParams, config, signal);
+    await upsertToHindsight(client, upsertParams, config, signal, resolvedProjectName);
 
     // Finalize: write parsed artifacts and complete the claim. If the claim dir
     // disappeared during the network call, queue state was concurrently cleared;

--- a/src/runtime-state.ts
+++ b/src/runtime-state.ts
@@ -2,48 +2,147 @@
  * Tiny runtime-state module shared across event handlers, tools, and slash
  * commands without threading callbacks through every subcommand creator.
  *
- * Currently holds only {@link startupReady}; the recall-display override / last
- * recall details remain in index.ts (they need index-local getters/setters that
- * tests already mock). Keeping this module minimal avoids a larger refactor.
+ * Holds two independent latches plus a unified getter:
  *
- * `startupReady` is a **latch**: it starts `false` and flips to `true` after
- * the first successful health check + version compatibility check. That probe
- * is normally triggered by `session_start`, but first-turn auto-recall can also
- * trigger it from `before_agent_start` when that event races ahead of startup
- * readiness. It is never flipped back to `false` by later failures; a later
- * health failure still sets the status-bar indicator unhealthy, but does not
- * re-disable operational handlers or re-hide tools.
+ * - `startupReady`: process-global health/version latch reflecting the most
+ *   recent probe. Starts `false`, set `true` after a healthy probe and `false`
+ *   again when a later `session_start` probe observes an unreachable/
+ *   incompatible server — so the extension re-enters the unified degraded mode
+ *   on later server failures (it is NOT a one-way latch). status HEALTHY
+ *   is independent: a failed probe sets the status-bar unhealthy regardless of
+ *   prior readiness.
  *
- * Before the first successful readiness probe, operational handlers
- * (auto-retain, auto-recall, auto-flush) and operational subcommands gate on
- * this so no operational side effects occur while startup hasn't succeeded.
- * Hindsight tools are related but separate: they are registered lazily by the
- * first healthy `session_start` (not by `before_agent_start` and not at
- * extension init), so session-specific setup remains owned by the session
- * lifecycle. The recall filter and renderer are always active regardless of
- * readiness.
+ * - `activeSessionFlushReady`: per-active-session project-local flush-config
+ *   latch. Re-evaluated by every `session_start` (after the health/version
+ *   probe succeeds). `true` means the current session can safely retain under
+ *   a resolved project name (config is valid, detached, or unmarked with a
+ *   derivable default). `false` means the active session's cwd-local flush
+ *   config is required-but-missing/invalid, or present-but-invalid for an
+ *   unmarked session. Unlike `startupReady`, this CAN flip back to `true`
+ *   (e.g. after `/hindsight detach-flush-config`, or a later `session_start` in
+ *   a fixed cwd).
  *
- * index.ts's `_resetState()` is the single reset entrypoint and calls
- * {@link resetStartupReady}(); tests already invoke `_resetState()`.
+ * - `isOperationalReady()`: the unified operational-ready getter
+ *   (`startupReady && activeSessionFlushReady`). Any single failed cause
+ *   (unreachable/incompatible server, or required-but-missing/invalid cwd-local
+ *   flush config) puts the extension into the single degraded mode: unhealthy
+ *   status, ALL Hindsight tools hidden, no auto-recall/retain/flush, no queue
+ *   writes/network, and operational slash commands blocked. The flush path
+ *   (`parseAndUpsertSession`) re-validates freshly via `resolveProjectNameForFlush`
+ *   and is NOT gated by this latch — it handles non-active sessions in
+ *   `flush-pending` and catches files that disappeared or became invalid after
+ *   `session_start`.
+ *
+ * Also tracks `registeredHindsightTools` (set by `registerTools`) so the unified
+ * `refreshToolVisibility` knows which tool names to show when leaving degraded
+ * mode and which to hide when entering it.
+ *
+ * Hindsight tools are process-global and registered lazily by the first healthy
+ * `session_start` (not by `before_agent_start` and not at extension init), so
+ * session-specific setup remains owned by the session lifecycle. `before_agent_start`
+ * only READS `isOperationalReady()` and returns if degraded — it never probes or
+ * mutates readiness (session_start is awaited before the first prompt). The
+ * recall filter and renderer are always active regardless of readiness.
+ *
+ * index.ts's `_resetState()` is the single reset entrypoint and calls all the
+ * resets here; tests already invoke `_resetState()`.
  */
 
 let startupReady = false;
 
-/** Whether at least one health + version readiness probe has succeeded. */
+/** Whether the most recent health + version readiness probe succeeded. */
 export function isStartupReady(): boolean {
   return startupReady;
 }
 
 /**
- * Mark startup as ready (true). This is a one-way latch: callers only ever set
- * it to true after a successful health + version readiness check. To
- * reset (tests / module reset), use {@link resetStartupReady}.
+ * Mark startup as ready (true). Called after a successful health + version
+ * probe. Readiness is re-enterable: {@link clearStartupReady} flips it back to
+ * false when a later `session_start` probe observes an unreachable/
+ * incompatible server, so the extension re-enters the unified degraded mode.
  */
 export function markStartupReady(): void {
   startupReady = true;
 }
 
+/** Flip startup readiness back to false (a later probe failed). */
+export function clearStartupReady(): void {
+  startupReady = false;
+}
+
 /** Reset the startup-ready latch to false. Exported for testing/reset only. */
 export function resetStartupReady(): void {
   startupReady = false;
+}
+
+/**
+ * Per-active-session project-local flush-config readiness.
+ *
+ * Defaults to `true` (assume OK) so the pre-`session_start` window is not
+ * spuriously blocked — `startupReady` (false until the first healthy probe)
+ * gates that window. `session_start` re-evaluates and sets this on every
+ * session after the health/version probe. `/hindsight detach-flush-config`
+ * also sets it back to `true` (detached wins) so the retain tool is
+ * immediately re-enabled.
+ */
+let activeSessionFlushReady = true;
+
+/** Whether the active session's project-local flush config is usable for retention. */
+export function isActiveSessionFlushReady(): boolean {
+  return activeSessionFlushReady;
+}
+
+/**
+ * Set the active-session flush-config readiness. Unlike `markStartupReady`,
+ * this is NOT a one-way latch — callers may set it false (failed session_start)
+ * and back to true (detach / fixed cwd on a later session_start).
+ */
+export function setActiveSessionFlushReady(ready: boolean): void {
+  activeSessionFlushReady = ready;
+}
+
+/** Reset the active-session flush-config latch to true. Exported for testing/reset only. */
+export function resetActiveSessionFlushReady(): void {
+  activeSessionFlushReady = true;
+}
+
+/**
+ * Unified operational-ready getter for the normal (enabled, valid-config)
+ * path. The extension is operational only when BOTH the process-global
+ * health/version probe has succeeded AND the active session's project-local
+ * flush config is usable. Any single failed cause (unreachable/incompatible
+ * server, or required-but-missing/invalid cwd-local flush config) puts the
+ * extension into the single degraded mode (status unhealthy, no Hindsight
+ * tools active, no auto-recall/retain/flush, operational subcommands
+ * blocked). See `index.ts`'s session_start handler for the per-session
+ * evaluation.
+ *
+ * The fail-fast path (invalid global config) is separate — it never creates
+ * a client and registers commands with a constant `() => false` readiness.
+ */
+export function isOperationalReady(): boolean {
+  return isStartupReady() && activeSessionFlushReady;
+}
+
+/**
+ * The set of Hindsight tools that have been registered (process-global, via
+ * `registerTools`). Used by `refreshToolVisibility` to know which tools to
+ * re-show after leaving degraded mode, and to hide all of them when entering
+ * it. Set by `tools.ts`'s `registerTools`; reset by `index.ts`'s `_resetState()`.
+ */
+let registeredHindsightTools: string[] = [];
+
+/** Recorded registered Hindsight tool names (set by `registerTools`). */
+export function getRegisteredHindsightTools(): string[] {
+  return registeredHindsightTools;
+}
+
+/** Record the registered Hindsight tool names. Called by `registerTools`. */
+export function setRegisteredHindsightTools(names: string[]): void {
+  registeredHindsightTools = names;
+}
+
+/** Reset the registered-tools record. Exported for testing/reset only. */
+export function resetRegisteredHindsightTools(): void {
+  registeredHindsightTools = [];
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -8,8 +8,14 @@ import type { Budget, RecallResponse, ReflectResponse } from "@vectorize-io/hind
 import { type Static, Type } from "typebox";
 import type { HindsightClientWrapper } from "./client";
 import type { HindsightConfig, MemoryType, ToolName } from "./config";
+import { resolveProjectNameForFlush } from "./flush-config";
 import { getHindsightMeta, shouldSessionBeRetained, updateSessionMetadata } from "./meta";
 import { queueToolRetain } from "./retention";
+import {
+  getRegisteredHindsightTools,
+  isOperationalReady,
+  setRegisteredHindsightTools,
+} from "./runtime-state";
 import { extractParentSessionId } from "./utils";
 
 // Reusable schemas
@@ -96,12 +102,10 @@ export function registerTools(
   pi: ExtensionAPI,
   config: HindsightConfig,
   client: HindsightClientWrapper | null
-): void {
-  // Register hindsight_set_extra_context when enabled.
-  // Gated by toolsEnabled like all other tools. Can be included in the array
-  // as "set_extra_context". The /hindsight set-extra-context slash command still
-  // works regardless of this setting.
+): string[] {
+  const registered: string[] = [];
   if (isToolEnabled(config, "set_extra_context")) {
+    registered.push("hindsight_set_extra_context");
     pi.registerTool({
       name: "hindsight_set_extra_context",
       label: "Hindsight Extra Context",
@@ -157,6 +161,7 @@ export function registerTools(
   }
 
   if (isToolEnabled(config, "get_extra_context")) {
+    registered.push("hindsight_get_extra_context");
     pi.registerTool({
       name: "hindsight_get_extra_context",
       label: "Hindsight Get Extra Context",
@@ -206,6 +211,7 @@ export function registerTools(
 
   // Register hindsight_retain if enabled
   if (isToolEnabled(config, "retain")) {
+    registered.push("hindsight_retain");
     // hindsight_retain - always available, just queues to disk
     pi.registerTool({
       name: "hindsight_retain",
@@ -277,15 +283,40 @@ export function registerTools(
         const meta = getHindsightMeta(entries);
         const sessionUserTags = meta?.tags ?? [];
 
+        // Resolve the project name flush-config-aware so tool retains share the
+        // same `project:` tag as session flushes. The session's recorded cwd
+        // (header.cwd) is authoritative — matches what the upsert path uses.
+        // If the session is marked as using project-local flush config and the
+        // resolution fails (cwd gone, or config missing/invalid), fail closed:
+        // do not queue — the memory would otherwise be tagged with the wrong
+        // project name
+        const retainCwd = header?.cwd ?? ctx.cwd;
+        const projectNameResult = resolveProjectNameForFlush(
+          retainCwd,
+          meta?.usesProjectFlushConfig
+        );
+        if (!projectNameResult.ok) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Failed to store memory: ${projectNameResult.error}. Use /hindsight detach-flush-config to stop requiring the project-local flush config, or restore the config at ${retainCwd}/.pi/epimetheus/.`,
+              },
+            ],
+            details: { success: false, error: projectNameResult.error },
+          };
+        }
+
         const result = await queueToolRetain(
           sessionId,
           params.content,
           params.tags,
           params.metadata,
-          ctx.cwd,
+          retainCwd,
           parentSessionId,
           config,
-          sessionUserTags
+          sessionUserTags,
+          projectNameResult.projectName
         );
         if (!result.success) {
           return {
@@ -303,10 +334,11 @@ export function registerTools(
   }
 
   // recall and reflect require client
-  if (!client) return;
+  if (!client) return registered;
 
   // Register hindsight_recall if enabled
   if (isToolEnabled(config, "recall")) {
+    registered.push("hindsight_recall");
     pi.registerTool({
       name: "hindsight_recall",
       label: "Hindsight Recall",
@@ -383,6 +415,7 @@ export function registerTools(
 
   // Register hindsight_reflect if enabled
   if (isToolEnabled(config, "reflect")) {
+    registered.push("hindsight_reflect");
     pi.registerTool({
       name: "hindsight_reflect",
       label: "Hindsight Reflect",
@@ -442,31 +475,44 @@ export function registerTools(
       },
     });
   }
+
+  setRegisteredHindsightTools(registered);
+  return registered;
 }
 
 /**
- * Update whether hindsight_retain is visible to the LLM based on retention state.
+ * Refresh the visibility of all registered Hindsight tools based on the
+ * unified operational state and the session's retention flag.
  *
- * When a session is not retained, hindsight_retain is removed from active tools
- * so the LLM never sees it as an option (instead of seeing it and having calls fail).
- * When retained, it's added back if it was previously removed.
+ * - Degraded (`!isOperationalReady()`): hide ALL hindsight tools so the LLM
+ *   never sees any of them (no recall/reflect/retain/extra-context). This is
+ *   the single degraded mode regardless of cause (unreachable/incompatible
+ *   server, or required-but-missing/invalid cwd-local flush config).
+ * - Operational: show all registered hindsight tools, except `hindsight_retain`
+ *   is hidden when the session is not retained (so the LLM never sees a tool
+ *   whose calls would fail). `retained` has no effect on the other tools.
  *
- * Note: The execute-time check in hindsight_retain remains as a defensive
- * fallback in case the tool is called through edge cases (e.g., mid-turn toggle).
+ * Reads `isOperationalReady()` and the registered-tool list from
+ * `runtime-state`, so callers only need to pass the session's `retained` flag.
+ *
+ * Enabling/disabling tools is the only place degraded mode is enforced — there
+ * are no operational-state checks inside tool execute handlers.
  */
-export function updateRetainToolVisibility(pi: ExtensionAPI, retained: boolean): void {
-  const toolName = "hindsight_retain";
+export function refreshToolVisibility(pi: ExtensionAPI, retained: boolean): void {
   const activeNames = pi.getActiveTools();
+  // Preserve non-hindsight tools (other extensions / built-ins) unchanged.
+  const nonHindsight = activeNames.filter((n) => !n.startsWith("hindsight_"));
 
-  if (retained) {
-    // Add hindsight_retain if not already active
-    if (!activeNames.includes(toolName)) {
-      pi.setActiveTools([...activeNames, toolName]);
-    }
-  } else {
-    // Remove hindsight_retain from active tools
-    if (activeNames.includes(toolName)) {
-      pi.setActiveTools(activeNames.filter((n) => n !== toolName));
-    }
+  if (!isOperationalReady()) {
+    // Degraded: hide all hindsight tools.
+    pi.setActiveTools(nonHindsight);
+    return;
   }
+
+  // Operational: show all registered hindsight tools except retain when not
+  // retained.
+  const toShow = getRegisteredHindsightTools().filter(
+    (name) => name !== "hindsight_retain" || retained
+  );
+  pi.setActiveTools([...nonHindsight, ...toShow]);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,8 +2,27 @@
  * Shared utility functions.
  */
 
-import { existsSync, readFileSync } from "node:fs";
-import { basename } from "node:path";
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { basename, dirname, isAbsolute, join } from "node:path";
+
+/** Convert a parser/string offset into a 1-based line/character location. */
+export function offsetToLineColumn(
+  content: string,
+  offset: number
+): { line: number; character: number } {
+  let line = 1;
+  let character = 1;
+  for (let i = 0; i < offset && i < content.length; i++) {
+    if (content[i] === "\n") {
+      line++;
+      character = 1;
+    } else {
+      character++;
+    }
+  }
+  return { line, character };
+}
 
 /**
  * Truncate a string to max character count (code points, not code units).
@@ -98,14 +117,121 @@ export function getBasedir(cwd: string): string {
 }
 
 /**
- * Get the project name, falling back to basedir if not set via env var.
- * Reads `EPIMETHEUS_PROJECT_NAME` if set, with `PI_HINDSIGHT_PROJECT_NAME` as a
- * legacy fallback; otherwise derives from the cwd basename.
+ * Derive the main repo name from `<cwd>/.git`'s git common dir, so worktrees
+ * share the main repo name instead of each getting their worktree dir name.
+ *
+ * Uses `git rev-parse --git-common-dir`, then takes
+ * `basename(dirname(commonDir))`:
+ *   - main repo `/repo`         → commondir `/repo/.git` → `repo`
+ *   - worktree `/repo/wt/foo`   → commondir `/repo/.git` → `repo` (shared)
+ *
+ * Returns `null` when `git` is unavailable, the commondir cannot be resolved,
+ * or the derived name is empty / degenerate. Callers fall back to basename.
+ *
+ * Callers should guard this with `existsSync(join(cwd, ".git"))` to avoid
+ * spawning git for directories that are not git repos.
+ */
+export function deriveGitProjectName(cwd: string): string | null {
+  let result: ReturnType<typeof spawnSync>;
+  try {
+    result = spawnSync("git", ["rev-parse", "--git-common-dir"], {
+      cwd,
+      encoding: "utf-8",
+      // Keep this snappy — git is normally a few ms. A 5s ceiling guards
+      // against pathological hangs (e.g. a slow disk or interactive prompt).
+      timeout: 5000,
+    });
+  } catch {
+    return null;
+  }
+  if (result.error) return null;
+  if (typeof result.status !== "number" || result.status !== 0) return null;
+  const raw = typeof result.stdout === "string" ? result.stdout.trim() : "";
+  if (!raw) return null;
+
+  const abs = isAbsolute(raw) ? raw : join(cwd, raw);
+  const resolved = realpathOrSelf(abs);
+  const parent = dirname(resolved);
+  const name = basename(parent);
+  if (!name || name === "/" || name === ".") return null;
+  return name;
+}
+
+/**
+ * Resolve a symlink'd path to its real target. Falls back to the input path
+ * when realpath fails (e.g., the path was already removed between the
+ * `existsSync` check and the realpath call).
+ */
+function realpathOrSelf(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
+}
+
+/**
+ * Derive the default project name for a cwd and report its source, WITHOUT
+ * caching. If `<cwd>/.git` exists and {@link deriveGitProjectName} returns a
+ * name, returns `{ name, source: "git" }` (so a main repo and its worktrees
+ * share the main repo name); otherwise returns `{ name: basename(cwd),
+ * source: "basename" }`.
+ *
+ * This is the uncached primitive underneath {@link getProjectName}. The flush
+ * path calls this directly (via `flush-config.ts`'s `defaultProjectName`) rather
+ * than {@link getProjectName}, because `flush-pending` resolves many session
+ * cwds per run and must NOT go through the active-session-oriented single-slot
+ * cache.
+ */
+export function deriveDefaultProjectName(cwd: string): {
+  name: string;
+  source: "git" | "basename";
+} {
+  if (existsSync(join(cwd, ".git"))) {
+    const gitName = deriveGitProjectName(cwd);
+    if (gitName !== null) return { name: gitName, source: "git" };
+    // fall through to basename on any git failure
+  }
+  return { name: basename(cwd), source: "basename" };
+}
+
+/**
+ * Single-slot cache for the default project name, keyed by cwd. The active
+ * session's cwd is stable within a session, so the (potentially slow) git
+ * derivation runs at most once per cwd instead of on every turn (auto-recall
+ * builds `{project}` placeholder params on every `before_agent_start`).
+ * Cleared by {@link clearProjectNameCache} (tests / module reset).
+ *
+ * Only the *active* session's name is cached here — batch flushers that resolve
+ * many cwds (flush-pending) should call {@link deriveDefaultProjectName} directly.
+ */
+let projectNameCache: { cwd: string; name: string } | null = null;
+
+/** Clear the project-name cache. Exported for tests/reset via `_resetState()`. */
+export function clearProjectNameCache(): void {
+  projectNameCache = null;
+}
+
+/**
+ * Get the default project name for a cwd: git common dir (so worktrees share
+ * the main repo name) → basename. Cached per cwd (single-slot, active-session
+ * oriented).
+ *
+ * This is the default derivation shared by the flush path (via
+ * {@link ./flush-config.ts resolveProjectNameForFlush}'s detached/unmarked case)
+ * and the auto-recall `{project}` placeholder. Project-local flush config can
+ * override the project name for flush/tool-retain tagging. Env-var overrides
+ * (`EPIMETHEUS_PROJECT_NAME` / legacy `PI_HINDSIGHT_PROJECT_NAME`) were removed
+ * because env vars do not track Pi session switching.
+ *
+ * Callers resolving many cwds per run (e.g. flush-pending) should call
+ * {@link deriveDefaultProjectName} directly to bypass the active-session cache.
  */
 export function getProjectName(cwd: string): string {
-  return (
-    process.env.EPIMETHEUS_PROJECT_NAME || process.env.PI_HINDSIGHT_PROJECT_NAME || basename(cwd)
-  );
+  if (projectNameCache?.cwd === cwd) return projectNameCache.name;
+  const name = deriveDefaultProjectName(cwd).name;
+  projectNameCache = { cwd, name };
+  return name;
 }
 
 /**

--- a/tests/bootstrap.test.ts
+++ b/tests/bootstrap.test.ts
@@ -371,6 +371,280 @@ describe("real entrypoint bootstrap", () => {
     expect(pi.appendedEntries).toHaveLength(0);
   });
 
+  it("session_start auto-marks usesProjectFlushConfig:true when cwd has a valid flush config (new session)", async () => {
+    // New session, no existing metadata, but cwd has a valid cwd-local flush
+    // config: session_start should mint both retained:true AND
+    // usesProjectFlushConfig:true in the new hindsight-meta entry.
+    const { withTempDir } = await import("./fixtures");
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    await withTempDir(async (tmpCwd) => {
+      mkdirSync(join(tmpCwd, ".pi", "epimetheus"), { recursive: true });
+      writeFileSync(
+        join(tmpCwd, ".pi", "epimetheus", "flush-config.jsonc"),
+        JSON.stringify({ projectName: "marked-project" }),
+        "utf-8"
+      );
+
+      const pi = createMockPi();
+      const extension = await import("../src/index");
+      extension.default(pi);
+
+      const baseCtx = createMockContext();
+      const ctx = {
+        ...baseCtx,
+        cwd: tmpCwd,
+        sessionManager: {
+          ...baseCtx.sessionManager,
+          getHeader: mock(() => ({
+            id: "auto-mark-sess",
+            timestamp: "2026-01-01T00:00:00Z",
+            cwd: tmpCwd,
+            parentSession: undefined,
+          })),
+          getEntries: mock(() => []),
+        },
+      } as unknown as ExtensionContext;
+      const handler = pi.handlers.get("session_start")!;
+      await handler({ type: "session_start" }, ctx);
+
+      const metaEntries = pi.appendedEntries.filter((e) => e.customType === "hindsight-meta");
+      expect(metaEntries).toHaveLength(1);
+      const data = metaEntries[0]?.data as {
+        retained?: boolean;
+        usesProjectFlushConfig?: boolean;
+      };
+      expect(data.retained).toBe(true);
+      expect(data.usesProjectFlushConfig).toBe(true);
+    });
+  });
+
+  it("session_start preserves an explicit usesProjectFlushConfig:false detach on resume (latest-wins; no auto-remark)", async () => {
+    // Resumed session with an explicit usesProjectFlushConfig:false (after a
+    // /hindsight detach-flush-config). cwd still has a valid flush config.
+    // session_start must NOT append a new true entry that would override the
+    // detach (latest-wins means we leave an explicit value alone).
+    const { withTempDir } = await import("./fixtures");
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    await withTempDir(async (tmpCwd) => {
+      mkdirSync(join(tmpCwd, ".pi", "epimetheus"), { recursive: true });
+      writeFileSync(
+        join(tmpCwd, ".pi", "epimetheus", "flush-config.jsonc"),
+        JSON.stringify({ projectName: "marked-project" }),
+        "utf-8"
+      );
+
+      const pi = createMockPi();
+      const extension = await import("../src/index");
+      extension.default(pi);
+
+      const baseCtx = createMockContext();
+      const ctx = {
+        ...baseCtx,
+        cwd: tmpCwd,
+        sessionManager: {
+          ...baseCtx.sessionManager,
+          getHeader: mock(() => ({
+            id: "detach-resume-sess",
+            timestamp: "2026-01-01T00:00:00Z",
+            cwd: tmpCwd,
+            parentSession: undefined,
+          })),
+          getEntries: mock(() => [
+            {
+              type: "custom",
+              customType: "hindsight-meta",
+              data: { retained: true, usesProjectFlushConfig: false },
+            },
+          ]),
+        },
+      } as unknown as ExtensionContext;
+      const handler = pi.handlers.get("session_start")!;
+      await handler({ type: "session_start" }, ctx);
+
+      // Existing meta already has usesProjectFlushConfig:false explicit. No new
+      // hindsight-meta entry should be appended auto-marking true.
+      const metaEntries = pi.appendedEntries.filter((e) => e.customType === "hindsight-meta");
+      expect(metaEntries).toHaveLength(0);
+    });
+  });
+
+  it("session_start enters failed/unhealthy mode when the cwd-local flush config is invalid (unmarked active session)", async () => {
+    // Single degraded mode: an invalid cwd-local flush-config at the active
+    // session's cwd hard-fails the active session: unhealthy status, ALL
+    // Hindsight tools hidden (not just retain), no auto-retain, no metadata
+    // auto-mark, no startup flush. Diagnostic commands + detach-flush-config
+    // remain available.
+    const { withTempDir } = await import("./fixtures");
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    await withTempDir(async (tmpCwd) => {
+      mkdirSync(join(tmpCwd, ".pi", "epimetheus"), { recursive: true });
+      // Invalid: missing required projectName.
+      writeFileSync(
+        join(tmpCwd, ".pi", "epimetheus", "flush-config.jsonc"),
+        JSON.stringify({ notProjectName: "x" }),
+        "utf-8"
+      );
+
+      const pi = createMockPi();
+      const extension = await import("../src/index");
+      extension.default(pi);
+
+      const baseCtx = createMockContext();
+      const ctx = {
+        ...baseCtx,
+        cwd: tmpCwd,
+        sessionManager: {
+          ...baseCtx.sessionManager,
+          getHeader: mock(() => ({
+            id: "invalid-flush-sess",
+            timestamp: "2026-01-01T00:00:00Z",
+            cwd: tmpCwd,
+            parentSession: undefined,
+          })),
+          getEntries: mock(() => []), // unmarked (no existing meta)
+        },
+      } as unknown as ExtensionContext;
+      const handler = pi.handlers.get("session_start")!;
+      await handler({ type: "session_start" }, ctx);
+
+      // Failed mode: unhealthy status, no metadata appended.
+      expect(ctx.ui.setStatus).toHaveBeenCalledWith("epimetheus", "🤯");
+      const metaEntries = pi.appendedEntries.filter((e) => e.customType === "hindsight-meta");
+      expect(metaEntries).toHaveLength(0);
+      // ALL Hindsight tools were hidden (degraded hides every hindsight_* tool):
+      // the last setActiveTools call must contain no hindsight_* tool names.
+      const lastSetActive = pi.setActiveToolsCalls[pi.setActiveToolsCalls.length - 1] ?? [];
+      expect(lastSetActive.filter((n) => n.startsWith("hindsight_"))).toHaveLength(0);
+      // The active-session flush latch is false → the extension is not operational.
+      const { isActiveSessionFlushReady, isOperationalReady } =
+        require("../src/runtime-state") as typeof import("../src/runtime-state");
+      expect(isActiveSessionFlushReady()).toBe(false);
+      expect(isOperationalReady()).toBe(false);
+      // A clear warning was surfaced pointing at the recovery command.
+      const notifyCalls = (ctx.ui.notify as ReturnType<typeof mock>).mock.calls.map((c) =>
+        String(c[0])
+      );
+      expect(
+        notifyCalls.some(
+          (m) =>
+            m.includes("Hindsight active session unavailable") && m.includes("detach-flush-config")
+        )
+      ).toBe(true);
+    });
+  });
+
+  it("message_end auto-retain is blocked when the active session is in failed flush-config mode", async () => {
+    const { withTempDir } = await import("./fixtures");
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    await withTempDir(async (tmpCwd) => {
+      mkdirSync(join(tmpCwd, ".pi", "epimetheus"), { recursive: true });
+      writeFileSync(
+        join(tmpCwd, ".pi", "epimetheus", "flush-config.jsonc"),
+        JSON.stringify({ notProjectName: "x" }),
+        "utf-8"
+      );
+
+      const pi = createMockPi();
+      const extension = await import("../src/index");
+      extension.default(pi);
+
+      const sessionId = BOOTSTRAP_SESSION;
+      const { removePendingFlag, hasPendingFlag } =
+        require("../src/queue") as typeof import("../src/queue");
+      removePendingFlag(sessionId);
+
+      const baseCtx = createMockContext();
+      const ctx = {
+        ...baseCtx,
+        cwd: tmpCwd,
+        sessionManager: {
+          ...baseCtx.sessionManager,
+          getSessionId: mock(() => sessionId),
+          getHeader: mock(() => ({
+            id: sessionId,
+            timestamp: "2026-01-01T00:00:00Z",
+            cwd: tmpCwd,
+            parentSession: undefined,
+          })),
+          getEntries: mock(() => []),
+        },
+      } as unknown as ExtensionContext;
+
+      // session_start: failed mode (invalid flush config).
+      const startHandler = pi.handlers.get("session_start")!;
+      await startHandler({ type: "session_start" }, ctx);
+      expect(ctx.ui.setStatus).toHaveBeenCalledWith("epimetheus", "🤯");
+
+      // message_end must NOT queue (active session failed flush-config state).
+      const messageEndHandler = pi.handlers.get("message_end")!;
+      await messageEndHandler(
+        { type: "message_end", message: { role: "user", content: [{ type: "text", text: "Hi" }] } },
+        ctx
+      );
+      expect(hasPendingFlag(sessionId)).toBe(false);
+
+      removePendingFlag(sessionId);
+    });
+  });
+
+  it("session_start preserves a valid active session (usesProjectFlushConfig:false detached) even when cwd has an invalid flush config", async () => {
+    // Detached wins: when the session has an explicit usesProjectFlushConfig:false,
+    // an invalid cwd-local flush config must NOT fail the active session.
+    const { withTempDir } = await import("./fixtures");
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    await withTempDir(async (tmpCwd) => {
+      mkdirSync(join(tmpCwd, ".pi", "epimetheus"), { recursive: true });
+      writeFileSync(
+        join(tmpCwd, ".pi", "epimetheus", "flush-config.jsonc"),
+        JSON.stringify({ notProjectName: "x" }),
+        "utf-8"
+      );
+
+      const pi = createMockPi();
+      const extension = await import("../src/index");
+      extension.default(pi);
+      await runHealthySessionStart(pi); // latch startupReady on a healthy (no-flush-config) session first
+
+      const baseCtx = createMockContext();
+      const ctx = {
+        ...baseCtx,
+        cwd: tmpCwd,
+        sessionManager: {
+          ...baseCtx.sessionManager,
+          getHeader: mock(() => ({
+            id: "detached-despite-invalid",
+            timestamp: "2026-01-01T00:00:00Z",
+            cwd: tmpCwd,
+            parentSession: undefined,
+          })),
+          getEntries: mock(() => [
+            {
+              type: "custom",
+              customType: "hindsight-meta",
+              data: { retained: true, usesProjectFlushConfig: false },
+            },
+          ]),
+        },
+      } as unknown as ExtensionContext;
+      const handler = pi.handlers.get("session_start")!;
+      await handler({ type: "session_start" }, ctx);
+
+      // Detached wins: NOT unhealthy (server probe succeeds → healthy; flush state ready).
+      expect(ctx.ui.setStatus).toHaveBeenCalledWith("epimetheus", "🧠");
+      const { isActiveSessionFlushReady } =
+        require("../src/runtime-state") as typeof import("../src/runtime-state");
+      expect(isActiveSessionFlushReady()).toBe(true);
+      // No new hindsight-meta appended (existing meta already present; detach preserved).
+      const metaEntries = pi.appendedEntries.filter((e) => e.customType === "hindsight-meta");
+      expect(metaEntries).toHaveLength(0);
+    });
+  });
+
   it("session_start handler sets unhealthy status when server version is incompatible", async () => {
     activeClientFactory = () => ({
       healthCheck: mock(() => Promise.resolve({ success: true })),
@@ -1628,6 +1902,80 @@ describe("real entrypoint bootstrap", () => {
     }
   });
 
+  it("operational subcommands are blocked on the unified getter when the active session's flush config is invalid", async () => {
+    // Point 3: operational commands gate on the unified operational-ready getter
+    // (startupReady && activeSessionFlushReady), not just startupReady. When the
+    // active session fails the flush-config check, operational commands are
+    // blocked even though the server is healthy (startupReady latched).
+    const { withTempDir } = await import("./fixtures");
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    await withTempDir(async (tmpCwd) => {
+      mkdirSync(join(tmpCwd, ".pi", "epimetheus"), { recursive: true });
+      writeFileSync(
+        join(tmpCwd, ".pi", "epimetheus", "flush-config.jsonc"),
+        JSON.stringify({ notProjectName: "x" }),
+        "utf-8"
+      );
+
+      const pi = createMockPi();
+      const extension = await import("../src/index");
+      extension.default(pi);
+
+      const sessionId = BOOTSTRAP_SESSION;
+      const { removePendingFlag, hasPendingFlag, touchPendingFlag, clearSessionQueueState } =
+        require("../src/queue") as typeof import("../src/queue");
+      removePendingFlag(sessionId);
+
+      const baseCtx = createMockContext({ _sessionId: sessionId });
+      const ctx = {
+        ...baseCtx,
+        cwd: tmpCwd,
+        sessionManager: {
+          ...baseCtx.sessionManager,
+          getSessionId: mock(() => sessionId),
+          getHeader: mock(() => ({
+            id: sessionId,
+            timestamp: "2026-01-01T00:00:00Z",
+            cwd: tmpCwd,
+            parentSession: undefined,
+          })),
+          getEntries: mock(() => []), // unmarked + invalid config → failed
+        },
+      } as unknown as ExtensionContext;
+
+      // session_start: server healthy (latches startupReady) but flush config
+      // invalid → activeSessionFlushReady=false → not operational.
+      const startHandler = pi.handlers.get("session_start")!;
+      await startHandler({ type: "session_start" }, ctx);
+      const { isStartupReady, isOperationalReady } =
+        require("../src/runtime-state") as typeof import("../src/runtime-state");
+      expect(isStartupReady()).toBe(true);
+      expect(isOperationalReady()).toBe(false);
+
+      // An operational subcommand (/hindsight flush) must be blocked by the
+      // unified getter → unavailable message, no side effects.
+      await touchPendingFlag(sessionId);
+      const commandHandler = (
+        pi.commands.get("hindsight") as {
+          handler: (a: string, ctx: ExtensionContext) => Promise<void>;
+        }
+      ).handler;
+      const ctxCmd = createMockContext({ _sessionId: sessionId });
+      await commandHandler("flush", ctxCmd);
+      const msgs = (ctxCmd.ui.notify as ReturnType<typeof mock>).mock.calls.map((c) =>
+        String(c[0])
+      );
+      expect(msgs.some((m) => m.includes("not ready"))).toBe(true);
+      // No flush ran: the pending marker survives.
+      expect(hasPendingFlag(sessionId)).toBe(true);
+
+      removePendingFlag(sessionId);
+      clearSessionQueueState(sessionId);
+      cleanupParsedArtifacts(sessionId);
+    });
+  });
+
   it("session_before_switch handler flushes queued messages", async () => {
     const pi = createMockPi();
     const extension = await import("../src/index");
@@ -2676,16 +3024,17 @@ describe("real entrypoint bootstrap", () => {
     // Verifies that auto-recall uses event.prompt instead of scanning entries.
     // getEntries() returns empty here (first message of session), confirming
     // the handler doesn't depend on entries being populated.
+    const recall = mock(() =>
+      Promise.resolve({
+        success: true,
+        response: { results: [{ id: "1", text: "First message memory" }] },
+      })
+    );
     activeClientFactory = () => ({
       healthCheck: mock(() => Promise.resolve({ success: true })),
       retain: mock(() => Promise.resolve({ success: true })),
       retainBatch: mock(() => Promise.resolve({ success: true })),
-      recall: mock(() =>
-        Promise.resolve({
-          success: true,
-          response: { results: [{ id: "1", text: "First message memory" }] },
-        })
-      ),
+      recall,
       reflect: mock(() => Promise.resolve({ success: true, response: { text: "" } })),
     });
 
@@ -2704,6 +3053,10 @@ describe("real entrypoint bootstrap", () => {
 
     // event.prompt is available even though entries are empty
     await basHandler({ type: "before_agent_start", prompt: "Hello from first message" }, ctxBas);
+
+    expect(recall).toHaveBeenCalledTimes(1);
+    const recallCalls = recall.mock.calls as unknown as Array<[Record<string, unknown>]>;
+    expect(recallCalls[0]?.[0]).toMatchObject({ query: "Hello from first message" });
 
     // Recall was performed and cached — context handler re-injects it
     const contextHandler = pi.handlers.get("context")!;
@@ -2750,8 +3103,69 @@ describe("real entrypoint bootstrap", () => {
   // the real first-turn ordering rather than masking it with a pre-latched
   // readiness.
 
-  it("before_agent_start recalls on the first turn even before a healthy session_start has latched readiness", async () => {
-    // Healthy server. Readiness is NOT pre-latched (no runHealthySessionStart).
+  it("before_agent_start skips recall and does NOT probe/mutate readiness when not operational", async () => {
+    // New contract: session_start is awaited before the first prompt, so
+    // before_agent_start only checks the unified operational state and returns
+    // if degraded. It must NOT call ensureStartupReady() or mutate readiness
+    // (no on-demand health/version probe, no status mutation). Here no healthy
+    // session_start has latched readiness, so recall is skipped for this turn.
+    activeClientFactory = () => ({
+      healthCheck: mock(() => Promise.resolve({ success: true })),
+      getServerVersion: mock(() => Promise.resolve({ success: true, version: "0.9.0" })),
+      retain: mock(() => Promise.resolve({ success: true })),
+      retainBatch: mock(() => Promise.resolve({ success: true })),
+      recall: mock(() =>
+        Promise.resolve({
+          success: true,
+          response: { results: [{ id: "1", text: "should not be used" }] },
+        })
+      ),
+      reflect: mock(() => Promise.resolve({ success: true, response: { text: "" } })),
+    });
+
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+
+    const { isStartupReady, isActiveSessionFlushReady } =
+      require("../src/runtime-state") as typeof import("../src/runtime-state");
+    expect(isStartupReady()).toBe(false);
+    expect(isActiveSessionFlushReady()).toBe(true); // default, but startup not latched
+
+    const basHandler = pi.handlers.get("before_agent_start")!;
+    const ctx = createMockContext();
+    await basHandler({ type: "before_agent_start", prompt: "Hello" }, ctx);
+
+    // before_agent_start did NOT probe or mutate readiness: startup stays
+    // unlatched, and NO status call was made (session_start owns status).
+    expect(isStartupReady()).toBe(false);
+    expect(ctx.ui.setStatus).not.toHaveBeenCalled();
+    // No operational side effects: no metadata, no tools registered, no recall.
+    expect(pi.appendedEntries.filter((e) => e.customType === "hindsight-meta")).toHaveLength(0);
+    expect(pi.tools.filter((t) => t.name.startsWith("hindsight_"))).toHaveLength(0);
+
+    // Recall was skipped: the context handler has no cached memory to inject.
+    const contextHandler = pi.handlers.get("context")!;
+    const contextResult = (await contextHandler(
+      {
+        type: "context",
+        messages: [
+          { role: "user", content: [{ type: "text", text: "Hello" }], customType: undefined },
+        ],
+      },
+      createMockContext()
+    )) as Record<string, unknown> | undefined;
+    const messages = (contextResult?.messages ?? []) as Array<{ content?: unknown }>;
+    const leaked = messages.find(
+      (m) => typeof m.content === "string" && m.content.includes("should not be used")
+    );
+    expect(leaked).toBeUndefined();
+  });
+
+  it("before_agent_start recalls when operational (after a healthy session_start)", async () => {
+    // Once a healthy session_start has latched startup readiness and validated
+    // the active session's flush config, the extension is operational and
+    // before_agent_start recalls from event.prompt.
     activeClientFactory = () => ({
       healthCheck: mock(() => Promise.resolve({ success: true })),
       getServerVersion: mock(() => Promise.resolve({ success: true, version: "0.9.0" })),
@@ -2770,31 +3184,20 @@ describe("real entrypoint bootstrap", () => {
     const extension = await import("../src/index");
     extension.default(pi);
 
-    const { isStartupReady } =
-      require("../src/runtime-state") as typeof import("../src/runtime-state");
-    expect(isStartupReady()).toBe(false);
+    // Latch readiness + validate the active session via a healthy session_start.
+    await runHealthySessionStart(pi);
 
-    // First turn: no healthy session_start yet. before_agent_start must
-    // establish health/version readiness on demand (so recall is allowed even
-    // before a healthy session_start has latched it), then recall using
-    // event.prompt. It deliberately does NOT initialize session metadata/tools/
-    // retain visibility — that stays owned by session_start (which will run on
-    // the real lifecycle event). Here we only assert recall works from
-    // event.prompt despite empty entries.
     const basHandler = pi.handlers.get("before_agent_start")!;
     const ctxBas = createMockContext({
       sessionManager: {
         ...createMockContext().sessionManager,
-        getEntries: mock(() => []), // First message — no entries yet
+        getEntries: mock(() => []),
       },
     });
     await basHandler({ type: "before_agent_start", prompt: "Hello from first turn" }, ctxBas);
 
-    // Readiness was latched by the on-demand health/version establish.
-    expect(isStartupReady()).toBe(true);
-
-    // Recall ran (query from event.prompt despite empty entries): the context
-    // handler re-injects the cached memory.
+    // Recall ran (query from event.prompt): the context handler re-injects
+    // the cached memory.
     const contextHandler = pi.handlers.get("context")!;
     const contextResult = (await contextHandler(
       {
@@ -2818,74 +3221,11 @@ describe("real entrypoint bootstrap", () => {
     expect(recallMsg?.content).toContain("First-turn memory");
   });
 
-  it("before_agent_start skips recall when the first-turn health check genuinely fails (safety preserved)", async () => {
-    // Server is genuinely unreachable — health check fails on the on-demand
-    // verify too. Recall must be skipped and readiness must NOT latch.
-    activeClientFactory = () => ({
-      healthCheck: mock(() => Promise.resolve({ success: false, error: "Connection refused" })),
-      getServerVersion: mock(() => Promise.resolve({ success: true, version: "0.9.0" })),
-      retain: mock(() => Promise.resolve({ success: true })),
-      retainBatch: mock(() => Promise.resolve({ success: true })),
-      recall: mock(() =>
-        Promise.resolve({
-          success: true,
-          response: { results: [{ id: "1", text: "should not be used" }] },
-        })
-      ),
-      reflect: mock(() => Promise.resolve({ success: true, response: { text: "" } })),
-    });
-
-    const pi = createMockPi();
-    const extension = await import("../src/index");
-    extension.default(pi);
-
-    const { isStartupReady } =
-      require("../src/runtime-state") as typeof import("../src/runtime-state");
-    expect(isStartupReady()).toBe(false);
-
-    const basHandler = pi.handlers.get("before_agent_start")!;
-    const ctx = createMockContext();
-    await basHandler({ type: "before_agent_start", prompt: "Hello" }, ctx);
-
-    // Readiness was NOT latched (on-demand verify failed).
-    expect(isStartupReady()).toBe(false);
-    expect(ctx.ui.setStatus).toHaveBeenCalledWith("epimetheus", "🤯");
-    // Safety: no operational init ran on the failed probe — no metadata, no
-    // tools, no recall. (Health/version readiness gated recall here; session
-    // init is session_start-owned and a healthy session_start never ran.)
-    expect(pi.appendedEntries.filter((e) => e.customType === "hindsight-meta")).toHaveLength(0);
-    expect(pi.tools.filter((t) => t.name.startsWith("hindsight_"))).toHaveLength(0);
-
-    // Recall was skipped: no memory is available for the context handler to
-    // re-inject (the returned messages are the original user message only).
-    const contextHandler = pi.handlers.get("context")!;
-    const contextResult = (await contextHandler(
-      {
-        type: "context",
-        messages: [
-          {
-            role: "user",
-            content: [{ type: "text", text: "Hello" }],
-            customType: undefined,
-          },
-        ],
-      },
-      createMockContext()
-    )) as Record<string, unknown> | undefined;
-    const messages = (contextResult?.messages ?? []) as Array<{ content?: unknown }>;
-    const leaked = messages.find(
-      (m) => typeof m.content === "string" && m.content.includes("should not be used")
-    );
-    expect(leaked).toBeUndefined();
-  });
-
-  it("ensureStartupReady is single-flight: overlapping session_start and before_agent_start share one probe pass", async () => {
-    // If session_start and before_agent_start both try to establish readiness
-    // concurrently (before the first latch), they must join the same in-flight
-    // health/version probe rather than running duplicate/concurrent probes.
-    // (`ensureStartupReady` does health/version readiness only; session init is
-    // owned by session_start. The init-once assertions below cover session_start's
-    // path, which the winning — healthy — readiness attempt then runs into.)
+  it("ensureStartupReady is single-flight across overlapping session_starts; before_agent_start does not probe at all", async () => {
+    // New contract: before_agent_start no longer calls ensureStartupReady() — it
+    // only reads isOperationalReady() and returns if degraded, so it must NOT
+    // trigger or join any health/version probe. ensureStartupReady remains
+    // single-flight for overlapping session_starts (they share one probe pass).
     let probeCount = 0;
     let resolveHealth: (v: { success: boolean }) => void = () => {};
     activeClientFactory = () => ({
@@ -2914,9 +3254,6 @@ describe("real entrypoint bootstrap", () => {
     const startHandler = pi.handlers.get("session_start")!;
     const basHandler = pi.handlers.get("before_agent_start")!;
 
-    // Both ctxs return no existing hindsight-meta so the single shared probe's
-    // session_start winner always appends exactly one (deterministic regardless
-    // of which caller wins).
     const ctxNoMeta = () =>
       createMockContext({
         sessionManager: {
@@ -2925,32 +3262,37 @@ describe("real entrypoint bootstrap", () => {
         },
       });
 
-    // Kick off both WITHOUT awaiting, so both see isStartupReady()===false and
-    // both try to establish readiness before the first one completes.
-    const startPromise = startHandler({ type: "session_start" }, ctxNoMeta());
-    const basPromise = basHandler({ type: "before_agent_start", prompt: "overlap" }, ctxNoMeta());
-
-    // Let the microtask queue settle so both callers have entered their
-    // ensureStartupReady() (first sets the promise, second joins it).
-    await Promise.resolve();
-    await Promise.resolve();
-
-    // Only ONE health probe should be in flight (single-flight shared).
-    expect(probeCount).toBe(1);
-
-    // Resolve the single probe healthy → both promises resolve ready.
-    resolveHealth({ success: true });
-    await Promise.all([startPromise, basPromise]);
-
-    const { isStartupReady } =
+    // Fire a before_agent_start while no session_start has run (not ready).
+    // It must NOT call ensureStartupReady: no probe is triggered, and recall is
+    // skipped (degraded). So probeCount stays 0.
+    await basHandler({ type: "before_agent_start", prompt: "overlap" }, ctxNoMeta());
+    expect(probeCount).toBe(0);
+    const { isStartupReady, isOperationalReady } =
       require("../src/runtime-state") as typeof import("../src/runtime-state");
+    expect(isStartupReady()).toBe(false);
+    expect(isOperationalReady()).toBe(false);
+
+    // Now kick off two overlapping session_starts. They must share ONE probe.
+    const startPromise1 = startHandler({ type: "session_start" }, ctxNoMeta());
+    const startPromise2 = startHandler({ type: "session_start" }, ctxNoMeta());
+    await Promise.resolve();
+    await Promise.resolve();
+    // A before_agent_start fired while the probe is in flight must also not
+    // trigger a second probe (it only reads operational state, still false).
+    const basInFlight = basHandler(
+      { type: "before_agent_start", prompt: "in-flight" },
+      ctxNoMeta()
+    );
+    expect(probeCount).toBe(1); // only the single shared session_start probe
+
+    resolveHealth({ success: true });
+    await Promise.all([startPromise1, startPromise2, basInFlight]);
+
     expect(isStartupReady()).toBe(true);
-    // Session init ran exactly once (via session_start, after readiness): only
-    // one hindsight-meta append and one set of tools. before_agent_start does no
-    // session init, so the dedupe is of the health/version probe above.
-    expect(pi.appendedEntries.filter((e) => e.customType === "hindsight-meta")).toHaveLength(1);
+    expect(isOperationalReady()).toBe(true);
+    // Both session_starts ran session init (tools registered once; one meta each).
     expect(pi.tools.filter((t) => t.name === "hindsight_retain").length).toBe(1);
-    // Only the single in-flight probe ran throughout (no duplicate re-probe).
+    // No additional probes ran from before_agent_start.
     expect(probeCount).toBe(1);
   });
 
@@ -3324,6 +3666,7 @@ describe("real entrypoint bootstrap", () => {
     const pi = createMockPi();
     const extension = await import("../src/index");
     extension.default(pi);
+    await runHealthySessionStart(pi);
 
     const commandHandler = (
       pi.commands.get("hindsight") as {
@@ -3354,6 +3697,7 @@ describe("real entrypoint bootstrap", () => {
     const pi = createMockPi();
     const extension = await import("../src/index");
     extension.default(pi);
+    await runHealthySessionStart(pi);
 
     const basHandler = pi.handlers.get("before_agent_start")!;
     const switchHandler = pi.handlers.get("session_before_switch")!;
@@ -3404,6 +3748,7 @@ describe("real entrypoint bootstrap", () => {
     const pi = createMockPi();
     const extension = await import("../src/index");
     extension.default(pi);
+    await runHealthySessionStart(pi);
 
     const basHandler = pi.handlers.get("before_agent_start")!;
     const forkHandler = pi.handlers.get("session_before_fork")!;
@@ -4522,12 +4867,13 @@ describe("real entrypoint bootstrap", () => {
     cleanupParsedArtifacts(sessionId);
   });
 
-  it("a later failed session_start after a healthy one does not turn readiness off or re-hide tools", async () => {
-    // Latch invariant: once the first healthy startup completes, readiness is
-    // true and is never flipped back to false by later session_start failures.
-    // A later failure still sets the status-bar indicator unhealthy, but must
-    // NOT re-disable operational handlers or re-hide tools.
-    const { isStartupReady } =
+  it("a later failed session_start after a healthy one re-enters degraded mode and re-hides all tools", async () => {
+    // Re-enterable readiness: once the first healthy session_start completes,
+    // a later session_start observing an unreachable/incompatible server must
+    // flip startupReady back to false → unified degraded mode (isOperationalReady
+    // false, ALL hindsight tools hidden, auto-retain skipped, operational
+    // commands blocked). Status is unhealthy.
+    const { isStartupReady, isOperationalReady } =
       require("../src/runtime-state") as typeof import("../src/runtime-state");
     let healthSuccess = true;
     activeClientFactory = () => ({
@@ -4545,30 +4891,27 @@ describe("real entrypoint bootstrap", () => {
 
     const startHandler = pi.handlers.get("session_start")!;
     const healthyCtx = createMockContext();
-
-    // First start: healthy → readiness latches on, tools registered lazily.
     await startHandler({ type: "session_start" }, healthyCtx);
     expect(isStartupReady()).toBe(true);
+    expect(isOperationalReady()).toBe(true);
     const activeAfterHealthy = pi.getActiveTools().filter((n) => n.startsWith("hindsight_"));
     expect(activeAfterHealthy).toContain("hindsight_retain");
     expect(healthyCtx.ui.setStatus).toHaveBeenCalledWith("epimetheus", "🧠");
 
-    // Now a later session_start fails (server became unreachable).
+    // A later session_start fails (server became unreachable).
     healthSuccess = false;
     const failingCtx = createMockContext();
     await startHandler({ type: "session_start" }, failingCtx);
 
-    // Readiness stays on (latch not flipped back).
-    expect(isStartupReady()).toBe(true);
-    // The later failure set the status-bar indicator unhealthy...
+    // Re-entered degraded mode.
+    expect(isStartupReady()).toBe(false);
+    expect(isOperationalReady()).toBe(false);
     expect(failingCtx.ui.setStatus).toHaveBeenCalledWith("epimetheus", "🤯");
-    // ...but tools were NOT unregistered or re-hidden (still registered/active
-    // from the healthy startup).
+    // ALL hindsight tools are now hidden.
     const activeAfterFailure = pi.getActiveTools().filter((n) => n.startsWith("hindsight_"));
-    expect(activeAfterFailure).toEqual(activeAfterHealthy);
-    expect(activeAfterFailure).toContain("hindsight_retain");
+    expect(activeAfterFailure).toHaveLength(0);
 
-    // Operational handlers still run after the later failure (readiness on).
+    // Auto-retain is now skipped (degraded).
     const sessionId = BOOTSTRAP_SESSION;
     const { removePendingFlag, hasPendingFlag } =
       require("../src/queue") as typeof import("../src/queue");
@@ -4579,16 +4922,56 @@ describe("real entrypoint bootstrap", () => {
       { type: "message_end", message: { role: "user", content: [{ type: "text", text: "Hi" }] } },
       retainCtx
     );
-    expect(hasPendingFlag(sessionId)).toBe(true);
+    expect(hasPendingFlag(sessionId)).toBe(false);
 
     removePendingFlag(sessionId);
   });
 
+  it("a subsequent healthy session_start after a server failure restores operational readiness and re-shows tools", async () => {
+    // Recovery: after re-entering degraded mode due to a server failure, a
+    // subsequent healthy session_start (flush config OK) must make the
+    // extension operational again and re-show tools per retention.
+    const { isStartupReady, isOperationalReady } =
+      require("../src/runtime-state") as typeof import("../src/runtime-state");
+    let healthSuccess = false;
+    activeClientFactory = () => ({
+      healthCheck: mock(() => Promise.resolve({ success: healthSuccess })),
+      getServerVersion: mock(() => Promise.resolve({ success: true, version: "0.9.0" })),
+      retain: mock(() => Promise.resolve({ success: true })),
+      retainBatch: mock(() => Promise.resolve({ success: true })),
+      recall: mock(() => Promise.resolve({ success: true, response: { results: [] } })),
+      reflect: mock(() => Promise.resolve({ success: true, response: { text: "" } })),
+    });
+
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+
+    const startHandler = pi.handlers.get("session_start")!;
+    // First start: server unreachable → degraded.
+    await startHandler({ type: "session_start" }, createMockContext());
+    expect(isStartupReady()).toBe(false);
+    expect(isOperationalReady()).toBe(false);
+    expect(pi.getActiveTools().filter((n) => n.startsWith("hindsight_"))).toHaveLength(0);
+
+    // Recovery: server is healthy again → operational, tools re-shown.
+    healthSuccess = true;
+    const recoveredCtx = createMockContext();
+    await startHandler({ type: "session_start" }, recoveredCtx);
+    expect(isStartupReady()).toBe(true);
+    expect(isOperationalReady()).toBe(true);
+    expect(recoveredCtx.ui.setStatus).toHaveBeenCalledWith("epimetheus", "🧠");
+    const activeAfterRecovery = pi.getActiveTools().filter((n) => n.startsWith("hindsight_"));
+    // Session is retained by default in createMockContext → retain visible too.
+    expect(activeAfterRecovery).toContain("hindsight_retain");
+    expect(activeAfterRecovery).toContain("hindsight_recall");
+  });
+
   it("startup auto-flush skips when a latched session_start refresh probe fails", async () => {
-    // Readiness is one-way, so a later failed probe should not undo metadata or
-    // tool visibility work. Startup auto-flush is different: it is automatic
-    // network work, so skip it when this same session_start just observed the
-    // server as unhealthy.
+    // Readiness is re-enterable, so a later failed probe re-enters degraded
+    // mode (returning before any startup auto-flush). Startup auto-flush is
+    // automatic network work, so skip it when this same session_start just
+    // observed the server as unhealthy.
     activeConfig = { ...testConfig, autoFlushPendingOn: ["startup"] };
     let healthSuccess = true;
     activeClientFactory = () => ({
@@ -4707,5 +5090,174 @@ describe("real entrypoint bootstrap", () => {
     );
     expect(configMessages.some((m: string) => m.includes("== Config Source =="))).toBe(true);
     expect(configMessages.some((m: string) => m.includes("not ready"))).toBe(false);
+  });
+
+  it("degraded mode keeps diagnostic/display/recovery commands while blocking operational commands", async () => {
+    activeConfig = { ...testConfig, autoRecallPersist: true, autoRecallDisplay: false };
+    const { withTempDir } = await import("./fixtures");
+    await withTempDir(async (tmpCwd) => {
+      mkdirSync(join(tmpCwd, ".pi", "epimetheus"), { recursive: true });
+      writeFileSync(
+        join(tmpCwd, ".pi", "epimetheus", "flush-config.jsonc"),
+        JSON.stringify({ notProjectName: "x" }),
+        "utf-8"
+      );
+
+      const pi = createMockPi();
+      const extension = await import("../src/index");
+      extension.default(pi);
+
+      const sessionId = BOOTSTRAP_SESSION;
+      const baseCtx = createMockContext({ _sessionId: sessionId });
+      const ctx = {
+        ...baseCtx,
+        cwd: tmpCwd,
+        ui: {
+          ...baseCtx.ui,
+          confirm: mock(() => Promise.resolve(true)),
+        },
+        sessionManager: {
+          ...baseCtx.sessionManager,
+          getSessionId: mock(() => sessionId),
+          getHeader: mock(() => ({
+            id: sessionId,
+            timestamp: "2026-01-01T00:00:00Z",
+            cwd: tmpCwd,
+            parentSession: undefined,
+          })),
+          getEntries: mock(() => [
+            {
+              type: "custom",
+              customType: "hindsight-meta",
+              data: { retained: true, usesProjectFlushConfig: true },
+            },
+          ]),
+        },
+      } as unknown as ExtensionContext;
+
+      const startHandler = pi.handlers.get("session_start")!;
+      await startHandler({ type: "session_start" }, ctx);
+
+      const { isOperationalReady } =
+        require("../src/runtime-state") as typeof import("../src/runtime-state");
+      expect(isOperationalReady()).toBe(false);
+
+      const commandHandler = (
+        pi.commands.get("hindsight") as {
+          handler: (args: string, ctx: ExtensionContext) => Promise<void>;
+        }
+      ).handler;
+
+      // Diagnostic commands remain available.
+      const statusCtx = createMockContext({ _sessionId: sessionId });
+      await commandHandler("status", statusCtx);
+      expect(
+        (statusCtx.ui.notify as ReturnType<typeof mock>).mock.calls.some((c) =>
+          String(c[0]).includes("== Connection ==")
+        )
+      ).toBe(true);
+
+      const configCtx = createMockContext({ _sessionId: sessionId });
+      await commandHandler("config", configCtx);
+      expect(
+        (configCtx.ui.notify as ReturnType<typeof mock>).mock.calls.some((c) =>
+          String(c[0]).includes("== Config Source ==")
+        )
+      ).toBe(true);
+
+      // Display command remains available and affects persisted recall rendering.
+      const renderer = pi.renderers.get("hindsight-recall") as (
+        message: Record<string, unknown>,
+        options: { expanded: boolean },
+        theme: Record<string, unknown>
+      ) => { render: (width: number) => string[] } | undefined;
+      const component = renderer(
+        { details: { count: 1, snippet: "memory", memories: "memory" } },
+        { expanded: false },
+        { fg: (_color: unknown, text: string) => text, bg: (_color: unknown, text: string) => text }
+      );
+      expect(component?.render(80)).toHaveLength(0);
+      await commandHandler("toggle-display", createMockContext({ _sessionId: sessionId }));
+      expect(component?.render(80).join("\n")).toContain("Hindsight recalled");
+
+      // Operational commands are blocked while degraded.
+      const { hasPendingFlag, removePendingFlag, touchPendingFlag } =
+        require("../src/queue") as typeof import("../src/queue");
+      removePendingFlag(sessionId);
+      await touchPendingFlag(sessionId);
+      const flushCtx = createMockContext({ _sessionId: sessionId });
+      await commandHandler("flush", flushCtx);
+      expect(hasPendingFlag(sessionId)).toBe(true);
+      expect(
+        (flushCtx.ui.notify as ReturnType<typeof mock>).mock.calls.some((c) =>
+          String(c[0]).includes("not ready")
+        )
+      ).toBe(true);
+
+      // Recovery command remains available and clears the active-session failure.
+      await commandHandler("detach-flush-config", ctx);
+      expect(isOperationalReady()).toBe(true);
+      expect(
+        pi.appendedEntries.some(
+          (e) =>
+            e.customType === "hindsight-meta" &&
+            (e.data as { usesProjectFlushConfig?: boolean }).usesProjectFlushConfig === false
+        )
+      ).toBe(true);
+      removePendingFlag(sessionId);
+    });
+  });
+
+  it("/hindsight popup is unavailable in degraded mode (no recall to inspect) even if recall details are cached", async () => {
+    // Degraded (server unreachable) → auto-recall is skipped, so there is no
+    // current recall for the popup to inspect. It must report it is not ready
+    // and NOT invoke the overlay, even when a cached recall from a prior
+    // operational turn is present.
+    activeClientFactory = () => ({
+      healthCheck: mock(() => Promise.resolve({ success: false, error: "connection refused" })),
+      getServerVersion: mock(() => Promise.resolve({ success: true, version: "0.9.0" })),
+      retain: mock(() => Promise.resolve({ success: true })),
+      retainBatch: mock(() => Promise.resolve({ success: true })),
+      recall: mock(() =>
+        Promise.resolve({
+          success: true,
+          response: { results: [{ id: "1", text: "cached recall" }] },
+        })
+      ),
+      reflect: mock(() => Promise.resolve({ success: true, response: { text: "" } })),
+    });
+    activeConfig = { ...testConfig, autoRecallPersist: true };
+
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+
+    // A failed (unhealthy) session_start → degraded (not operational).
+    const startHandler = pi.handlers.get("session_start")!;
+    await startHandler({ type: "session_start" }, createMockContext());
+
+    const commandHandler = (
+      pi.commands.get("hindsight") as {
+        handler: (args: string, ctx: ExtensionContext) => Promise<void>;
+      }
+    ).handler;
+
+    let overlayCalled = false;
+    const ctx = {
+      ...createMockContext(),
+      ui: {
+        ...createMockContext().ui,
+        custom: mock(async () => {
+          overlayCalled = true;
+        }),
+      },
+    } as unknown as ExtensionContext;
+    await commandHandler("popup", ctx);
+
+    expect(overlayCalled).toBe(false);
+    const msgs = (ctx.ui.notify as ReturnType<typeof mock>).mock.calls.map((c: unknown[]) =>
+      String(c[0])
+    );
+    expect(msgs.some((m: string) => m.includes("not ready"))).toBe(true);
   });
 });

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -9,6 +9,12 @@ import type { HindsightClientWrapper } from "../src/client";
 import { registerCommands } from "../src/commands";
 import type { RecallMessageDetails } from "../src/index";
 import {
+  markStartupReady,
+  resetRegisteredHindsightTools,
+  resetStartupReady,
+  setRegisteredHindsightTools,
+} from "../src/runtime-state";
+import {
   createMockClient,
   readToolQueueFromDisk,
   setupTempAgentDir,
@@ -41,6 +47,10 @@ afterEach(() => {
   } catch {
     // best-effort
   }
+  // Reset runtime-state so tests start/leave operational state clean (these
+  // tests call registerCommands directly, without a session_start).
+  resetStartupReady();
+  resetRegisteredHindsightTools();
 });
 
 interface RegisteredCmd {
@@ -109,6 +119,14 @@ describe("registerCommands", () => {
   });
 
   function register(config = statusTestConfig, client = mockClient) {
+    registerWithReady(config, client, () => true);
+  }
+
+  function registerWithReady(
+    config = statusTestConfig,
+    client = mockClient,
+    isReady: () => boolean = () => true
+  ) {
     registerCommands(
       mockPi as unknown as import("@earendil-works/pi-coding-agent").ExtensionAPI,
       config,
@@ -118,7 +136,7 @@ describe("registerCommands", () => {
       () => {
         autoRecallDisplayOverride = !autoRecallDisplayOverride;
       },
-      () => true,
+      isReady,
       { configPath: undefined, envVars: [], warning: undefined, validationWarnings: [] }
     );
   }
@@ -814,6 +832,19 @@ describe("registerCommands", () => {
         { type: "custom", customType: "hindsight-meta", data: { retained: false } },
       ];
       register({ ...statusTestConfig, retainSessionsByDefault: false });
+
+      // refreshToolVisibility reads the unified operational state + the
+      // registered-tools list from runtime-state. These registerCommands
+      // tests bypass session_start, so latch operational + record the
+      // registered tools manually.
+      markStartupReady();
+      setRegisteredHindsightTools([
+        "hindsight_set_extra_context",
+        "hindsight_get_extra_context",
+        "hindsight_retain",
+        "hindsight_recall",
+        "hindsight_reflect",
+      ]);
 
       // Simulate session_start hiding the tool
       mockActiveTools.length = 0;
@@ -2233,6 +2264,61 @@ describe("registerCommands", () => {
       await getHandler()("popup", ctx);
 
       expect((overlayDetails as RecallMessageDetails | null)?.count).toBe(1);
+    });
+
+    it("is unavailable in degraded mode (not ready): no overlay, no recall to inspect", async () => {
+      // Degraded mode skips auto-recall, so there is no current recall to
+      // inspect. /hindsight popup must short-circuit with an info message and
+      // NOT invoke the overlay — even when recall details are cached from a
+      // prior operational turn.
+      recallDetails = {
+        count: 2,
+        snippet: "cached",
+        memories: "cached",
+      };
+      registerWithReady(statusTestConfig, mockClient, () => false);
+
+      let overlayCalled = false;
+      const ctx = {
+        ...makeCtx(),
+        ui: {
+          ...makeCtx().ui,
+          custom: mock(async () => {
+            overlayCalled = true;
+          }),
+        },
+      } as unknown as ExtensionContext;
+
+      await getHandler()("popup", ctx);
+
+      expect(overlayCalled).toBe(false);
+      expect(lastNotification?.message).toContain("not ready");
+      expect(lastNotification?.message).toContain("auto-recall is skipped");
+    });
+
+    it("reports it requires autoRecallEnabled when auto-recall is disabled", async () => {
+      recallDetails = {
+        count: 2,
+        snippet: "cached",
+        memories: "cached",
+      };
+      registerWithReady({ ...statusTestConfig, autoRecallEnabled: false }, mockClient, () => true);
+
+      let overlayCalled = false;
+      const ctx = {
+        ...makeCtx(),
+        ui: {
+          ...makeCtx().ui,
+          custom: mock(async () => {
+            overlayCalled = true;
+          }),
+        },
+      } as unknown as ExtensionContext;
+
+      await getHandler()("popup", ctx);
+
+      expect(overlayCalled).toBe(false);
+      expect(lastNotification?.message).toContain("autoRecallEnabled is false");
     });
   });
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -737,7 +737,7 @@ describe("loadConfig", () => {
     expect(warning).toContain('(value: "value")');
   });
 
-  it("rejects projectName in config file (EPIMETHEUS_PROJECT_NAME is env-only)", () => {
+  it("rejects projectName in global config file (project-local setting only)", () => {
     writeFileSync(
       join(TEST_DIR, "config.json"),
       JSON.stringify({

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -339,8 +339,8 @@ export function setupTempAgentDir(label: string): string {
  *
  * Includes both the current `EPIMETHEUS_*` (preferred) and legacy
  * `PI_HINDSIGHT_*` fallback names so tests that set either get cleaned up.
- * `HINDSIGHT_API_URL` / `HINDSIGHT_API_KEY` (official Hindsight service vars)
- * and `EPIMETHEUS_PROJECT_NAME` / `PI_HINDSIGHT_PROJECT_NAME` are included too.
+ * `HINDSIGHT_API_URL` / `HINDSIGHT_API_KEY` are official Hindsight service vars.
+ * Removed project-name env vars are still listed so tests can verify they are ignored.
  */
 export const HINDSIGHT_ENV_KEYS = [
   "EPIMETHEUS_ENABLED",
@@ -463,6 +463,12 @@ export async function withTempDir<T>(fn: (tmpDir: string) => Promise<T>): Promis
  * @param options.parentSession - Optional parent session path (for forked sessions)
  * @param options.messages - Messages to include. Defaults to a single user message.
  *   Pass an empty array to write a header-only file (e.g. for fork-without-messages tests).
+ * @param options.cwd - Optional cwd to record in the session header (defaults to
+ *   "/test" for backward compat with existing tests).
+ * @param options.retained - Defaults to true; sets the hindsight-meta retained flag.
+ * @param options.extraContext - Optional hindsight-meta extraContext string.
+ * @param options.usesProjectFlushConfig - Optional hindsight-meta flag marking
+ *   the session as requiring a cwd-local flush config.
  */
 export function writeSessionFile(
   dir: string,
@@ -470,8 +476,10 @@ export function writeSessionFile(
   options: {
     parentSession?: string;
     messages?: Array<{ role: string; content: unknown }>;
+    cwd?: string;
     retained?: boolean;
     extraContext?: string;
+    usesProjectFlushConfig?: boolean;
   } = {}
 ): string {
   const sessionPath = join(dir, `${sessionId}.jsonl`);
@@ -479,7 +487,7 @@ export function writeSessionFile(
     type: "session",
     id: sessionId,
     timestamp: new Date().toISOString(),
-    cwd: "/test",
+    cwd: options.cwd ?? "/test",
   };
   if (options.parentSession) {
     header.parentSession = options.parentSession;
@@ -492,6 +500,9 @@ export function writeSessionFile(
   const metaData: Record<string, unknown> = { retained };
   if (options.extraContext !== undefined) {
     metaData.extraContext = options.extraContext;
+  }
+  if (options.usesProjectFlushConfig !== undefined) {
+    metaData.usesProjectFlushConfig = options.usesProjectFlushConfig;
   }
   lines.push(
     JSON.stringify({

--- a/tests/flush-config.test.ts
+++ b/tests/flush-config.test.ts
@@ -1,0 +1,1294 @@
+/**
+ * Tests for the project-local flush config feature.
+ *
+ * Covers `resolveFlushConfig` (load + validate cwd-local config), the default
+ * project name derivation (inclusive of git common dir handling so worktrees
+ * share the main repo name), fail-closed behavior for marked sessions whose
+ * config is missing/invalid, the `/hindsight detach-flush-config` command,
+ * flush-pending handling each session independently, and the `/hindsight config`
+ * session-specific diagnostics.
+ *
+ * Adheres to AGENTS.md: never modifies the real pi agent directory (uses
+ * setupTempAgentDir to redirect PI_CODING_AGENT_DIR), exercises real handlers
+ * (no simulation of production logic), and tests behavior — not implementation.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { HindsightClientWrapper } from "../src/client";
+import { registerCommands } from "../src/commands";
+import {
+  evaluateActiveSessionFlushState,
+  findFlushConfigFile,
+  resolveFlushConfig,
+  resolveProjectNameForFlush,
+} from "../src/flush-config";
+import type { RecallMessageDetails } from "../src/index";
+import { getHindsightMeta, updateSessionMetadata } from "../src/meta";
+import { getMessagesPath, getMetaPath } from "../src/parsed-store";
+import {
+  clearSessionQueueState,
+  hasPendingFlag,
+  removePendingFlag,
+  touchPendingFlag,
+} from "../src/queue";
+import { parseAndUpsertSession } from "../src/retention";
+import { getSessionStatePath } from "../src/session-state";
+import {
+  cleanupParsedArtifacts,
+  createMockClient,
+  HINDSIGHT_ENV_KEYS,
+  makeNotifyCtx,
+  saveEnvKeys,
+  setupTempAgentDir,
+  testConfig,
+  withTempDir,
+  writeSessionFile,
+} from "./fixtures";
+
+setupTempAgentDir("flush-config");
+
+let restoreEnv: () => void;
+
+beforeEach(() => {
+  restoreEnv = saveEnvKeys(HINDSIGHT_ENV_KEYS);
+});
+
+afterEach(() => {
+  restoreEnv();
+});
+
+// ============================================
+// Helpers
+// ============================================
+
+/**
+ * Write a flush-config file (`.jsonc` or `.json`) under `<cwd>/.pi/epimetheus/`.
+ */
+function writeFlushConfig(cwd: string, ext: "jsonc" | "json", content: string): string {
+  const dir = join(cwd, ".pi", "epimetheus");
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `flush-config.${ext}`);
+  writeFileSync(path, content, "utf-8");
+  return path;
+}
+
+/**
+ * Run a `git` command in `cwd`. Throws (failing the test) only on spawnSync error;
+ * non-zero exit leaves it to the caller to assert — but for setup we expect 0.
+ */
+function git(cwd: string, args: string[]): void {
+  const result = spawnSync("git", args, { cwd, encoding: "utf-8", timeout: 30_000 });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} (cwd=${cwd}) failed with status ${result.status}: ${result.stderr}`
+    );
+  }
+}
+
+/**
+ * Capture the call args passed to client.retain by returning a mock client
+ * and a `retainCalls` array mirroring production test helpers.
+ */
+function capturingClient(): {
+  client: HindsightClientWrapper;
+  retainCalls: { tags?: string[] }[];
+} {
+  const retainCalls: { tags?: string[] }[] = [];
+  const client = {
+    retain: mock(async (opts: { tags?: string[] }) => {
+      retainCalls.push(opts);
+      return { success: true };
+    }),
+    retainBatch: mock(async () => ({ success: true })),
+  } as unknown as HindsightClientWrapper;
+  return { client, retainCalls };
+}
+
+// ============================================
+// resolveFlushConfig (load + schema)
+// ============================================
+
+describe("resolveFlushConfig", () => {
+  it("fails closed (not ok) when no cwd-local config exists", async () => {
+    await withTempDir(async (cwd) => {
+      const r = resolveFlushConfig(cwd);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/no cwd-local flush-config/);
+    });
+  });
+
+  it("loads .jsonc (preferred over .json)", async () => {
+    await withTempDir(async (cwd) => {
+      writeFlushConfig(cwd, "jsonc", JSON.stringify({ projectName: "from-jsonc" }));
+      writeFlushConfig(cwd, "json", JSON.stringify({ projectName: "from-json" }));
+      const r = resolveFlushConfig(cwd);
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.config.projectName).toBe("from-jsonc");
+        expect(r.path.endsWith("flush-config.jsonc")).toBe(true);
+      }
+    });
+  });
+
+  it("loads .json when no .jsonc exists", async () => {
+    await withTempDir(async (cwd) => {
+      writeFlushConfig(cwd, "json", JSON.stringify({ projectName: "from-json" }));
+      const r = resolveFlushConfig(cwd);
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.config.projectName).toBe("from-json");
+    });
+  });
+
+  it("parses JSONC with comments and trailing commas", async () => {
+    await withTempDir(async (cwd) => {
+      writeFlushConfig(
+        cwd,
+        "jsonc",
+        // Leading comment, inline comment, trailing comma
+        `// project-local flush config
+{
+  "projectName": "commented", // inline comment
+}`
+      );
+      const r = resolveFlushConfig(cwd);
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.config.projectName).toBe("commented");
+    });
+  });
+
+  it("fails closed when projectName is missing", async () => {
+    await withTempDir(async (cwd) => {
+      writeFlushConfig(cwd, "jsonc", JSON.stringify({ other: "x" }));
+      const r = resolveFlushConfig(cwd);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/projectName/);
+    });
+  });
+
+  it("fails closed when projectName is not a string", async () => {
+    await withTempDir(async (cwd) => {
+      writeFlushConfig(cwd, "jsonc", JSON.stringify({ projectName: 42 }));
+      const r = resolveFlushConfig(cwd);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/projectName/);
+    });
+  });
+
+  it("fails closed when projectName is empty/whitespace", async () => {
+    await withTempDir(async (cwd) => {
+      writeFlushConfig(cwd, "jsonc", JSON.stringify({ projectName: "   " }));
+      const r = resolveFlushConfig(cwd);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/empty\/whitespace/);
+    });
+  });
+
+  it("fails closed when top-level is not an object", async () => {
+    await withTempDir(async (cwd) => {
+      writeFlushConfig(cwd, "jsonc", `["not", "an", "object"]`);
+      const r = resolveFlushConfig(cwd);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/JSON object/);
+    });
+  });
+
+  it("fails closed when JSON is malformed", async () => {
+    await withTempDir(async (cwd) => {
+      writeFlushConfig(cwd, "jsonc", `{ "projectName": "x" `); // missing close
+      const r = resolveFlushConfig(cwd);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/not valid JSON/);
+    });
+  });
+
+  it("warns and ignores unknown keys while keeping projectName", async () => {
+    await withTempDir(async (cwd) => {
+      writeFlushConfig(
+        cwd,
+        "jsonc",
+        JSON.stringify({ projectName: "stable", destination: "x", mode: "y" })
+      );
+      const r = resolveFlushConfig(cwd);
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.config.projectName).toBe("stable");
+        expect(r.warnings.some((w) => w.includes(`"destination"`))).toBe(true);
+        expect(r.warnings.some((w) => w.includes(`"mode"`))).toBe(true);
+      }
+    });
+  });
+
+  it("trims whitespace around projectName", async () => {
+    await withTempDir(async (cwd) => {
+      writeFlushConfig(cwd, "jsonc", JSON.stringify({ projectName: "  stable  " }));
+      const r = resolveFlushConfig(cwd);
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.config.projectName).toBe("stable");
+    });
+  });
+
+  it("findFlushConfigFile returns the path when jsonc present, null otherwise", async () => {
+    await withTempDir(async (cwd) => {
+      expect(findFlushConfigFile(cwd)).toBeNull();
+      writeFlushConfig(cwd, "jsonc", JSON.stringify({ projectName: "x" }));
+      expect(findFlushConfigFile(cwd)).not.toBeNull();
+      expect(findFlushConfigFile(cwd)?.endsWith("flush-config.jsonc")).toBe(true);
+    });
+  });
+
+  it("does not walk ancestors (only cwd-local checked)", async () => {
+    await withTempDir(async (dir) => {
+      const ancestor = join(dir, "ancestor");
+      mkdirSync(ancestor, { recursive: true });
+      writeFlushConfig(ancestor, "jsonc", JSON.stringify({ projectName: "ancestor-name" }));
+      const child = join(ancestor, "child");
+      mkdirSync(child, { recursive: true });
+      // Child has no flush-config of its own; ancestor does. Should NOT find any.
+      expect(findFlushConfigFile(child)).toBeNull();
+      expect(resolveFlushConfig(child).ok).toBe(false);
+    });
+  });
+});
+
+// ============================================
+// resolveProjectNameForFlush
+// ============================================
+
+describe("resolveProjectNameForFlush (default / non-marked)", () => {
+  // Env-var overrides were removed; default derivation is git common dir -> basename.
+  it("ignores EPIMETHEUS_PROJECT_NAME and falls back to basename", () => {
+    process.env.EPIMETHEUS_PROJECT_NAME = "env-override";
+    try {
+      const r = resolveProjectNameForFlush("/some/path/myapp", false);
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.projectName).toBe("myapp");
+        expect(r.source).toBe("basename");
+      }
+    } finally {
+      delete process.env.EPIMETHEUS_PROJECT_NAME;
+    }
+  });
+
+  it("ignores legacy PI_HINDSIGHT_PROJECT_NAME and falls back to basename", () => {
+    process.env.PI_HINDSIGHT_PROJECT_NAME = "legacy-override";
+    try {
+      const r = resolveProjectNameForFlush("/some/path/myapp", false);
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.projectName).toBe("myapp");
+        expect(r.source).toBe("basename");
+      }
+    } finally {
+      delete process.env.PI_HINDSIGHT_PROJECT_NAME;
+    }
+  });
+
+  it("falls back to basename when no env var and no .git", () => {
+    const r = resolveProjectNameForFlush("/some/path/myapp", false);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.projectName).toBe("myapp");
+      expect(r.source).toBe("basename");
+    }
+  });
+
+  it("derives basename for non-existent cwd with no .git (no fail-closed)", () => {
+    const r = resolveProjectNameForFlush("/totally/nonexistent/path-xyz", false);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.projectName).toBe("path-xyz");
+      expect(r.source).toBe("basename");
+    }
+  });
+
+  it("derives main-repo name from git common dir (basename of common dir parent)", async () => {
+    await withTempDir(async (dir) => {
+      const mainRepo = join(dir, "realrepo");
+      mkdirSync(mainRepo, { recursive: true });
+      git(mainRepo, ["init", "-q", "--initial-branch=main"]);
+      git(mainRepo, ["config", "user.email", "test@test.local"]);
+      git(mainRepo, ["config", "user.name", "Test"]);
+      writeFileSync(join(mainRepo, "README.md"), "init\n", "utf-8");
+      git(mainRepo, ["add", "."]);
+      git(mainRepo, ["commit", "-q", "-m", "init"]);
+
+      const r = resolveProjectNameForFlush(mainRepo, false);
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.projectName).toBe("realrepo");
+        expect(r.source).toBe("git");
+      }
+    });
+  });
+
+  it("worktrees share the main repo name (git common dir handles this)", async () => {
+    await withTempDir(async (dir) => {
+      const mainRepo = join(dir, "mainshared");
+      mkdirSync(mainRepo, { recursive: true });
+      git(mainRepo, ["init", "-q", "--initial-branch=main"]);
+      git(mainRepo, ["config", "user.email", "test@test.local"]);
+      git(mainRepo, ["config", "user.name", "Test"]);
+      writeFileSync(join(mainRepo, "README.md"), "init\n", "utf-8");
+      git(mainRepo, ["add", "."]);
+      git(mainRepo, ["commit", "-q", "-m", "init"]);
+
+      const worktree = join(dir, "wt-should-share-name");
+      git(mainRepo, ["worktree", "add", "-q", worktree]);
+
+      try {
+        const mainR = resolveProjectNameForFlush(mainRepo, false);
+        const wtR = resolveProjectNameForFlush(worktree, false);
+        expect(mainR.ok).toBe(true);
+        expect(wtR.ok).toBe(true);
+        if (mainR.ok && wtR.ok) {
+          expect(mainR.projectName).toBe("mainshared");
+          expect(wtR.projectName).toBe("mainshared"); // shared with main repo
+          expect(mainR.source).toBe("git");
+          expect(wtR.source).toBe("git");
+        }
+      } finally {
+        try {
+          git(mainRepo, ["worktree", "remove", "--force", worktree]);
+        } catch {
+          // best-effort cleanup
+          rmSync(worktree, { recursive: true, force: true });
+        }
+      }
+    });
+  });
+});
+
+describe("resolveProjectNameForFlush (marked case)", () => {
+  it("uses cwd-local flush config projectName when marked", async () => {
+    await withTempDir(async (cwd) => {
+      writeFlushConfig(cwd, "jsonc", JSON.stringify({ projectName: "marked-stable" }));
+      const r = resolveProjectNameForFlush(cwd, true);
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.projectName).toBe("marked-stable");
+        expect(r.source).toBe("flush-config");
+      }
+    });
+  });
+
+  it("does not fall back to env var when marked (config projectName is authoritative)", async () => {
+    process.env.EPIMETHEUS_PROJECT_NAME = "env-should-be-ignored";
+    await withTempDir(async (cwd) => {
+      writeFlushConfig(cwd, "json", JSON.stringify({ projectName: "from-config" }));
+      const r = resolveProjectNameForFlush(cwd, true);
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.projectName).toBe("from-config");
+        expect(r.source).toBe("flush-config");
+      }
+    });
+  });
+
+  it("fails closed when marked but cwd no longer exists", () => {
+    const r = resolveProjectNameForFlush("/nonexistent/path/abc", true);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/cwd .* no longer exists/);
+  });
+
+  it("fails closed when marked and cwd-local config is missing", async () => {
+    await withTempDir(async (cwd) => {
+      // No flush config written.
+      const r = resolveProjectNameForFlush(cwd, true);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/marked .* using project-local flush config/);
+    });
+  });
+
+  it("fails closed when marked and cwd-local config is invalid (missing projectName)", async () => {
+    await withTempDir(async (cwd) => {
+      writeFlushConfig(cwd, "jsonc", JSON.stringify({ other: "x" }));
+      const r = resolveProjectNameForFlush(cwd, true);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/invalid/);
+    });
+  });
+
+  it("fails closed when marked and no cwd-local config even though an ancestor has one (no ancestor walk)", async () => {
+    await withTempDir(async (dir) => {
+      const ancestor = join(dir, "ancestor");
+      mkdirSync(ancestor, { recursive: true });
+      writeFlushConfig(ancestor, "jsonc", JSON.stringify({ projectName: "ancestor-name" }));
+      const child = join(ancestor, "child");
+      mkdirSync(child, { recursive: true });
+      // Marked, cwd-local missing, ancestor has one — must fail closed.
+      const r = resolveProjectNameForFlush(child, true);
+      expect(r.ok).toBe(false);
+    });
+  });
+});
+
+// ============================================
+// resolveProjectNameForFlush (unmarked / undefined tristate)
+// ============================================
+
+describe("resolveProjectNameForFlush (unmarked / undefined)", () => {
+  it("uses cwd-local config projectName when a valid file is present (unmarked)", async () => {
+    await withTempDir(async (cwd) => {
+      writeFlushConfig(cwd, "jsonc", JSON.stringify({ projectName: "stable-name" }));
+      // unmarked = undefined (NOT false) → valid config is used (mirrors session_start auto-mark intent)
+      const r = resolveProjectNameForFlush(cwd, undefined);
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.projectName).toBe("stable-name");
+        expect(r.source).toBe("flush-config");
+      }
+    });
+  });
+
+  it("fails closed when a file is present but invalid (unmarked — no silent fallback)", async () => {
+    // Point 4 regression: an invalid cwd-local flush-config for an unmarked
+    // session must NOT silently fall back to env/git/basename and allow ingestion.
+    await withTempDir(async (cwd) => {
+      writeFlushConfig(cwd, "jsonc", JSON.stringify({ notProjectName: "x" }));
+      const r = resolveProjectNameForFlush(cwd, undefined);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/invalid/);
+    });
+  });
+
+  it("uses default derivation when no file is present (unmarked)", () => {
+    const r = resolveProjectNameForFlush("/some/path/myapp", undefined);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.projectName).toBe("myapp");
+      expect(r.source).toBe("basename");
+    }
+  });
+
+  it("detached (false) ignores a present invalid file (detached wins, not fail-closed)", async () => {
+    await withTempDir(async (cwd) => {
+      writeFlushConfig(cwd, "jsonc", JSON.stringify({ notProjectName: "x" }));
+      // false (detached) → ignore the flush config entirely → default derivation.
+      const r = resolveProjectNameForFlush(cwd, false);
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.projectName).toBe(cwd.split("/").pop() ?? "");
+        expect(r.source).toBe("basename");
+      }
+    });
+  });
+});
+
+// ============================================
+// evaluateActiveSessionFlushState (session_start readiness gate)
+// ============================================
+
+describe("evaluateActiveSessionFlushState", () => {
+  it("detached (false) is always ready, no auto-mark", () => {
+    const r = evaluateActiveSessionFlushState("/anything", { usesProjectFlushConfig: false });
+    expect(r.ready).toBe(true);
+    expect(r.autoMark).toBeUndefined();
+  });
+
+  it("detached (false) is ready even with cwd undefined", () => {
+    const r = evaluateActiveSessionFlushState(undefined, { usesProjectFlushConfig: false });
+    expect(r.ready).toBe(true);
+  });
+
+  it("detached (false) is ready even when cwd has an invalid flush config (detach wins)", async () => {
+    await withTempDir(async (cwd) => {
+      writeFlushConfig(cwd, "jsonc", JSON.stringify({ notProjectName: "x" }));
+      const r = evaluateActiveSessionFlushState(cwd, { usesProjectFlushConfig: false });
+      expect(r.ready).toBe(true);
+      expect(r.autoMark).toBeUndefined();
+      expect(r.reason).toBeUndefined();
+    });
+  });
+
+  it("marked (true) + valid config → ready, no auto-mark", async () => {
+    await withTempDir(async (cwd) => {
+      writeFlushConfig(cwd, "jsonc", JSON.stringify({ projectName: "marked" }));
+      const r = evaluateActiveSessionFlushState(cwd, { usesProjectFlushConfig: true });
+      expect(r.ready).toBe(true);
+      expect(r.autoMark).toBeUndefined();
+    });
+  });
+
+  it("marked (true) + invalid config → failed", async () => {
+    await withTempDir(async (cwd) => {
+      writeFlushConfig(cwd, "jsonc", JSON.stringify({ x: 1 }));
+      const r = evaluateActiveSessionFlushState(cwd, { usesProjectFlushConfig: true });
+      expect(r.ready).toBe(false);
+      expect(r.reason).toMatch(/invalid/);
+      expect(r.configPath).toBeTruthy();
+    });
+  });
+
+  it("marked (true) + no config → failed (required but missing)", async () => {
+    await withTempDir(async (cwd) => {
+      const r = evaluateActiveSessionFlushState(cwd, { usesProjectFlushConfig: true });
+      expect(r.ready).toBe(false);
+      expect(r.reason).toMatch(/no cwd-local flush-config file is present/);
+    });
+  });
+
+  it("marked (true) + cwd does not exist → failed", () => {
+    const r = evaluateActiveSessionFlushState("/nonexistent/abc/xyz", {
+      usesProjectFlushConfig: true,
+    });
+    expect(r.ready).toBe(false);
+    expect(r.reason).toMatch(/cwd .* does not exist/);
+  });
+
+  it("unmarked (undefined) + valid config → ready + autoMark", async () => {
+    await withTempDir(async (cwd) => {
+      writeFlushConfig(cwd, "jsonc", JSON.stringify({ projectName: "auto" }));
+      const r = evaluateActiveSessionFlushState(cwd, null);
+      expect(r.ready).toBe(true);
+      expect(r.autoMark).toBe(true);
+    });
+  });
+
+  it("unmarked (undefined) + invalid config → failed (no silent fallback)", async () => {
+    await withTempDir(async (cwd) => {
+      writeFlushConfig(cwd, "jsonc", JSON.stringify({ nope: true }));
+      const r = evaluateActiveSessionFlushState(cwd, null);
+      expect(r.ready).toBe(false);
+      expect(r.autoMark).toBeUndefined();
+      expect(r.reason).toMatch(/invalid/);
+    });
+  });
+
+  it("unmarked (undefined) + no config → ready (default derivation), no autoMark", async () => {
+    await withTempDir(async (cwd) => {
+      const r = evaluateActiveSessionFlushState(cwd, null);
+      expect(r.ready).toBe(true);
+      expect(r.autoMark).toBeUndefined();
+    });
+  });
+
+  it("unmarked (undefined) + cwd undefined → ready (non-fatal)", () => {
+    const r = evaluateActiveSessionFlushState(undefined, null);
+    expect(r.ready).toBe(true);
+  });
+});
+
+// ============================================
+// Hardened reads: findFlushConfigFile / resolveFlushConfig never throw
+// ============================================
+
+describe("flush-config hardened reads", () => {
+  it("findFlushConfigFile returns the path for a directory named like the config (does not throw)", async () => {
+    await withTempDir(async (cwd) => {
+      // Create a DIRECTORY at the flush-config.jsonc path (existsSync is true
+      // for dirs). findFlushConfigFile must not throw — it returns the path.
+      const dir = join(cwd, ".pi", "epimetheus", "flush-config.jsonc");
+      mkdirSync(dir, { recursive: true });
+      const path = findFlushConfigFile(cwd);
+      expect(path).not.toBeNull();
+      expect(path?.endsWith("flush-config.jsonc")).toBe(true);
+    });
+  });
+
+  it("resolveFlushConfig fails closed (ok:false) for a directory instead of throwing", async () => {
+    await withTempDir(async (cwd) => {
+      const dir = join(cwd, ".pi", "epimetheus", "flush-config.jsonc");
+      mkdirSync(dir, { recursive: true });
+      let threw = false;
+      let r: ReturnType<typeof resolveFlushConfig> | undefined;
+      try {
+        r = resolveFlushConfig(cwd);
+      } catch {
+        threw = true;
+      }
+      expect(threw).toBe(false);
+      expect(r?.ok).toBe(false);
+      if (r && !r.ok) {
+        expect(r.path).toBeTruthy();
+        expect(r.error).toMatch(/could not read|not a regular file/);
+      }
+    });
+  });
+
+  it("findFlushConfigFile returns null when cwd doesn't exist (no throw)", () => {
+    let threw = false;
+    let path: string | null = null;
+    try {
+      path = findFlushConfigFile("/totally/nonexistent/xyz");
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(false);
+    expect(path).toBeNull();
+  });
+});
+
+// ============================================
+// parseAndUpsertSession integration (fail-closed + flush-config)
+// ============================================
+
+describe("parseAndUpsertSession: project-local flush config", () => {
+  const SESSION_ID = "flush-config-session";
+
+  async function setupSession(
+    tmpDir: string,
+    options: { usesProjectFlushConfig?: boolean }
+  ): Promise<void> {
+    // writeSessionFile's `cwd` option lets the session header point at a real
+    // tmpdir (so existsSync checks behave realistically).
+    writeSessionFile(tmpDir, SESSION_ID, {
+      cwd: tmpDir,
+      messages: [{ role: "user", content: "Hello" }],
+      retained: true,
+      usesProjectFlushConfig: options.usesProjectFlushConfig,
+    });
+    await touchPendingFlag(SESSION_ID);
+  }
+
+  afterEach(() => {
+    removePendingFlag(SESSION_ID);
+    clearSessionQueueState(SESSION_ID);
+    cleanupParsedArtifacts(SESSION_ID);
+    rmSync(getMetaPath(SESSION_ID), { force: true });
+    rmSync(getMessagesPath(SESSION_ID), { force: true });
+    rmSync(getSessionStatePath(SESSION_ID), { force: true });
+  });
+
+  it("uses cwd-local flush config projectName when session is marked and config is valid", async () => {
+    await withTempDir(async (tmpDir) => {
+      writeFlushConfig(tmpDir, "jsonc", JSON.stringify({ projectName: "from-flush-config" }));
+      await setupSession(tmpDir, { usesProjectFlushConfig: true });
+
+      const ctx = makeNotifyCtx();
+      const { client, retainCalls } = capturingClient();
+      await parseAndUpsertSession(
+        join(tmpDir, `${SESSION_ID}.jsonl`),
+        SESSION_ID,
+        testConfig,
+        client,
+        ctx
+      );
+
+      expect(retainCalls).toHaveLength(1);
+      const tags = retainCalls[0]?.tags ?? [];
+      expect(tags).toContain("project:from-flush-config");
+      // Pending marker cleared on successful flush.
+      expect(hasPendingFlag(SESSION_ID)).toBe(false);
+    });
+  });
+
+  it("fails closed (no upsert, pending stays queued) when marked and cwd-local config is missing", async () => {
+    await withTempDir(async (tmpDir) => {
+      // No flush config at tmpDir.
+      await setupSession(tmpDir, { usesProjectFlushConfig: true });
+
+      const ctx = makeNotifyCtx();
+      const { client, retainCalls } = capturingClient();
+      await parseAndUpsertSession(
+        join(tmpDir, `${SESSION_ID}.jsonl`),
+        SESSION_ID,
+        testConfig,
+        client,
+        ctx
+      );
+
+      expect(retainCalls).toHaveLength(0); // no upsert
+      expect(hasPendingFlag(SESSION_ID)).toBe(true); // pending left queued
+      const notify = (ctx.ui.notify as ReturnType<typeof mock>).mock.calls.map((c) => String(c[0]));
+      expect(notify.some((m) => m.includes("Flush blocked for session"))).toBe(true);
+      expect(notify.some((m) => m.includes("/hindsight detach-flush-config"))).toBe(true);
+    });
+  });
+
+  it("fails closed (no upsert, pending stays queued) when marked and flush config is invalid", async () => {
+    await withTempDir(async (tmpDir) => {
+      writeFlushConfig(tmpDir, "jsonc", JSON.stringify({ notProjectName: "x" }));
+      await setupSession(tmpDir, { usesProjectFlushConfig: true });
+
+      const ctx = makeNotifyCtx();
+      const { client, retainCalls } = capturingClient();
+      await parseAndUpsertSession(
+        join(tmpDir, `${SESSION_ID}.jsonl`),
+        SESSION_ID,
+        testConfig,
+        client,
+        ctx
+      );
+
+      expect(retainCalls).toHaveLength(0);
+      expect(hasPendingFlag(SESSION_ID)).toBe(true);
+    });
+  });
+
+  it("non-marked session still uses default derivation (basename) and flushes normally", async () => {
+    await withTempDir(async (tmpDir) => {
+      // No flush config, not marked → default derivation uses basename(tmpDir)
+      // (no env var, no .git in the temp dir).
+      await setupSession(tmpDir, { usesProjectFlushConfig: false });
+
+      const ctx = makeNotifyCtx();
+      const { client, retainCalls } = capturingClient();
+      await parseAndUpsertSession(
+        join(tmpDir, `${SESSION_ID}.jsonl`),
+        SESSION_ID,
+        testConfig,
+        client,
+        ctx
+      );
+
+      expect(retainCalls).toHaveLength(1);
+      const tags = retainCalls[0]?.tags ?? [];
+      const expectedBasename = tmpDir.split("/").pop();
+      expect(expectedBasename).toBeTruthy();
+      expect(tags).toContain(`project:${expectedBasename}`);
+      expect(hasPendingFlag(SESSION_ID)).toBe(false);
+    });
+  });
+
+  it("uses cwd-local config projectName per session (flush-pending handles sessions independently)", async () => {
+    // Two sessions in two different cwds, each marked usesProjectFlushConfig
+    // with its own flush config and its own projectName. parseAndUpsertSession
+    // per session must use each cwd's config independently.
+    const SESSION_A = `${SESSION_ID}-a`;
+    const SESSION_B = `${SESSION_ID}-b`;
+
+    try {
+      await withTempDir(async (dirA) => {
+        await withTempDir(async (dirB) => {
+          writeFlushConfig(dirA, "jsonc", JSON.stringify({ projectName: "project-a" }));
+          writeFlushConfig(dirB, "jsonc", JSON.stringify({ projectName: "project-b" }));
+
+          for (const [sid, dir, _name] of [
+            [SESSION_A, dirA, "project-a"],
+            [SESSION_B, dirB, "project-b"],
+          ] as const) {
+            writeSessionFile(dir, sid, {
+              cwd: dir,
+              messages: [{ role: "user", content: "Hello" }],
+              retained: true,
+              usesProjectFlushConfig: true,
+            });
+            await touchPendingFlag(sid);
+          }
+
+          const ctx = makeNotifyCtx();
+          const { client, retainCalls } = capturingClient();
+
+          // Flush each session independently — like flush-pending iterates.
+          await parseAndUpsertSession(
+            join(dirA, `${SESSION_A}.jsonl`),
+            SESSION_A,
+            testConfig,
+            client,
+            ctx
+          );
+          await parseAndUpsertSession(
+            join(dirB, `${SESSION_B}.jsonl`),
+            SESSION_B,
+            testConfig,
+            client,
+            ctx
+          );
+
+          expect(retainCalls).toHaveLength(2);
+          expect(retainCalls[0]?.tags ?? []).toContain("project:project-a");
+          expect(retainCalls[1]?.tags ?? []).toContain("project:project-b");
+          expect(hasPendingFlag(SESSION_A)).toBe(false);
+          expect(hasPendingFlag(SESSION_B)).toBe(false);
+        });
+      });
+    } finally {
+      for (const sid of [SESSION_A, SESSION_B]) {
+        removePendingFlag(sid);
+        clearSessionQueueState(sid);
+        cleanupParsedArtifacts(sid);
+        rmSync(getMetaPath(sid), { force: true });
+        rmSync(getMessagesPath(sid), { force: true });
+        rmSync(getSessionStatePath(sid), { force: true });
+      }
+    }
+  });
+});
+
+// ============================================
+// /hindsight detach-flush-config command
+// ============================================
+
+describe("/hindsight detach-flush-config", () => {
+  const SESSION_ID = "detach-flush-config-session";
+
+  it("appends usesProjectFlushConfig:false (latest-wins overrides true) and marks pending", async () => {
+    // Use the fixtures' createMockPi builder so the command registration captures
+    // the real /hindsight command handler + appendedEntries.
+    const { createMockPi } = await import("./fixtures");
+    const pi = createMockPi();
+    registerCommands(
+      pi,
+      { ...testConfig, apiUrl: "https://x", apiKey: "y", bankId: "b", observationScopes: [] },
+      createMockClient(),
+      () => null as RecallMessageDetails | null,
+      () => null,
+      () => {},
+      () => true,
+      { configPath: undefined, envVars: [], warning: undefined, validationWarnings: [] }
+    );
+
+    const entries = [
+      {
+        type: "custom",
+        customType: "hindsight-meta",
+        data: { retained: true, usesProjectFlushConfig: true },
+      },
+    ];
+    const ctx = {
+      sessionManager: {
+        getSessionId: () => SESSION_ID,
+        getEntries: () => entries,
+        getSessionFile: () => null,
+        getHeader: () => ({ id: SESSION_ID, cwd: tmpdir() }),
+        getSessionName: () => undefined,
+      },
+      ui: {
+        notify: mock(),
+        confirm: mock(async () => true),
+        select: mock(),
+      },
+      signal: undefined,
+      cwd: "/test",
+    } as unknown as ExtensionContext;
+
+    try {
+      // createMockPi exposes `.commands` (a Map) on the ExtensionAPI mock.
+      const cmd = (
+        pi as unknown as {
+          commands: Map<string, { handler: (a: string, ctx: ExtensionContext) => Promise<void> }>;
+        }
+      ).commands.get("hindsight");
+      expect(cmd).toBeDefined();
+      await cmd!.handler("detach-flush-config", ctx);
+
+      // The latest hindsight-meta entry is built by buildMetaUpdate({retained:true,usesProjectFlushConfig:true}, {usesProjectFlushConfig:false}).
+      // Latest value wins → false.
+      const metaEntries = pi.appendedEntries.filter((e) => e.customType === "hindsight-meta");
+      expect(metaEntries.length).toBeGreaterThan(0);
+      const latestData = metaEntries[metaEntries.length - 1]?.data as {
+        retained?: boolean;
+        usesProjectFlushConfig?: boolean;
+      };
+      expect(latestData.retained).toBe(true); // carried forward
+      expect(latestData.usesProjectFlushConfig).toBe(false); // latest-wins overrides true
+
+      // Detach marks the session pending for a re-flush (project tag may change).
+      expect(hasPendingFlag(SESSION_ID)).toBe(true);
+
+      // The notification makes clear the file is NOT deleted.
+      const notify = (ctx.ui.notify as ReturnType<typeof mock>).mock.calls.map((c) => String(c[0]));
+      expect(notify.some((m) => m.includes("NOT deleted"))).toBe(true);
+    } finally {
+      removePendingFlag(SESSION_ID);
+      clearSessionQueueState(SESSION_ID);
+    }
+  });
+
+  it("bails cleanly when the user declines confirmation", async () => {
+    const { createMockPi } = await import("./fixtures");
+    const pi = createMockPi();
+    registerCommands(
+      pi,
+      { ...testConfig, apiUrl: "https://x", apiKey: "y", bankId: "b", observationScopes: [] },
+      createMockClient(),
+      () => null as RecallMessageDetails | null,
+      () => null,
+      () => {},
+      () => true,
+      { configPath: undefined, envVars: [], warning: undefined, validationWarnings: [] }
+    );
+
+    const ctx = {
+      sessionManager: {
+        getSessionId: () => SESSION_ID,
+        getEntries: () => [
+          {
+            type: "custom",
+            customType: "hindsight-meta",
+            data: { retained: true, usesProjectFlushConfig: true },
+          },
+        ],
+        getSessionFile: () => null,
+        getHeader: () => ({ id: SESSION_ID, cwd: tmpdir() }),
+        getSessionName: () => undefined,
+      },
+      ui: {
+        notify: mock(),
+        confirm: mock(async () => false), // decline
+        select: mock(),
+      },
+      signal: undefined,
+      cwd: "/test",
+    } as unknown as ExtensionContext;
+
+    try {
+      const cmd = (
+        pi as unknown as {
+          commands: Map<string, { handler: (a: string, ctx: ExtensionContext) => Promise<void> }>;
+        }
+      ).commands.get("hindsight");
+      await cmd!.handler("detach-flush-config", ctx);
+      expect(pi.appendedEntries.filter((e) => e.customType === "hindsight-meta")).toHaveLength(0);
+      expect(hasPendingFlag(SESSION_ID)).toBe(false);
+      const notify = (ctx.ui.notify as ReturnType<typeof mock>).mock.calls.map((c) => String(c[0]));
+      expect(notify.some((m) => m.includes("not detached"))).toBe(true);
+    } finally {
+      removePendingFlag(SESSION_ID);
+      clearSessionQueueState(SESSION_ID);
+    }
+  });
+
+  it("remains available when not ready (failed/not-ready state) and clears the flush latch; does NOT re-enable tools if another degraded cause still applies", async () => {
+    // Point 3: detach-flush-config is a recovery command that must remain
+    // available even when isReady() returns false (NOT in
+    // OPERATIONAL_SUBCOMMANDS). It clears the per-session flush latch. But
+    // detach does NOT mark the extension operational if another degraded cause
+    // still applies — here startup has not been latched (server degraded), so
+    // tools stay hidden even after detach clears the project-local failure.
+    const { createMockPi } = await import("./fixtures");
+    const {
+      setActiveSessionFlushReady,
+      isActiveSessionFlushReady,
+      resetStartupReady,
+      resetRegisteredHindsightTools,
+    } = await import("../src/runtime-state");
+    const pi = createMockPi();
+    // isReady returns false (simulating the operational-command gate blocked).
+    registerCommands(
+      pi,
+      { ...testConfig, apiUrl: "https://x", apiKey: "y", bankId: "b", observationScopes: [] },
+      createMockClient(),
+      () => null as RecallMessageDetails | null,
+      () => null,
+      () => {},
+      () => false, // not ready
+      { configPath: undefined, envVars: [], warning: undefined, validationWarnings: [] }
+    );
+
+    // startup NOT latched (another degraded cause: server unreachable/incompat).
+    resetStartupReady();
+    // Simulate the failed active-session flush-config state from session_start.
+    setActiveSessionFlushReady(false);
+    expect(isActiveSessionFlushReady()).toBe(false);
+
+    const ctx = {
+      sessionManager: {
+        getSessionId: () => SESSION_ID,
+        getEntries: () => [
+          {
+            type: "custom",
+            customType: "hindsight-meta",
+            data: { retained: true, usesProjectFlushConfig: true },
+          },
+        ],
+        getSessionFile: () => null,
+        getHeader: () => ({ id: SESSION_ID, cwd: tmpdir() }),
+        getSessionName: () => undefined,
+      },
+      ui: {
+        notify: mock(),
+        confirm: mock(async () => true),
+        select: mock(),
+      },
+      signal: undefined,
+      cwd: "/test",
+    } as unknown as ExtensionContext;
+
+    try {
+      const cmd = (
+        pi as unknown as {
+          commands: Map<string, { handler: (a: string, ctx: ExtensionContext) => Promise<void> }>;
+        }
+      ).commands.get("hindsight");
+      // detach-flush-config must NOT be blocked by the not-ready gate (it's the
+      // recovery command). It runs and writes metadata despite isReady()=false.
+      await cmd!.handler("detach-flush-config", ctx);
+
+      const metaEntries = pi.appendedEntries.filter((e) => e.customType === "hindsight-meta");
+      expect(metaEntries.length).toBeGreaterThan(0);
+      const latestData = metaEntries[metaEntries.length - 1]?.data as {
+        usesProjectFlushConfig?: boolean;
+      };
+      expect(latestData.usesProjectFlushConfig).toBe(false);
+
+      // Detach clears the failed active-session flush latch (detached wins).
+      expect(isActiveSessionFlushReady()).toBe(true);
+      // But the extension is NOT operational (startup not latched), so tools
+      // must NOT be re-enabled: no setActiveTools call re-adds hindsight_retain.
+      const enableCalls = pi.setActiveToolsCalls.filter((names) =>
+        names.includes("hindsight_retain")
+      );
+      expect(enableCalls.length).toBe(0);
+      expect(hasPendingFlag(SESSION_ID)).toBe(true);
+    } finally {
+      removePendingFlag(SESSION_ID);
+      clearSessionQueueState(SESSION_ID);
+      setActiveSessionFlushReady(true);
+      resetStartupReady();
+      resetRegisteredHindsightTools();
+    }
+  });
+
+  it("re-enables tools when detach clears the flush failure and the extension is otherwise operational", async () => {
+    // When the ONLY degraded cause is the active-session flush config (startup
+    // is latched), detach clears it and the extension becomes operational — so
+    // tools are re-shown (retain visible because the session is retained:true).
+    const { createMockPi } = await import("./fixtures");
+    const {
+      setActiveSessionFlushReady,
+      isActiveSessionFlushReady,
+      markStartupReady,
+      resetStartupReady,
+      resetRegisteredHindsightTools,
+    } = await import("../src/runtime-state");
+    const { registerTools } = await import("../src/tools");
+    const pi = createMockPi();
+    registerCommands(
+      pi,
+      { ...testConfig, apiUrl: "https://x", apiKey: "y", bankId: "b", observationScopes: [] },
+      createMockClient(),
+      () => null as RecallMessageDetails | null,
+      () => null,
+      () => {},
+      () => true,
+      { configPath: undefined, envVars: [], warning: undefined, validationWarnings: [] }
+    );
+    // Register tools so there's something to re-show, and latch startup.
+    registerTools(pi, testConfig, createMockClient());
+    markStartupReady();
+    // Flush config failed (the only degraded cause).
+    setActiveSessionFlushReady(false);
+    expect(isActiveSessionFlushReady()).toBe(false);
+
+    const ctx = {
+      sessionManager: {
+        getSessionId: () => SESSION_ID,
+        getEntries: () => [
+          {
+            type: "custom",
+            customType: "hindsight-meta",
+            data: { retained: true, usesProjectFlushConfig: true },
+          },
+        ],
+        getSessionFile: () => null,
+        getHeader: () => ({ id: SESSION_ID, cwd: tmpdir() }),
+        getSessionName: () => undefined,
+      },
+      ui: {
+        notify: mock(),
+        confirm: mock(async () => true),
+        select: mock(),
+      },
+      signal: undefined,
+      cwd: "/test",
+    } as unknown as ExtensionContext;
+
+    try {
+      const cmd = (
+        pi as unknown as {
+          commands: Map<string, { handler: (a: string, ctx: ExtensionContext) => Promise<void> }>;
+        }
+      ).commands.get("hindsight");
+      await cmd!.handler("detach-flush-config", ctx);
+
+      // Detach clears the flush latch → now operational (startup was latched).
+      expect(isActiveSessionFlushReady()).toBe(true);
+      // Tools re-shown: a setActiveTools call re-adds hindsight_retain
+      // (session is retained:true).
+      const enableCalls = pi.setActiveToolsCalls.filter((names) =>
+        names.includes("hindsight_retain")
+      );
+      expect(enableCalls.length).toBeGreaterThan(0);
+    } finally {
+      removePendingFlag(SESSION_ID);
+      clearSessionQueueState(SESSION_ID);
+      setActiveSessionFlushReady(true);
+      resetStartupReady();
+      resetRegisteredHindsightTools();
+    }
+  });
+});
+
+// ============================================
+// /hindsight config shows session-specific flush config section
+// ============================================
+
+describe("/hindsight config: session-specific flush config section", () => {
+  it("shows resolved and default project name from a real cwd-local flush config", async () => {
+    const { createMockPi } = await import("./fixtures");
+    const pi = createMockPi();
+    registerCommands(
+      pi,
+      { ...testConfig, apiUrl: "https://x", apiKey: "y", bankId: "b", observationScopes: [] },
+      createMockClient(),
+      () => null as RecallMessageDetails | null,
+      () => null,
+      () => {},
+      () => true,
+      { configPath: undefined, envVars: [], warning: undefined, validationWarnings: [] }
+    );
+
+    await withTempDir(async (cwd) => {
+      writeFlushConfig(cwd, "jsonc", JSON.stringify({ projectName: "stable-from-config" }));
+      const notify = mock((_msg: string, _level?: "info" | "warning" | "error") => {});
+      const ctx = {
+        sessionManager: {
+          getSessionId: () => "config-sess",
+          getEntries: () => [
+            {
+              type: "custom",
+              customType: "hindsight-meta",
+              data: { retained: true, usesProjectFlushConfig: true },
+            },
+          ],
+          getSessionFile: () => null,
+          getHeader: () => ({ id: "config-sess", cwd }),
+          getSessionName: () => undefined,
+        },
+        ui: { notify, confirm: mock(), select: mock() },
+        signal: undefined,
+        cwd,
+      } as unknown as ExtensionContext;
+
+      const cmd = (
+        pi as unknown as {
+          commands: Map<string, { handler: (a: string, ctx: ExtensionContext) => Promise<void> }>;
+        }
+      ).commands.get("hindsight");
+      await cmd!.handler("config", ctx);
+      const calls = notify.mock.calls.map((c) => String(c[0]));
+      const section = calls.find((m) => m.includes("== Session-Specific Flush Config =="));
+      expect(section).toBeDefined();
+      expect(section).toContain(`Session cwd: ${cwd}`);
+      expect(section).toContain("usesProjectFlushConfig: true");
+      expect(section).toContain(`Config file:`);
+      expect(section).toContain("flush-config.jsonc");
+      expect(section).toContain("Config projectName: stable-from-config");
+      expect(section).toContain("Resolved project name: stable-from-config (source: flush-config)");
+      expect(section).toContain("Default project name:");
+      // Marked case -> proceed; default case -> also proceed (cwd exists).
+      expect(section).toContain("Flush would proceed: yes");
+    });
+  });
+
+  it("shows blocked resolution when marked and cwd-local config is missing", async () => {
+    const { createMockPi } = await import("./fixtures");
+    const pi = createMockPi();
+    registerCommands(
+      pi,
+      { ...testConfig, apiUrl: "https://x", apiKey: "y", bankId: "b", observationScopes: [] },
+      createMockClient(),
+      () => null as RecallMessageDetails | null,
+      () => null,
+      () => {},
+      () => true,
+      { configPath: undefined, envVars: [], warning: undefined, validationWarnings: [] }
+    );
+
+    await withTempDir(async (cwd) => {
+      // No flush-config written at cwd.
+      const notify = mock((_msg: string, _level?: "info" | "warning" | "error") => {});
+      const ctx = {
+        sessionManager: {
+          getSessionId: () => "config-sess",
+          getEntries: () => [
+            {
+              type: "custom",
+              customType: "hindsight-meta",
+              data: { retained: true, usesProjectFlushConfig: true },
+            },
+          ],
+          getSessionFile: () => null,
+          getHeader: () => ({ id: "config-sess", cwd }),
+          getSessionName: () => undefined,
+        },
+        ui: { notify, confirm: mock(), select: mock() },
+        signal: undefined,
+        cwd,
+      } as unknown as ExtensionContext;
+
+      const cmd = (
+        pi as unknown as {
+          commands: Map<string, { handler: (a: string, ctx: ExtensionContext) => Promise<void> }>;
+        }
+      ).commands.get("hindsight");
+      await cmd!.handler("config", ctx);
+      const calls = notify.mock.calls.map((c) => String(c[0]));
+      const section = calls.find((m) => m.includes("== Session-Specific Flush Config =="));
+      expect(section).toBeDefined();
+      expect(section).toContain(`Config file: (missing)`);
+      expect(section).toContain("Resolved project name: (blocked)");
+      expect(section).toContain("Flush would proceed: no");
+    });
+  });
+});
+
+// ============================================
+// updateSessionMetadata carry-forward of usesProjectFlushConfig
+// ============================================
+
+describe("updateSessionMetadata carry-forward of usesProjectFlushConfig", () => {
+  const SESSION_ID = "carryforward-meta";
+
+  afterEach(() => {
+    rmSync(getSessionStatePath(SESSION_ID), { force: true });
+  });
+
+  it("buildMetaUpdate carries forward existing usesProjectFlushConfig when updating other fields", async () => {
+    const { buildMetaUpdate } = await import("../src/meta");
+    const updated = buildMetaUpdate(
+      { retained: true, usesProjectFlushConfig: true, tags: ["x"] },
+      { retained: true }
+    );
+    expect(updated.usesProjectFlushConfig).toBe(true);
+    expect(updated.retained).toBe(true);
+    // tags should NOT be carried when input updates.tags is undefined? Actually
+    // buildMetaUpdate carries existing tags forward when updates.tags is undefined.
+    // Verify carry-forward keeps tags from existing.
+    expect(updated.tags).toEqual(["x"]);
+  });
+
+  it("updates api call: detach via updateSessionMetadata appends latest-wins false", async () => {
+    const { createMockPi } = await import("./fixtures");
+    const pi = createMockPi();
+    const existing = [
+      {
+        type: "custom",
+        customType: "hindsight-meta",
+        data: { retained: true, usesProjectFlushConfig: true },
+      },
+    ];
+    await updateSessionMetadata(
+      pi as unknown as import("@earendil-works/pi-coding-agent").ExtensionAPI,
+      SESSION_ID,
+      existing,
+      { usesProjectFlushConfig: false },
+      { ...testConfig }
+    );
+    const metaEntries = pi.appendedEntries.filter((e) => e.customType === "hindsight-meta");
+    expect(metaEntries).toHaveLength(1);
+    const data = metaEntries[0]?.data as { retained?: boolean; usesProjectFlushConfig?: boolean };
+    expect(data.retained).toBe(true); // carried forward
+    expect(data.usesProjectFlushConfig).toBe(false); // latest wins
+  });
+
+  it("getHindsightMeta exposes usesProjectFlushConfig", () => {
+    const entries = [
+      {
+        type: "custom",
+        customType: "hindsight-meta",
+        data: { retained: true, usesProjectFlushConfig: true },
+      },
+    ];
+    const meta = getHindsightMeta(entries);
+    expect(meta?.usesProjectFlushConfig).toBe(true);
+  });
+});

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -9,7 +9,14 @@ import type { RecallResponse, ReflectResponse } from "@vectorize-io/hindsight-cl
 import type { HindsightClientWrapper } from "../src/client";
 import type { HindsightConfig } from "../src/config";
 import { clearSessionQueueState, removePendingFlag } from "../src/queue";
-import { isToolEnabled, registerTools, updateRetainToolVisibility } from "../src/tools";
+import {
+  markStartupReady,
+  resetActiveSessionFlushReady,
+  resetRegisteredHindsightTools,
+  resetStartupReady,
+  setActiveSessionFlushReady,
+} from "../src/runtime-state";
+import { isToolEnabled, refreshToolVisibility, registerTools } from "../src/tools";
 import {
   readToolQueueFromDisk,
   setupTempAgentDir,
@@ -117,6 +124,10 @@ afterEach(() => {
   // Clean up any queue files created during tests
   removePendingFlag(TEST_SESSION_ID);
   clearSessionQueueState(TEST_SESSION_ID);
+  // Reset runtime-state latches so tests start/leave operational state clean.
+  resetStartupReady();
+  resetActiveSessionFlushReady();
+  resetRegisteredHindsightTools();
 });
 
 // ============================================
@@ -757,65 +768,94 @@ describe("hindsight_retain context forwarding", () => {
 });
 
 // ============================================
-// updateRetainToolVisibility tests
+// refreshToolVisibility tests
 // ============================================
 
-describe("updateRetainToolVisibility", () => {
-  it("removes hindsight_retain from active tools when not retained", () => {
+describe("refreshToolVisibility", () => {
+  /** Make the extension operational so tools can be shown. */
+  function beOperational(): void {
+    markStartupReady();
+    setActiveSessionFlushReady(true);
+  }
+
+  it("hides ALL hindsight tools when degraded (not operational)", () => {
     const pi = createMockPi();
     registerTools(pi, testConfig, createMockClient());
+    beOperational();
+    // Start operational+retained: all hindsight tools active.
+    refreshToolVisibility(pi, true);
+    expect(pi.getActiveTools()).toContain("hindsight_retain");
+    expect(pi.getActiveTools()).toContain("hindsight_recall");
+    expect(pi.getActiveTools()).toContain("hindsight_reflect");
 
-    // Initially all tools are active
-    const activeBefore = pi.getActiveTools();
-    expect(activeBefore).toContain("hindsight_retain");
-
-    updateRetainToolVisibility(pi, false);
-
-    const activeAfter = pi.getActiveTools();
-    expect(activeAfter).not.toContain("hindsight_retain");
-    // Other hindsight tools should remain
-    expect(activeAfter).toContain("hindsight_recall");
-    expect(activeAfter).toContain("hindsight_reflect");
+    // Flip to degraded: ALL hindsight tools hidden (not just retain).
+    setActiveSessionFlushReady(false);
+    refreshToolVisibility(pi, true);
+    const active = pi.getActiveTools();
+    expect(active).not.toContain("hindsight_retain");
+    expect(active).not.toContain("hindsight_recall");
+    expect(active).not.toContain("hindsight_reflect");
+    expect(active).not.toContain("hindsight_set_extra_context");
+    expect(active).not.toContain("hindsight_get_extra_context");
   });
 
-  it("adds hindsight_retain back when session becomes retained", () => {
+  it("when operational + retained, shows all registered hindsight tools incl retain", () => {
     const pi = createMockPi();
     registerTools(pi, testConfig, createMockClient());
+    beOperational();
 
-    // Remove first
-    updateRetainToolVisibility(pi, false);
-    const activeAfterRemove = pi.getActiveTools();
-    expect(activeAfterRemove).not.toContain("hindsight_retain");
+    refreshToolVisibility(pi, true);
 
-    // Add back
-    updateRetainToolVisibility(pi, true);
-    const activeAfterAdd = pi.getActiveTools();
-    expect(activeAfterAdd).toContain("hindsight_retain");
+    const active = pi.getActiveTools();
+    expect(active).toContain("hindsight_retain");
+    expect(active).toContain("hindsight_recall");
+    expect(active).toContain("hindsight_reflect");
   });
 
-  it("is a no-op when retained=true and tool is already active", () => {
+  it("when operational + not retained, hides only hindsight_retain", () => {
     const pi = createMockPi();
     registerTools(pi, testConfig, createMockClient());
+    beOperational();
 
-    // Tool is active by default
-    const callCountBefore = pi.setActiveToolsCalls.length;
-    updateRetainToolVisibility(pi, true);
+    refreshToolVisibility(pi, false);
 
-    // setActiveTools should not have been called
-    expect(pi.setActiveToolsCalls.length).toBe(callCountBefore);
+    const active = pi.getActiveTools();
+    expect(active).not.toContain("hindsight_retain");
+    // Read-only tools remain available when operational.
+    expect(active).toContain("hindsight_recall");
+    expect(active).toContain("hindsight_reflect");
   });
 
-  it("is a no-op when retained=false and tool is already inactive", () => {
+  it("restores hindsight_retain when transitioning not-retained -> retained while operational", () => {
     const pi = createMockPi();
     registerTools(pi, testConfig, createMockClient());
+    beOperational();
 
-    // Remove first
-    updateRetainToolVisibility(pi, false);
-    const callCountAfterRemove = pi.setActiveToolsCalls.length;
+    refreshToolVisibility(pi, false);
+    expect(pi.getActiveTools()).not.toContain("hindsight_retain");
 
-    // Calling again should be a no-op
-    updateRetainToolVisibility(pi, false);
-    expect(pi.setActiveToolsCalls.length).toBe(callCountAfterRemove);
+    refreshToolVisibility(pi, true);
+    expect(pi.getActiveTools()).toContain("hindsight_retain");
+  });
+
+  it("preserves non-hindsight tools across visibility changes", () => {
+    const pi = createMockPi();
+    // Register an unrelated tool to simulate other extensions/built-ins.
+    (pi as unknown as { registerTool: (t: unknown) => void }).registerTool({
+      name: "other_tool",
+      execute: () => ({}),
+      parameters: {},
+    });
+    registerTools(pi, testConfig, createMockClient());
+    beOperational();
+
+    refreshToolVisibility(pi, false); // hide retain
+    expect(pi.getActiveTools()).toContain("other_tool");
+
+    setActiveSessionFlushReady(false); // degraded
+    refreshToolVisibility(pi, true);
+    expect(pi.getActiveTools()).toContain("other_tool");
+    expect(pi.getActiveTools()).not.toContain("hindsight_retain");
   });
 });
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -5,8 +5,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import {
+  clearProjectNameCache,
   extractParentSessionId,
   extractTextFromContent,
   getBasedir,
@@ -181,62 +182,55 @@ describe("getBasedir", () => {
 });
 
 describe("getProjectName", () => {
-  it("returns EPIMETHEUS_PROJECT_NAME when set", () => {
-    const originalNew = process.env.EPIMETHEUS_PROJECT_NAME;
-    const originalOld = process.env.PI_HINDSIGHT_PROJECT_NAME;
-    process.env.EPIMETHEUS_PROJECT_NAME = "custom-project";
-    try {
-      expect(getProjectName("/home/user/myapp")).toBe("custom-project");
-    } finally {
-      if (originalNew === undefined) delete process.env.EPIMETHEUS_PROJECT_NAME;
-      else process.env.EPIMETHEUS_PROJECT_NAME = originalNew;
-      if (originalOld === undefined) delete process.env.PI_HINDSIGHT_PROJECT_NAME;
-      else process.env.PI_HINDSIGHT_PROJECT_NAME = originalOld;
-    }
+  // Env-var overrides (EPIMETHEUS_PROJECT_NAME / PI_HINDSIGHT_PROJECT_NAME) were
+  // removed because env vars do not track Pi session switching. Default
+  // derivation is git common dir -> basename (cached per cwd).
+  afterEach(() => clearProjectNameCache());
+
+  it("returns cwd basename for a non-git directory", () => {
+    expect(getProjectName("/home/user/myapp")).toBe("myapp");
   });
 
-  it("falls back to legacy PI_HINDSIGHT_PROJECT_NAME when EPIMETHEUS_PROJECT_NAME is unset", () => {
-    const originalNew = process.env.EPIMETHEUS_PROJECT_NAME;
-    const originalOld = process.env.PI_HINDSIGHT_PROJECT_NAME;
-    delete process.env.EPIMETHEUS_PROJECT_NAME;
-    process.env.PI_HINDSIGHT_PROJECT_NAME = "custom-project";
-    try {
-      expect(getProjectName("/home/user/myapp")).toBe("custom-project");
-    } finally {
-      if (originalNew === undefined) delete process.env.EPIMETHEUS_PROJECT_NAME;
-      else process.env.EPIMETHEUS_PROJECT_NAME = originalNew;
-      if (originalOld === undefined) delete process.env.PI_HINDSIGHT_PROJECT_NAME;
-      else process.env.PI_HINDSIGHT_PROJECT_NAME = originalOld;
-    }
-  });
-
-  it("prioritizes EPIMETHEUS_PROJECT_NAME over PI_HINDSIGHT_PROJECT_NAME", () => {
-    const originalNew = process.env.EPIMETHEUS_PROJECT_NAME;
-    const originalOld = process.env.PI_HINDSIGHT_PROJECT_NAME;
-    process.env.EPIMETHEUS_PROJECT_NAME = "new-project";
-    process.env.PI_HINDSIGHT_PROJECT_NAME = "old-project";
-    try {
-      expect(getProjectName("/home/user/myapp")).toBe("new-project");
-    } finally {
-      if (originalNew === undefined) delete process.env.EPIMETHEUS_PROJECT_NAME;
-      else process.env.EPIMETHEUS_PROJECT_NAME = originalNew;
-      if (originalOld === undefined) delete process.env.PI_HINDSIGHT_PROJECT_NAME;
-      else process.env.PI_HINDSIGHT_PROJECT_NAME = originalOld;
-    }
-  });
-
-  it("falls back to cwd basename when neither project-name env var is set", () => {
-    const originalNew = process.env.EPIMETHEUS_PROJECT_NAME;
-    const originalOld = process.env.PI_HINDSIGHT_PROJECT_NAME;
-    delete process.env.EPIMETHEUS_PROJECT_NAME;
-    delete process.env.PI_HINDSIGHT_PROJECT_NAME;
+  it("ignores EPIMETHEUS_PROJECT_NAME (env overrides removed)", () => {
+    process.env.EPIMETHEUS_PROJECT_NAME = "ignored-project";
     try {
       expect(getProjectName("/home/user/myapp")).toBe("myapp");
     } finally {
-      if (originalNew === undefined) delete process.env.EPIMETHEUS_PROJECT_NAME;
-      else process.env.EPIMETHEUS_PROJECT_NAME = originalNew;
-      if (originalOld === undefined) delete process.env.PI_HINDSIGHT_PROJECT_NAME;
-      else process.env.PI_HINDSIGHT_PROJECT_NAME = originalOld;
+      delete process.env.EPIMETHEUS_PROJECT_NAME;
     }
+  });
+
+  it("ignores legacy PI_HINDSIGHT_PROJECT_NAME (env overrides removed)", () => {
+    process.env.PI_HINDSIGHT_PROJECT_NAME = "ignored-legacy";
+    try {
+      expect(getProjectName("/home/user/myapp")).toBe("myapp");
+    } finally {
+      delete process.env.PI_HINDSIGHT_PROJECT_NAME;
+    }
+  });
+
+  it("derives the git common dir name when `<cwd>/.git` exists (single repo)", () => {
+    // Use a real temp dir with a .git directory so deriveGitProjectName runs.
+    // git rev-parse from outside a repo returns non-zero, so we only assert
+    // the basename fallback path here; the git-common-dir derivation is
+    // covered by flush-config.test.ts real-git worktree tests.
+    const dir = join(tmpdir(), `epimetheus-utils-${Date.now()}`);
+    mkdirSync(join(dir, ".git"), { recursive: true });
+    try {
+      // No git repo config -> git fails -> basename fallback.
+      expect(getProjectName(dir)).toBe(basename(dir));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("caches the result per cwd (same cwd returns same name without re-deriving)", () => {
+    expect(getProjectName("/home/user/cached-app")).toBe("cached-app");
+    expect(getProjectName("/home/user/cached-app")).toBe("cached-app");
+  });
+
+  it("returns a different name for a different cwd", () => {
+    expect(getProjectName("/home/user/app-a")).toBe("app-a");
+    expect(getProjectName("/home/user/app-b")).toBe("app-b");
   });
 });


### PR DESCRIPTION
Add cwd-local flush-config support for session-specific project names. Marked sessions now require the project-local config at flush time and fail closed when it is missing or invalid.

Add /hindsight detach-flush-config as a recovery command, extend config diagnostics, and derive default project names from the git common dir before falling back to basename(cwd).

Document the config flow and update tests for cwd-specific session behavior.