### PR TITLE
feat(flush-config): add project-local overrides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # General Instructions
 - Use conventional commit messages, always include a scope
 - Prefer keeping commit subjects under ~50 chars and body lines at ~72 chars; commitlint enforces 72/72
-- Update CHANGELOG.md under the Pending section for any user-facing or internal changes
+- Update CHANGELOG.md under the Pending section for any user-facing or internal changes. Since changes land on a feature branch before main, describe fixes relative to main — do not include fixes to issues that were never on main in the changelog.
 - Do not use import aliases unless there is genuine naming conflict
 - The function that has enough context to produce the most accurate, non-duplicated user message should notify. Lower layers should return enough information to make that possible.
 - Update the ToC when adding new documentation headings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## Pending
 
+### Features
+
+- **Project-local config** — Added optional project-name overrides via `<cwd>/.pi/epimetheus/config.jsonc|.json` (`.jsonc` wins; no ancestor walk). The schema currently supports only `projectName`. Sessions started with a valid project-local config are marked to keep using it; marked sessions and sessions with an invalid present config fail closed instead of silently falling back. Unmarked sessions continue with the default project-name derivation. Flush tags and `{project}` auto-recall tags/tag groups use the same resolved project name.
+- **Git worktree config fallback** — Project-config lookup falls back to the git commondir's parent (the main repo root) when a cwd has no `.pi/epimetheus/config.*` of its own. Git worktrees share the main repo's project config without needing their own `.pi` directory, while cwd-local config still takes precedence. No ancestor walk beyond this git-aware fallback is performed.
+- **`/hindsight detach-project-name`** — Added a recovery command to stop requiring the project-local config for the current session and use the cwd-derived project name for future flushes and auto-recall. It is blocked when the degraded cause is invalid global config or server/version issues (not a project-name failure).
+- **Project-name diagnostics** — `/hindsight config` now reports the session cwd, metadata flag, config-file presence, resolved project name, and project-name resolution blocks.
+- **Degraded-mode block reasons** — Manual operational slash commands (`/hindsight flush`, `flush-pending`, `parse-and-upsert-session`, `toggle-retain`, `tag`, `remove-tag`, `set-extra-context`) now surface the specific degraded cause (unreachable/incompatible server, or the active session's project-name failure) on every attempt instead of a one-time generic catch-all. Diagnostic/display/recovery commands remain available.
+- **Compact project-name diagnostics** — `/hindsight config`'s `Session-Specific Project Config` section now shows the project-local config (file/presence/status + loaded `projectName` or invalid reason) in the same style as the main config source, and a one-line `Project name: <resolved> (source: <source>)` resolution, keeping the cwd-local/no-ancestor-walk note concise.
+- **Default project names now prefer the git common dir** — Unmarked sessions derive project names as git common dir → `basename(cwd)`, so worktrees share the main repo name. For git submodules (and their worktrees), the commondir basename is used directly (e.g. `<super>/.git/modules/<name>` → `name`), so submodule worktrees share the submodule name instead of resolving to `modules`. Project-name environment-variable overrides were removed because they do not follow Pi session switching.
+
+### Fixed
+
+- **Degraded mode is more consistent** — Config/server/startup failures and active-session project-name failures block operational tools, queue writes, network work, and operational slash commands while keeping diagnostics, display controls, recall rendering/filtering, and recovery commands available. When auto-recall is skipped due to a project-name resolution failure, the cached recall details from a previous turn are cleared so `/hindsight popup` and status don't show a stale recall for the skipped prompt. `enabled: false` remains a full global kill switch.
+
+### Internal
+
+- Added a centralized project-local config resolver and integrated project-aware project-name resolution into auto-recall, session, and tool flush paths.
+- Updated session parsing/upsert paths to use pre-resolved project names and restore pending claims on fail-closed project-name errors.
+- Expanded test fixtures for realistic session cwd and project-local config metadata cases.
+- Added typed degraded-mode reason causes so recovery paths do not parse human-readable reason text.
+
+### Documentation
+
+- Documented project-local config, resolution order, fail-closed behavior, and `/hindsight detach-project-name` in `docs/reference.md`.
+- Added `docs/architecture/config.md` and moved ingestion architecture docs to `docs/architecture/ingestion.md`.
+
 ## 0.5.0
 
 ### Breaking Changes
@@ -78,7 +104,7 @@ User note:
 
 ### Documentation
 
-- Added `docs/ARCHITECTURE.md` documenting the queue protocol, claim/recovery flow, live session state, parsed artifacts, and normal flush authority model.
+- Added `docs/architecture/ingestion.md` documenting the queue protocol, claim/recovery flow, live session state, parsed artifacts, and normal flush authority model.
 
 ### Internal
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ Status: I would call this beta level software, though I am focusing on stability
 - [Local Quickstart](#local-quickstart)
 - [Configuration](#configuration)
   - [Example Configuration](#example-configuration)
+- [Project-local Settings](#project-local-settings)
 - [Recommended User Best Practices](#recommended-user-best-practices)
 - [Caveats](#caveats)
 - [FAQ](#faq)
 
 See [Reference](docs/reference.md) for detailed configuration, tools, commands, and operational details.
+See [Architecture](docs/architecture/ingestion.md) and [Config Architecture](docs/architecture/config.md) for implementation design notes.
 See [Comparison](docs/comparison.md) for how this plugin compares to others and the design decisions behind it.
 
 # Key Features
@@ -58,7 +60,7 @@ Additionally:
 - Avoids breaking prompt caching - recall messages are appended at the end of the context for a single turn only; the canonical conversation history (which determines cache validity) grows normally with each turn, so caching should work as expected
 - Marks sessions as dirty on `message_end` so content is retained even if Hindsight is temporarily down; pending markers persist until the next successful flush
 - Properly handles forking when ingesting full sessions: forks will not duplicate parent content and will only contain new content
-- Provides automatic tags: session id, parent session id, cwd, basedir (cwd basename), project (configurable name, falls back to basedir), store method (tool or auto), and any configured tags like `harness:pi` (default)
+- Provides automatic tags: session id, parent session id, cwd, basedir (cwd basename), project (derived per session), store method (tool or auto), and any configured tags like `harness:pi` (default)
 - Allows choosing what content to retain and stripping unnecessary fields to reduce tokens/cost
 
 # Local Quickstart
@@ -151,6 +153,11 @@ Configuration is stored in `<getAgentDir()>/epimetheus/config.json` or `config.j
   // "requireExtraContextBeforeFlush": true,
 }
 ```
+
+# Project-local Settings
+Project-local settings live under a project cwd instead of the global epimetheus config. Currently, the only supported project-local setting is a `projectName` override used for project-scoped flushing and auto-recall. See [Project-local Settings](docs/reference.md#project-local-settings) for more details.
+
+If you need other project-local settings, please open an issue describing the setting and why it needs to vary by project.
 
 # Recommended User Best Practices
 ## Initially

--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -1,0 +1,116 @@
+# Config Architecture
+
+This document explains the high-level configuration and readiness flow. For the full setting reference, see [Reference](../reference.md).
+
+## Goals
+
+Config handling is designed to fail closed for writes while keeping enough of the extension alive for diagnosis and safe cleanup.
+
+- Invalid or unsafe config must not retain to the wrong bank, server, project name, or tag set.
+- Existing `hindsight-recall` messages should not leak into model context just because config is broken.
+- Users should still be able to inspect what is wrong and recover without hand-editing session files where possible.
+
+## Modes
+
+### Globally disabled mode (`enabled: false`)
+
+`enabled: false` is a global kill switch, not the same thing as degraded mode. In this mode epimetheus does not register slash commands, tools, a client, or operational lifecycle handlers.
+
+The only behavior kept is lightweight session hygiene:
+
+- existing `hindsight-recall` messages are filtered from LLM context;
+- the recall renderer still hides or displays old persisted recalls according to display settings.
+
+### Degraded mode
+
+Degraded mode is the single fail-closed operational state for any condition that makes Hindsight unsafe or unavailable while the extension remains enabled. It is not only a startup state: epimetheus can become operational after a successful check, then later re-enter degraded mode if a subsequent session start observes an unhealthy/incompatible server or an invalid project-local config for the current session.
+
+Conditions that enter or re-enter degraded mode include:
+
+- invalid global config;
+- unreachable Hindsight server;
+- incompatible or unavailable server version;
+- the current session's project-local config is required but missing/invalid;
+- the current session's project-local config exists but does not contain a valid non-empty `projectName`.
+
+All degraded causes have the same behavior: operational tools, retention, recall, flushes, queue writes, and network work are blocked. This applies both before the first successful startup and after a previously operational session later becomes unsafe. This prevents retaining under a wrong destination, server, project identity, or tag set.
+
+Lightweight diagnostics and recovery remain available:
+
+- `/hindsight status`
+- `/hindsight config`
+- `/hindsight toggle-display`
+- `/hindsight detach-project-name`
+- old `hindsight-recall` filtering/rendering
+
+`/hindsight detach-project-name` is a recovery command, not an operational command: it can clear a project-local config requirement for the current session, but it does not make the extension operational if another degraded-mode cause still applies.
+
+## Global config
+
+The global extension config lives under `<getAgentDir()>/epimetheus/config.jsonc` or `config.json`. When both files exist, `config.jsonc` has priority over `config.json`. Environment variables override global file/default values.
+
+Global config owns the Hindsight destination and ingestion policy: API URL/key, bank ID, retained content shape, stripping, constant tags, observation scopes, tools, auto-retain/recall/flush behavior, and status/display defaults.
+
+## Project Local Configuration
+Project-local config is intentionally not a general overlay for all settings. Settings that affect where or how data is flushed remain global for now to avoid surprising cross-session behavior.
+
+The current recommended way to work with different banks for totally isolated work, for example, is to have a separate pi wrapper script for each use case that sets the configuration environment variables. For work like this, it is probably better for you to use a separate session directory or possibly even a totally different pi coding agent directory.
+
+### Project-local config
+
+Project-local config is only for a session-specific project-name override used by project-aware flush tags and `{project}` auto-recall filters.
+
+When both files exist, `config.jsonc` has priority over `config.json`:
+
+```text
+<session-cwd>/.pi/epimetheus/config.jsonc
+<session-cwd>/.pi/epimetheus/config.json
+```
+
+The cwd is checked first. When `<cwd>/.git` exists and the git commondir resolves to a different directory, the commondir's parent (the main repo root) is checked as a fallback. This lets git worktrees share the main repo's project config without needing their own `.pi` directory, while still allowing worktrees to override with a cwd-local config. No ancestor walk beyond this git-aware fallback is performed.
+
+Users who need subproject identity can run Pi from that subdirectory and put a `.pi/epimetheus/config.jsonc` there.
+
+Initial schema:
+
+```jsonc
+{
+  "projectName": "my-stable-project-name"
+}
+```
+
+When a session starts in a cwd with a valid project config, epimetheus records append-only session metadata:
+
+```jsonc
+{
+  "usesProjectConfig": true
+}
+```
+
+The session metadata stores only the boolean. It does not store the config path or project name. On future project-aware operations, the project name is resolved again from the session file header `cwd`.
+
+If the latest metadata says `usesProjectConfig: true`, that session requires a cwd-local project config with a valid non-empty `projectName`. If the cwd is gone, the file is missing/invalid, or the file is valid JSON but does not specify a valid `projectName`, project-aware operations fail closed: pending flush work remains queued and auto-recall is skipped. `/hindsight detach-project-name` appends `usesProjectConfig: false` for the current session; it does not delete the file.
+
+If the session is detached or never used project-local config, the default project name is derived as:
+
+1. git common-dir repo name when `<cwd>/.git` exists, so worktrees share the main repo name;
+2. `basename(cwd)`.
+
+Environment-variable project-name overrides are intentionally not part of the resolution model because they do not follow Pi session switching across directories.
+
+## Flush-time resolution
+
+Flushes use the target session file's header `cwd`, not process cwd and not necessarily the active TUI session cwd. This matters for `/hindsight flush-pending`, which may process sessions from different directories in one command.
+
+Session upserts resolve project identity at flush time. Auto-recall resolves the same project identity before each turn for `{project}` filters. If a required project-local config is missing/invalid, or if a present project-local config is invalid for an unmarked session, the active session enters degraded mode: flush work is blocked and left queued, auto-recall is skipped, and the retain tool is hidden. Tool retain queue entries snapshot their tags and observation scopes when queued, so the current session's config must be valid before the retain tool can create entries.
+
+## Why keep lightweight mode
+
+Even when Hindsight operations are unavailable, epimetheus still protects existing sessions:
+
+- old persisted recall entries are filtered before model context;
+- old recall UI rendering remains controlled instead of showing raw custom-message data;
+- users can run diagnostics to see whether the failure is global config, project-local config, server reachability, or version compatibility;
+- recovery commands can detach a session from a missing/broken project-local config.
+
+The goal is to fail closed for writes, not to leave users blind.

--- a/docs/architecture/ingestion.md
+++ b/docs/architecture/ingestion.md
@@ -1,6 +1,6 @@
-# Architecture
+# Ingestion Architecture
 
-This document explains epimetheus' ingestion architecture: how session content, explicit tool retains, and metadata move from Pi session state into Hindsight.
+This document explains epimetheus' ingestion architecture: how session content, explicit tool retains, and metadata move from Pi session state into Hindsight. For config/readiness behavior, see [Config Architecture](config.md).
 
 ## Goals
 
@@ -270,7 +270,7 @@ Config/env-derived ingestion metadata is rebuilt whenever an upsert happens inst
 - final Hindsight context from current `hindsightContextPrefix`, session name, and extra context;
 - constant tags from current config;
 - structural tags such as `session:<id>`, `cwd:<path>`, `basedir:<name>`, `store_method:auto`, and `parent:<id>`;
-- project tag/name, including the current `EPIMETHEUS_PROJECT_NAME` override when set, otherwise derived from the session cwd;
+- project tag/name, resolved for the target session at flush time: project-local config `projectName` when required/present, otherwise git common-dir basename or cwd basename;
 - observation scopes from current config, with placeholders expanded using the session ID, parent session ID, session cwd, basedir, and project name;
 - entities from current config.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -22,6 +22,7 @@ Detailed configuration, tools, commands, and operational details for epimetheus.
     - [entities](#entities)
   - [observationScopes](#observationscopes)
     - [Project scope for relocatable projects](#project-scope-for-relocatable-projects)
+  - [Project-local Settings](#project-local-settings)
   - [autoRecallTags](#autorecalltags)
   - [Project-specific Recall and Storage](#project-specific-recall-and-storage)
   - [Environment Variables](#environment-variables)
@@ -375,14 +376,14 @@ Using custom scope groups is recommended. Most users should combine a per-user s
 | `{parent}` | `parent:<parentId>` | Cross-fork observations (falls back to session ID if no parent) |
 | `{cwd}` | `cwd:<path>` | Per-directory observations |
 | `{basedir}` | `basedir:<basename>` | Per-directory-name observations |
-| `{project}` | `project:<name>` | Per-project observations (name from `EPIMETHEUS_PROJECT_NAME` or cwd basename) |
+| `{project}` | `project:<name>` | Per-project observations (git common-dir name when available, otherwise cwd basename; can override with project-local config `projectName`) |
 
 Placeholders must be used as standalone tags — e.g. `["{session}"]` not `["{session}:extra"]`. Non-exact placeholder usage will produce a config warning.
 
 **Choosing your scopes:**
 - **Per-session observations** (`["{session}"]`) — facts within a single session only — this is rarely useful unless you frequently resume the same session over and over. In practice, you'll get more value from:
 - **Per-user** (`["user:<me>"]`) — facts that span all your sessions/documents and memories stored manually with `hindsight_retain` tool, even across different harnesses. Add `"user:<me>"` to `constantTags` and use it as a scope. This is the most broadly useful scope.
-- **Per-project** (`["{project}"]`) — facts about a specific project, independent of directory. The project tag defaults to the cwd basename but can be overridden with `EPIMETHEUS_PROJECT_NAME`. This is ideal when a project might change directories or have multiple separate worktrees — observations stay linked to the project identity rather than a specific path. See [Project scope for relocatable projects](#project-scope-for-relocatable-projects).
+- **Per-project** (`["{project}"]`) — facts about a specific project, independent of directory. The project tag defaults to the git common-dir name when available (so worktrees get the same project name), otherwise the cwd basename. It can be overridden per project with [project-local settings](#project-local-settings). This is ideal over `{cwd}` when a project might change directories or have multiple separate worktrees — observations stay linked to the project identity rather than a specific path. See [Project scope for relocatable projects](#project-scope-for-relocatable-projects).
 - **Per-directory** (`["{cwd}"]`) — facts about a specific project/codebase, consolidated across all sessions in that directory
 - **Per-basedir** (`["{basedir}"]`) — facts scoped by directory name (basename). Less precise than `{cwd}` but works across different parent paths with the same directory name
 - **Per-harness** (`["harness:pi"]`) — facts that span all pi sessions (included as a default constant tag)
@@ -394,29 +395,22 @@ Recommended example — Per-user scope plus per-project scope:
   "constantTags": ["harness:pi", "user:<me>"],
   "observationScopes": [
     ["user:<me>"],   // observations across all your sessions
-    ["{project}"]     // observations scoped to this project (basedir or EPIMETHEUS_PROJECT_NAME)
+    ["{project}"]     // observations scoped to this project
   ]
 }
 ```
 
 This creates two consolidation passes:
 1. One for facts that span all your sessions (even across different harnesses, assuming you've also tagged those documents with `user:<me>`)
-2. One for facts specific to the current project (identified by `EPIMETHEUS_PROJECT_NAME` or the cwd basename)
+2. One for facts specific to the current project (identified by project-local config when used, otherwise git common-dir name or cwd basename)
 
 > **Note on duplicate observations:** When you have multiple scopes in `observationScopes`, the same underlying memories may produce duplicate observations — one per scope. For example, a project-scoped observation and a global (per-user) observation may contain overlapping information. To avoid recalling duplicates, you should filter auto-recalled observations to the scope you currently want (e.g., use `autoRecallTags: ["{project}"]` for project-specific recall or `autoRecallTags: ["user:<me>"]` for global recall). Alternatively, if you will never need to switch between scopes, you can limit `observationScopes` to just one entry.
 
 ### Project scope for relocatable projects
 
-Use `{project}` when you want observations tied to a project identity rather than a specific directory path. By default `{project}` expands to the cwd basename, so observations automatically follow the project across directory moves (e.g., `~/projects/myapp` → `~/work/myapp` — the `cwd` tag changes but the `project` tag stays the same).
+Use `{project}` when you want observations tied to a project identity rather than a specific directory path. By default `{project}` expands to the git common-dir name when available, otherwise the cwd basename, so normal git worktrees share the main repo project name automatically.
 
-You only need to set `EPIMETHEUS_PROJECT_NAME` when you have multiple directories with the same basename that should have separate observations (e.g. `~/work/myapp` vs. `~/personal/myapp`) or if you are using separate worktree folders and want the project name to be the same for both.
-
-Set `EPIMETHEUS_PROJECT_NAME` per directory in, e.g. `.env` with [direnv](https://direnv.net/) or [mise](https://mise.jdx.dev/):
-
-```envrc
-# In .env per project directory (loaded by direnv or mise):
-EPIMETHEUS_PROJECT_NAME=myapp
-```
+Use [project-local settings](#project-local-settings) when the derived project name is not the identity you want to retain under, such as when multiple unrelated directories share the same basename or when you want to rename the project identity without moving the directory.
 
 ```jsonc
 {
@@ -429,13 +423,13 @@ EPIMETHEUS_PROJECT_NAME=myapp
 ```
 
 **When to use `{project}` vs. `{cwd}` vs. `{basedir}`:**
-- `{project}` (recommended) — Observations scoped by project name (cwd basename by default). Automatically follows directory moves. Set `EPIMETHEUS_PROJECT_NAME` to disambiguate directories with the same basename or to give separate worktree directories the same project name.
+- `{project}` (recommended) — Observations scoped by project name (git common-dir name when available, otherwise cwd basename). Use project-local config `projectName` to override the retained project identity for a project.
 - `{cwd}` — Use when you want observations tied to an exact directory path. Different directories with the same basename produce separate observations.
 - `{basedir}` — Use when you want observations grouped by directory name regardless of parent path. All directories named `myapp` share observations.
 
-> **Note:** Since `basedir:` and `project:` tags are generated at retain time, re-parsing and re-ingesting a session (via `/hindsight parse-and-upsert-session`) will use the *current* basedir or `EPIMETHEUS_PROJECT_NAME`. This means you can change the project identity of an existing session by updating the env var and re-ingesting — useful for correcting or migrating project names after the fact. The `cwd:` tag is fixed from the session header and does not change on re-parse (unless you manually change it).
+> **Note:** Since `basedir:` and `project:` tags are generated at retain time, re-parsing and re-ingesting a session (via `/hindsight parse-and-upsert-session`) will use the current project resolution for that session. This means you can change the retained project identity of an existing session by adding or editing its project-local config and re-ingesting. The `cwd:` tag is fixed from the session header and does not change on re-parse (unless you manually change it).
 >
-> The `cwd:` tag and `{cwd}`/`{basedir}`/`{project}` placeholders (in both observation scopes and auto-recall tags) use the session's cwd from the session header — the directory the session was first created in.
+> The `cwd:` tag and `{cwd}`/`{basedir}`/`{project}` placeholders use the session's cwd from the session header — the directory the session was first created in.
 
 Full example with all available scopes:
 ```jsonc
@@ -444,7 +438,7 @@ Full example with all available scopes:
   "observationScopes": [
     ["user:<me>"],    // observations across all your sessions
     ["harness:pi"],   // observations across all pi sessions
-    ["{project}"],    // observations scoped to this project (EPIMETHEUS_PROJECT_NAME or basedir)
+    ["{project}"],    // observations scoped to this project
     ["{cwd}"],        // observations scoped to this exact directory path
     ["{basedir}"],    // observations scoped to this directory name
     ["{session}"],    // observations scoped to this session only (rarely needed)
@@ -459,6 +453,44 @@ export EPIMETHEUS_OBSERVATION_SCOPES='[["{session}","user:alice"],["project:foo"
 ```
 
 Note: This is currently a config-only setting and not exposed as a parameter on the `hindsight_retain` tool. The configured scope applies to all retains (both auto and tool-initiated).
+
+## Project-local Settings
+
+Project-local settings live under the project cwd instead of in the global epimetheus config. The only project-local setting currently supported is `projectName`.
+
+If you need other project-local settings, please open an issue describing the setting and why it needs to vary by project.
+
+See [Config Architecture](architecture/config.md#project-local-config) for the high-level design. This subsection is for user-facing instructions.
+
+**File location** (`.jsonc` has priority over `.json`):
+
+- `<cwd>/.pi/epimetheus/config.jsonc`
+- `<cwd>/.pi/epimetheus/config.json`
+- `<git-commondir-parent>/.pi/epimetheus/config.jsonc` (fallback for git worktrees)
+- `<git-commondir-parent>/.pi/epimetheus/config.json` (fallback for git worktrees)
+
+The cwd is checked first. When `<cwd>/.git` exists and the git commondir resolves to a different directory, the commondir's parent (the main repo root) is checked as a fallback. This lets git worktrees share the main repo's project config without needing their own `.pi` directory. No ancestor walk beyond this git-aware fallback is performed.
+
+**Schema**:
+
+```jsonc
+{
+  "projectName": "my-stable-project-name"
+}
+```
+
+**Project-name resolution order**:
+
+1. **If the session is marked `usesProjectConfig: true`**, the project config file **must** exist and contain a valid non-empty `projectName` (checked in cwd first, then the git commondir parent), or project-aware operations fail closed — pending flush work is left queued and auto-recall is skipped.
+2. **If the session is unmarked and a project config file is present but invalid**, the flush **fails closed** instead of silently falling back to a derived project name.
+3. **Otherwise**:
+   - project-local `projectName` if specified (cwd first, then git commondir parent)
+   - if `<cwd>/.git` exists, the git common dir is resolved so worktrees share the main repo name (e.g. `/repo` and `/repo/worktrees/foo` both → `repo`)
+   - else `basename(cwd)`
+
+When a session is started in or resumed from a directory that contains a project-local config with a valid non-empty `projectName`, epimetheus marks the session as using it. Future project-aware operations for that session then require the cwd-local project config to exist and specify a valid `projectName`; that `projectName` is used in place of the cwd-derived default for flush tags and `{project}` auto-recall filters. Requiring the project config afterwards prevents accidentally using the wrong project identity later (e.g. moving to a new drive, recloning the project, etc.).
+
+`/hindsight detach-project-name` stops the current session from requiring the cwd-local `projectName`. Use this if you no longer want to override the project name for a session (e.g. the resolution algorithm handles a new VCS it did not handle before and the config is no longer necessary).
 
 ### autoRecallTags
 Tags to filter by during auto-recall. When set, only memories matching these tags will be recalled. Supports the same placeholder expansion as observation scopes (`{session}`, `{parent}`, `{cwd}`, `{basedir}`, `{project}`), expanded at recall time using the current session context.
@@ -567,15 +599,12 @@ Configuration options can also be set via environment variables (override config
 | `EPIMETHEUS_RETAIN_CONTENT` | `retainContent` | RetainContent (JSON) | *(see retainContent default)* |
 | `EPIMETHEUS_STRIP` | `strip` | StripConfig (JSON) | *(see strip default)* |
 | `EPIMETHEUS_TOOL_FILTER` | `toolFilter` | ToolFilter (JSON) | *(see toolFilter default)* |
-| `EPIMETHEUS_PROJECT_NAME` | *(not in config)* | string | *(falls back to cwd basename)* |
 | `EPIMETHEUS_ENTITIES` | `entities` | EntityInput[] (JSON) | `[]` |
 | `EPIMETHEUS_OBSERVATION_SCOPES` | `observationScopes` | ObservationScopes (JSON or preset string) | `null` (required) |
 | `EPIMETHEUS_STATUS_HEALTHY` | `statusHealthy` | string | `"🧠"` |
 | `EPIMETHEUS_STATUS_UNHEALTHY` | `statusUnhealthy` | string | `"🤯"` |
 | `EPIMETHEUS_DEBUG` | `debug` | boolean | `false` |
 </details>
-
-> **Note:** `EPIMETHEUS_PROJECT_NAME` is a special environment variable that controls the `project:` auto-tag and `{project}` observation scope placeholder. Unlike other env vars, it does not correspond to a config file key — it is read at tag-build time and falls back to the cwd basename if not set. This makes it ideal for setting per-directory in `.env` (with direnv or mise) to disambiguate directories that share the same basename or to give separate worktree directories the same project name so they share observations.
 
 # Additional Details
 ## Memory Fencing
@@ -629,6 +658,7 @@ All commands are under `/hindsight <subcommand>`. With no subcommand, defaults t
 | `tag <tag>` | Add a tag to the session's hindsight metadata |
 | `remove-tag <tag>` | Remove a tag from the session's hindsight metadata |
 | `set-extra-context <text>` | Set extra context for extraction caveats (appended to Hindsight context field). Call with no text to indicate no extra context is needed (satisfies the flush guard). |
+| `detach-project-name` | Stop requiring the cwd-local `projectName` for this session. See [Project-local Settings](#project-local-settings). |
 | `toggle-display` | Toggle recall message visibility in UI |
 | `popup` | Pop up last recalled messages in overlay |
 | `status` | Show operational status (connection, session, recall info, queue count) |

--- a/src/commands/detach-project-name.ts
+++ b/src/commands/detach-project-name.ts
@@ -1,0 +1,101 @@
+/**
+ * `/hindsight detach-project-name` subcommand.
+ *
+ * Stops the current session from requiring the cwd-local projectName override.
+ * Appends a new `hindsight-meta` entry with `usesProjectConfig: false` (latest
+ * metadata wins) and marks the session pending so the next flush re-runs with
+ * the cwd-derived project name (basename, or git common dir for worktrees).
+ *
+ * The cwd-local config file at `<cwd>/.pi/epimetheus/config.jsonc|.json` is
+ * **not** deleted — only this session's projectName requirement is removed.
+ * Other sessions (and the file itself) are untouched. Use a `cursor`/rm or
+ * `/hindsight detach-project-name` separately on any session you want to detach.
+ */
+
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { HindsightConfig } from "../config";
+import { STATUS_ID } from "../constants";
+import { getHindsightMeta, shouldSessionBeRetained, updateSessionMetadata } from "../meta";
+import { touchPendingFlag } from "../queue";
+import {
+  DegradedReasonKind,
+  getDegradedReason,
+  isOperationalReady,
+  setActiveSessionProjectReady,
+  setDegradedReason,
+} from "../runtime-state";
+import { refreshToolVisibility } from "../tools";
+import type { Subcommand } from "./types";
+
+/**
+ * Create the detach-project-name subcommand.
+ *
+ * Confirms (because future flushes may derive a different project name and
+ * thus produce different document tags / observation-scope linkage), appends
+ * `usesProjectConfig: false`, marks the session pending, and makes clear
+ * the file is left in place.
+ */
+export function createDetachProjectNameSubcommand(
+  pi: ExtensionAPI,
+  config: HindsightConfig
+): Subcommand {
+  return {
+    description:
+      "Stop requiring the cwd-local projectName for this session (does not delete the file)",
+    handler: async (_args: string, ctx: ExtensionContext) => {
+      const answer = await ctx.ui.confirm(
+        "Detach the project-local project name?",
+        "This session will stop requiring the cwd-local projectName override. Future " +
+          "flushes and auto-recall will use the derived project name instead, and " +
+          "pending work will be queued for re-flush. The config file is not deleted. Continue?"
+      );
+      if (!answer) {
+        ctx.ui.notify("Project name not detached", "info");
+        return;
+      }
+
+      const entries = ctx.sessionManager.getEntries();
+      const sessionId = ctx.sessionManager.getSessionId();
+      const existingMeta = getHindsightMeta(entries);
+
+      await updateSessionMetadata(pi, sessionId, entries, { usesProjectConfig: false }, config);
+
+      if (sessionId) {
+        const result = touchPendingFlag(sessionId, "detach-project-name");
+        if (!result.success) {
+          ctx.ui.notify(`Failed to queue session for re-flush: ${result.error}`, "warning");
+        }
+      }
+
+      // Detaching clears only the active-session project-name failure. Tool
+      // visibility still depends on the unified operational-ready state, so an
+      // unrelated server/global-config failure keeps tools hidden.
+      setActiveSessionProjectReady(true);
+      // Clear the degraded reason ONLY if it was a project-name cause; a server/
+      // version issue is owned by the startup probe path.
+      const currentReason = getDegradedReason();
+      if (currentReason?.kind === DegradedReasonKind.ProjectName) {
+        setDegradedReason(null);
+      }
+      const isRetained = shouldSessionBeRetained(entries, config);
+      refreshToolVisibility(pi, isRetained);
+
+      // If detach restored operational readiness (startup was already healthy and
+      // the project-name failure was the only degraded cause), update the status
+      // bar so it doesn't stay unhealthy until the next session_start.
+      if (isOperationalReady()) {
+        ctx.ui.setStatus(STATUS_ID, config.statusHealthy);
+      }
+
+      // Surface the prior state for context: if the session wasn't actually
+      // marked as using a projectName override, detaching is a no-op future-proof mark.
+      const wasMarked = existingMeta?.usesProjectConfig === true;
+      ctx.ui.notify(
+        wasMarked
+          ? "Detached project name for this session. Future flushes and auto-recall will use the derived project name. Pending work queued; the config file was not deleted."
+          : "Recorded project-name detach for this session. Future flushes and auto-recall will use the derived project name; the config file was not deleted.",
+        "info"
+      );
+    },
+  };
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -11,20 +11,10 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { HindsightClientWrapper } from "../client";
 import type { HindsightConfig } from "../config";
-import { EXTENSION_ID } from "../constants";
+import { prefixLog } from "../constants";
 import type { RecallMessageDetails } from "../index";
-
-// Whether the not-ready warning has been shown this process. Resets on
-// /reload (module re-import) and from index.ts's test reset hook. Avoids
-// spamming the same unavailable warning on repeated blocked operational
-// commands while startup hasn't completed.
-let notReadyWarned = false;
-
-/** Reset module-level command state. Exported for tests via index.ts._resetState(). */
-export function resetNotReadyWarned(): void {
-  notReadyWarned = false;
-}
-
+import { DEGRADED_REASON_PENDING, DegradedReasonKind, getDegradedReason } from "../runtime-state";
+import { createDetachProjectNameSubcommand } from "./detach-project-name";
 import {
   createExtraContextSubcommand,
   createRemoveTagSubcommand,
@@ -40,6 +30,69 @@ import {
 } from "./session";
 import { createConfigSubcommand, createStatusSubcommand } from "./status";
 import type { Subcommand } from "./types";
+
+/**
+ * Build the manual-command blocked message, surfacing the specific degraded
+ * reason when known (set by index.ts whenever readiness changes) and NEVER
+ * falling back to an all-encompassing generic warning. Repeated on every
+ * manual operational-command attempt (no dedup). Recovery advice is
+ * cause-specific so it never tells the user to detach the project name when
+ * the cause is actually a server/version or global-config issue.
+ */
+function blockedMessage(): string {
+  return prefixLog(
+    `operational commands ` +
+      "(flush, parse-and-upsert-session, toggle-retain, ...) are blocked while in degraded mode." +
+      `\n${degradedReasonSentence()}\n${degradedRecoveryAdvice()}`
+  );
+}
+
+/**
+ * The specific degraded reason as a finished sentence (or the internal
+ * "startup readiness has not completed yet" fallback when no reason is
+ * classified). Shared by the operational-command and popup block paths so the
+ * popup message never uses the old generic "not ready" wording either.
+ *
+ * Causes that carry an `errors[]` (currently global-config) render them as a
+ * bulleted list below the summary; the shared `epimetheus: ` log prefix is
+ * stripped from each error here because it is redundant inside an
+ * already-epimetheus-branded block message (and was previously duplicated
+ * once per error in the joined string).
+ */
+function degradedReasonSentence(): string {
+  const reason = getDegradedReason();
+  if (reason?.errors && reason.errors.length > 0) {
+    const bullets = reason.errors
+      .map((e) => e.replace(/^epimetheus:\s*/, ""))
+      .map((e) => `  - ${e}`)
+      .join("\n");
+    return `Reason: ${reason.message}:\n${bullets}`;
+  }
+  return `Reason: ${reason?.message ?? DEGRADED_REASON_PENDING}.`;
+}
+
+/**
+ * Cause-specific recovery advice. NEVER suggests detach-project-name for a
+ * server or global-config cause.
+ */
+function degradedRecoveryAdvice(): string {
+  const reason = getDegradedReason();
+  if (reason?.kind === DegradedReasonKind.ProjectName) {
+    const configPath = reason.configPath ?? `${reason.cwd ?? "<cwd>"}/.pi/epimetheus/config.jsonc`;
+    if (reason.projectNameRecovery === "fix-config") {
+      return `Fix ${configPath} (see \`/hindsight config\` for details).`;
+    }
+    return `Run \`/hindsight detach-project-name\` to stop requiring it, or fix ${configPath}.`;
+  }
+  if (reason?.kind === DegradedReasonKind.GlobalConfig) {
+    return (
+      "Run `/hindsight config` to inspect the config source and validation " +
+      "errors, then fix the global config file or environment variables."
+    );
+  }
+  // Server/version unreachable/incompatible, or any other cause.
+  return "Run `/hindsight status` for details, and `/reload` to retry after fixing the server or configuration.";
+}
 
 /**
  * Register the `/hindsight` command with all subcommands.
@@ -71,18 +124,24 @@ export function registerCommands(
     validationWarnings: string[];
   }
 ): void {
-  // Reset the not-ready dedup flag on each (re)registration: in production this
-  // is once per extension load (resets on /reload); in tests, once per
-  // extension.default(pi), so each test starts with a fresh warning.
-  resetNotReadyWarned();
-
   /**
    * Operational subcommands that perform writes/network or queue work. These are
    * blocked (unavailable message, no side effects) until a healthy startup has
-   * completed (`isReady()`). Diagnostic/display subcommands (`status`, `config`,
-   * `popup`, `toggle-display`, and the debug-only `active-tools`) remain
+   * completed (`isReady()`). Diagnostic/display subcommands (`status`,
+   * `config`, `toggle-display`, and the debug-only `active-tools`) remain
    * available even when not ready so users can inspect state and reason about
    * why the extension is unavailable.
+   *
+   * `detach-project-name` is intentionally NOT operational: it is the recovery
+   * command for an active session that failed readiness because of an invalid
+   * or missing cwd-local project name config. It must remain available even in
+   * that failed state so the user can stop requiring the project name without
+   * manually editing the session file. It only writes session metadata + a
+   * pending marker (no client/network), so running it while not ready is safe.
+   *
+   * `popup` is display-only but gated separately (see the handler): degraded
+   * mode skips auto-recall, so there is no current recall to inspect; it also
+   * requires `autoRecallEnabled`.
    */
   const OPERATIONAL_SUBCOMMANDS = new Set([
     "flush",
@@ -94,6 +153,11 @@ export function registerCommands(
     "remove-tag",
     "set-extra-context",
   ]);
+
+  // Display-only, but only meaningful when auto-recall can run and cache a
+  // current recall. Kept out of OPERATIONAL_SUBCOMMANDS so it gets a specific
+  // user-facing explanation instead of the generic operational-command warning.
+  const AUTO_RECALL_CACHE_SUBCOMMANDS = new Set(["popup"]);
 
   const subcommands: Record<string, Subcommand> = {
     flush: createFlushSubcommand(client, config),
@@ -122,6 +186,7 @@ export function registerCommands(
     tag: createTagSubcommand(pi, config),
     "remove-tag": createRemoveTagSubcommand(pi, config),
     "set-extra-context": createExtraContextSubcommand(pi, config),
+    "detach-project-name": createDetachProjectNameSubcommand(pi, config),
     "toggle-display": createToggleDisplaySubcommand(
       config,
       getAutoRecallDisplayOverride,
@@ -203,24 +268,62 @@ export function registerCommands(
         return;
       }
 
-      // Block operational subcommands until a healthy startup completes.
-      // Diagnostic/display subcommands (status, config, popup, toggle-display,
-      // active-tools) remain available so users can inspect why the extension
-      // is unavailable.
+      // Block operational subcommands until the extension is operational.
+      // Diagnostic/display subcommands (status, config, toggle-display,
+      // active-tools, and the detach-project-name recovery command) remain
+      // available so users can inspect why the extension is unavailable.
+      //
+      // Manual blocked attempts must REPEAT the reason on every invocation
+      // (no dedup) and surface the specific degraded cause when known, so the
+      // user is told exactly why this command is unavailable rather than a
+      // generic catch-all. The reason lives in `runtime-state`'s
+      // `degradedReason` slot, set by index.ts whenever readiness changes.
       if (OPERATIONAL_SUBCOMMANDS.has(subcommandName) && !isReady()) {
-        // Surface the full reason once per process; subsequent blocked attempts
-        // stay quiet so repeated commands while unhealthy don't spam.
-        if (!notReadyWarned) {
-          notReadyWarned = true;
-          ctx.ui.notify(
-            `${EXTENSION_ID} is not ready (config/startup checks failed or have not run). ` +
-              `Operational commands (flush, parse-and-upsert-session, toggle-retain, ...) ` +
-              `are unavailable until config is valid and the server is reachable/version-compatible. ` +
-              `Run \`/hindsight status\` for details.`,
-            "warning"
-          );
-        }
+        ctx.ui.notify(blockedMessage(), "warning");
         return;
+      }
+
+      // `detach-project-name` is a recovery command for the project-name
+      // degraded cause, so it stays available when that is the reason. But it
+      // writes session metadata + a pending marker, so it must be blocked when
+      // the degraded cause is global config or server/version — the fail-fast
+      // bootstrap path promises no metadata/session-state/queue writes while
+      // global config is invalid.
+      if (
+        subcommandName === "detach-project-name" &&
+        !isReady() &&
+        getDegradedReason()?.kind !== DegradedReasonKind.ProjectName
+      ) {
+        ctx.ui.notify(blockedMessage(), "warning");
+        return;
+      }
+
+      // Commands that inspect the auto-recall cache are display-only but still
+      // require operational auto-recall: degraded mode skips auto-recall, so
+      // there is no current recall to inspect. They also require
+      // `autoRecallEnabled` — without auto-recall, no recall is ever cached.
+      if (AUTO_RECALL_CACHE_SUBCOMMANDS.has(subcommandName)) {
+        if (!isReady()) {
+          // Degraded mode skips auto-recall, so there is no current recall to
+          // inspect. Surface the SPECIFIC degraded reason + cause-specific
+          // recovery advice (shared with operational-command blocking) rather
+          // than the old generic "not ready" wording.
+          ctx.ui.notify(
+            prefixLog(
+              `Cannot pop up recall: auto-recall is skipped in degraded mode, ` +
+                `so there is no recall to inspect. ${degradedReasonSentence()} ${degradedRecoveryAdvice()}`
+            ),
+            "info"
+          );
+          return;
+        }
+        if (!config.autoRecallEnabled) {
+          ctx.ui.notify(
+            "Cannot pop up recall: autoRecallEnabled is false (no recall is cached).",
+            "info"
+          );
+          return;
+        }
       }
 
       await subcommand.handler(subArgs, ctx);

--- a/src/commands/meta.ts
+++ b/src/commands/meta.ts
@@ -8,7 +8,7 @@ import type { HindsightConfig } from "../config";
 import { getHindsightMeta, shouldSessionBeRetained, updateSessionMetadata } from "../meta";
 import { clearSessionQueueState, touchPendingFlag } from "../queue";
 import { parseAndUpsertSession } from "../retention";
-import { isToolEnabled, updateRetainToolVisibility } from "../tools";
+import { isToolEnabled, refreshToolVisibility } from "../tools";
 import type { Subcommand } from "./types";
 
 /**
@@ -35,7 +35,7 @@ async function enableRetention(
   await updateSessionMetadata(pi, sessionId, entries, { retained: true }, config);
 
   if (isToolEnabled(config, "retain")) {
-    updateRetainToolVisibility(pi, true);
+    refreshToolVisibility(pi, true);
   }
 
   // Create a pending marker immediately so that if the upsert fails or can't
@@ -102,7 +102,7 @@ async function disableRetention(
   await updateSessionMetadata(pi, sessionId, entries, { retained: false }, config);
 
   if (isToolEnabled(config, "retain")) {
-    updateRetainToolVisibility(pi, false);
+    refreshToolVisibility(pi, false);
   }
 
   // clear after retain disabled to avoid new tool retains coming in and being

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -7,6 +7,7 @@ import type { HindsightClientWrapper } from "../client";
 import type { HindsightConfig } from "../config";
 import type { RecallMessageDetails } from "../index";
 import { getHindsightMeta, shouldSessionBeRetained } from "../meta";
+import { findProjectConfigFile, resolveProjectConfig, resolveProjectName } from "../project-config";
 import { getPendingWorkCount } from "../retention";
 import { getHindsightCompatibilityError, MIN_HINDSIGHT_VERSION } from "../version";
 import type { Subcommand } from "./types";
@@ -176,6 +177,59 @@ export function createConfigSubcommand(
         }
       } else {
         lines.push("  None");
+      }
+
+      // Session-specific project config diagnostics. These are unrelated to the
+      // global config above: they describe how the *current* session's project
+      // name will be resolved during a flush (its cwd-local project config,
+      // metadata flag, and derived name). The project-local section mirrors the
+      // main Config Source block above (file/presence/status + loaded
+      // projectName or invalid reason).
+      lines.push("\n== Session-Specific Project Config ==");
+      const header = ctx.sessionManager?.getHeader?.();
+      const sessionCwd = header?.cwd ?? ctx.cwd;
+      lines.push(`  Session cwd: ${sessionCwd ?? "(none)"}`);
+
+      const entries = ctx.sessionManager?.getEntries?.() ?? [];
+      const meta = getHindsightMeta(entries);
+      const usesFlag = meta?.usesProjectConfig;
+      const flagLabel =
+        usesFlag === undefined
+          ? "<unset>"
+          : usesFlag
+            ? "true (requires cwd-local project config)"
+            : "false (detached)";
+      lines.push(`  usesProjectConfig: ${flagLabel}`);
+
+      // Project-local config file: path/presence/status + loaded projectName
+      // (or invalid reason).
+      const configPath = findProjectConfigFile(sessionCwd ?? "");
+      if (configPath) {
+        const loaded = resolveProjectConfig(sessionCwd ?? "");
+        if (loaded.ok) {
+          lines.push(`  Project-local config: ${configPath} (valid)`);
+          lines.push(`    projectName: ${loaded.config.projectName}`);
+        } else {
+          lines.push(`  Project-local config: ${configPath} (invalid — ${loaded.error})`);
+        }
+        for (const w of loaded.warnings) lines.push(`    warning: ${w}`);
+      } else {
+        lines.push("  Project-local config: <missing>");
+      }
+
+      // Compact one-line resolution: what this session would use as the
+      // project name. Avoid saying flush would proceed: project-name resolution
+      // is only one prerequisite, and other flush guards may still block.
+      const resolutionMarked = resolveProjectName(sessionCwd ?? "", usesFlag);
+      if (resolutionMarked.ok) {
+        lines.push(
+          `  Project name: ${resolutionMarked.projectName} (source: ${resolutionMarked.source})`
+        );
+      } else {
+        lines.push(`  Project name: (blocked) ${resolutionMarked.error}`);
+        // When blocked by project-name resolution, pending work remains queued
+        // for retry after the user fixes or detaches the project-local config.
+        lines.push("  Flush: blocked — pending left queued");
       }
 
       ctx.ui.notify(lines.join("\n"), "info");

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,20 +14,7 @@ import type {
 import { type ParseError, parse as parseJsonc, printParseErrorCode } from "jsonc-parser";
 import { prefixLog } from "./constants";
 import { getDataDir } from "./data-dir";
-
-function offsetToLineColumn(content: string, offset: number): { line: number; character: number } {
-  let line = 1;
-  let character = 1;
-  for (let i = 0; i < offset && i < content.length; i++) {
-    if (content[i] === "\n") {
-      line++;
-      character = 1;
-    } else {
-      character++;
-    }
-  }
-  return { line, character };
-}
+import { offsetToLineColumn } from "./utils";
 
 export interface RetainContent {
   assistant: ("text" | "thinking" | "toolCall")[];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,9 @@
  *  command (`/hindsight`), tool names, or message types — those are separate. */
 export const EXTENSION_ID = "epimetheus";
 
+/** Human-facing extension name. */
+export const EXTENSION_DISPLAY_NAME = `${EXTENSION_ID.slice(0, 1).toUpperCase()}${EXTENSION_ID.slice(1)}`;
+
 /** Status-bar key (currently equal to {@link EXTENSION_ID}). */
 export const STATUS_ID = EXTENSION_ID;
 

--- a/src/document.ts
+++ b/src/document.ts
@@ -238,18 +238,29 @@ function buildForkedMessages(
 
 /**
  * Build tags for a document.
+ *
+ * `options.projectName`, when provided, overrides the cwd-derived project name
+ * for the `project:<name>` tag. Callers that have already resolved the project
+ * name (e.g. via `resolveProjectName`, which is project-aware)
+ * should pass it through here so documents and tool entries share the same
+ * `project:` tag. When omitted, falls back to `getProjectName(header.cwd)`.
  */
 export function buildDocumentTags(
   header: SessionHeader,
   config: HindsightConfig,
-  options?: { storeMethod?: "auto" | "tool"; sessionUserTags?: string[]; parentSessionId?: string }
+  options?: {
+    storeMethod?: "auto" | "tool";
+    sessionUserTags?: string[];
+    parentSessionId?: string;
+    projectName?: string;
+  }
 ): string[] {
   const tags = [
     ...config.constantTags,
     `session:${header.id}`,
     `cwd:${header.cwd}`,
     `basedir:${getBasedir(header.cwd)}`,
-    `project:${getProjectName(header.cwd)}`,
+    `project:${options?.projectName ?? getProjectName(header.cwd)}`,
     `store_method:${options?.storeMethod ?? "auto"}`,
   ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-c
 import { Box, type Component, Text } from "@earendil-works/pi-tui";
 import type { RecallResponse } from "@vectorize-io/hindsight-client";
 import { HindsightClientWrapper } from "./client";
-import { registerCommands, resetNotReadyWarned } from "./commands";
+import { registerCommands } from "./commands";
 import { flushAllPending } from "./commands/session";
 import {
   expandAutoRecallTagGroups,
@@ -24,11 +24,24 @@ import { getDataDir } from "./data-dir";
 import { getLegacyDataDir, migrateDataDir } from "./data-dir-migration";
 import { getHindsightMeta, shouldSessionBeRetained, updateSessionMetadata } from "./meta";
 import { shouldRetainMessage } from "./prepare";
+import { evaluateActiveSessionProjectState, resolveProjectName } from "./project-config";
 import { touchPendingFlag } from "./queue";
 import { flushCurrentSession } from "./retention";
-import { isStartupReady, markStartupReady, resetStartupReady } from "./runtime-state";
-import { isToolEnabled, registerTools, updateRetainToolVisibility } from "./tools";
-import { extractParentSessionId, getProjectName, truncate } from "./utils";
+import {
+  clearStartupReady,
+  DegradedReasonKind,
+  getDegradedReason,
+  isOperationalReady,
+  markStartupReady,
+  resetActiveSessionProjectReady,
+  resetDegradedReason,
+  resetRegisteredHindsightTools,
+  resetStartupReady,
+  setActiveSessionProjectReady,
+  setDegradedReason,
+} from "./runtime-state";
+import { refreshToolVisibility, registerTools } from "./tools";
+import { clearProjectNameCache, extractParentSessionId, truncate } from "./utils";
 import { getHindsightCompatibilityError } from "./version";
 
 // Runtime toggle for recall display (overrides config)
@@ -66,7 +79,10 @@ export function _resetState(): void {
   toolsRegistered = false;
   startupReadyPromise = null;
   resetStartupReady();
-  resetNotReadyWarned();
+  resetActiveSessionProjectReady();
+  resetRegisteredHindsightTools();
+  resetDegradedReason();
+  clearProjectNameCache();
 }
 
 /**
@@ -185,6 +201,14 @@ export default function (pi: ExtensionAPI) {
     for (const error of validation.errors) {
       console.error(error);
     }
+    // Classify the degraded reason for manual operational-command blocks so
+    // the user is told exactly which config fields are invalid (never the old
+    // generic catch-all, never detach-project-name advice).
+    setDegradedReason({
+      kind: DegradedReasonKind.GlobalConfig,
+      message: "global config is invalid",
+      errors: validation.errors,
+    });
     pi.on("session_start", async (_event, ctx) => {
       ctx.ui.setStatus(STATUS_ID, config.statusUnhealthy);
     });
@@ -224,12 +248,20 @@ export default function (pi: ExtensionAPI) {
     ctx: ExtensionContext
   ): Promise<boolean> {
     if (!targetClient) {
+      setDegradedReason({
+        kind: DegradedReasonKind.GlobalConfig,
+        message: "no Hindsight client is configured (invalid global config)",
+      });
       ctx.ui.setStatus(STATUS_ID, config.statusUnhealthy);
       return false;
     }
     // Verify server is reachable before querying version.
     const healthResult = await targetClient.healthCheck(ctx.signal);
     if (!healthResult.success) {
+      setDegradedReason({
+        kind: DegradedReasonKind.Server,
+        message: `Hindsight server is unreachable: ${healthResult.error ?? "unknown error"}`,
+      });
       ctx.ui.setStatus(STATUS_ID, config.statusUnhealthy);
       return false;
     }
@@ -240,6 +272,10 @@ export default function (pi: ExtensionAPI) {
       ? getHindsightCompatibilityError(versionResult.version)
       : `Unable to query Hindsight server version: ${versionResult.error ?? "unknown error"}`;
     if (compatibilityError) {
+      setDegradedReason({
+        kind: DegradedReasonKind.Server,
+        message: `Hindsight server version is incompatible: ${compatibilityError}`,
+      });
       if (compatibilityError !== lastCompatibilityMessage) {
         ctx.ui.notify(compatibilityError, "warning");
         lastCompatibilityMessage = compatibilityError;
@@ -248,37 +284,45 @@ export default function (pi: ExtensionAPI) {
       return false;
     }
 
+    // Server is healthy and compatible. Clear ONLY a server/version or
+    // no-client global-config degraded reason here; the session_start handler
+    // that called us owns project-name reasons (it re-evaluates and sets/clears
+    // them immediately after this).
+    const current = getDegradedReason();
+    if (
+      current?.kind === DegradedReasonKind.Server ||
+      current?.kind === DegradedReasonKind.GlobalConfig
+    ) {
+      setDegradedReason(null);
+    }
     ctx.ui.setStatus(STATUS_ID, config.statusHealthy);
     return true;
   }
 
   /**
-   * Establish health/version readiness with single-flight.
+   * Probe server health + version and update the readiness latch. Single-flight
+   * so overlapping `session_start` callers share one probe pass.
    *
-   * If readiness is already latched, returns true without probing. Otherwise,
-   * overlapping callers share one probe; a successful probe flips startupReady
-   * one-way. Failures leave readiness false and can be retried later.
+   * Readiness is re-enterable: there is no fast-path skip when already latched.
+   * Every call probes and updates the latch (`true` on success, `false` on
+   * failure via {@link clearStartupReady}) so that a later `session_start`
+   * observing an unreachable/incompatible server re-enters the unified degraded
+   * mode (all tools hidden, auto-recall/retain/flush skipped, operational
+   * commands blocked). A subsequent healthy probe restores readiness.
    *
-   * This helper must not perform session setup. session_start owns metadata,
-   * tool registration, retain visibility, and startup flushes.
+   * This helper must not perform session setup (metadata, tools, visibility,
+   * startup flush) — that stays in `session_start`.
    */
   function ensureStartupReady(ctx: ExtensionContext): Promise<boolean> {
-    // Fast path: already latched — no probe, no shared work.
-    if (isStartupReady()) return Promise.resolve(true);
-    // Single-flight: a concurrent caller (session_start + before_agent_start
-    // overlap, or two before_agent_start events) joins the in-flight probe.
+    // Single-flight: a concurrent session_start joins the in-flight probe.
     if (startupReadyPromise) return startupReadyPromise;
 
     startupReadyPromise = (async () => {
       try {
-        if (!(await probeStartupHealth(client, ctx))) return false;
-        // One-way latch: only ever flips false → true. After one successful
-        // config + connection pass, later health failures are treated as likely
-        // transient: report them via status, but don't tear down process-global
-        // handlers/tools or disturb per-session tool visibility. Health/version
-        // is the gating concern; session init stays in `session_start`.
-        markStartupReady();
-        return true;
+        const healthy = await probeStartupHealth(client, ctx);
+        if (healthy) markStartupReady();
+        else clearStartupReady();
+        return healthy;
       } finally {
         // Clear so a failed attempt can be retried, and so a post-latch caller
         // never observes a stale resolved promise.
@@ -289,34 +333,121 @@ export default function (pi: ExtensionAPI) {
   }
 
   pi.on("session_start", async (event, ctx) => {
-    // session_start owns per-session setup. Health/version readiness is checked
-    // first; when unavailable, skip side effects. Once ready, setup still runs
-    // on every session_start so new/resumed sessions get their own metadata and
-    // retain-tool visibility even after global readiness was latched earlier.
-    const wasReady = isStartupReady();
-    if (!(await ensureStartupReady(ctx))) return;
+    // session_start owns per-session setup. Health/version readiness is probed
+    // every time (re-enterable): a failed probe re-enters the unified degraded
+    // mode (startupReady=false → isOperationalReady=false → all tools hidden,
+    // auto-recall/retain/flush skipped, operational commands blocked); a healthy
+    // probe restores readiness. setup then runs on every session_start so
+    // new/resumed sessions get their own metadata and tool visibility.
+    const probeHealthy = await ensureStartupReady(ctx);
+    if (!probeHealthy) {
+      // Server unreachable/incompatible → unified degraded mode. Status was
+      // already set unhealthy by probeStartupHealth. If tools were already
+      // registered (e.g. from a prior healthy session_start), hide ALL of them
+      // now that we've re-entered degraded mode (isOperationalReady() is false).
+      // On a first-ever failed start, no tools are registered yet — tools
+      // register lazily only on a healthy session_start, so there is nothing to
+      // hide and no setActiveTools call. activeSessionProjectReady is left as-is;
+      // the server failure is the degraded cause for this session.
+      if (toolsRegistered) {
+        refreshToolVisibility(pi, false);
+      }
+      return;
+    }
 
-    // If readiness was already latched, probe again to refresh status. A later
-    // health/version failure is reported as unhealthy, but treated as transient:
-    // do not undo readiness, tear down tools, or skip this session's
-    // metadata/visibility work. Do skip startup auto-flush below because it is
-    // automatic network work and this handler just observed an unhealthy server.
-    const currentProbeHealthy = wasReady ? await probeStartupHealth(client, ctx) : true;
+    // Validate the active session's project-local config state BEFORE
+    // enabling operational behavior (retain tool visibility, auto-mark metadata,
+    // startup flush). An invalid/required-but-missing cwd-local project config
+    // hard-fails the ACTIVE session through this degraded pathway: unhealthy
+    // status, retain tool hidden, auto-retain skipped (see message_end), and no
+    // startup flush. Diagnostic commands (/hindsight status, /hindsight
+    // config) and the recovery command (/hindsight detach-project-name, which
+    // is NOT in OPERATIONAL_SUBCOMMANDS) remain available. The flush path
+    // (parseAndUpsertSession) re-validates freshly so flush-pending still
+    // handles other sessions and catches files that disappeared later.
+    const entries = ctx.sessionManager.getEntries();
+    const existingMeta = getHindsightMeta(entries);
+    const sessionHeader = ctx.sessionManager.getHeader();
+    const sessionCwd = sessionHeader?.cwd ?? ctx.cwd;
+    const projectState = evaluateActiveSessionProjectState(sessionCwd, existingMeta);
+
+    if (!projectState.ready) {
+      // Active session is in failed project-local config state → single
+      // degraded mode: unhealthy status, ALL Hindsight tools hidden (not just
+      // retain), no auto-retain (message_end), no startup flush. Diagnostic
+      // commands (/hindsight status, /hindsight config, /hindsight toggle-display,
+      // /hindsight popup) and the recovery command (/hindsight detach-project-name,
+      // which is NOT in OPERATIONAL_SUBCOMMANDS) remain available. The flush path
+      // (parseAndUpsertSession) re-validates freshly per target session so
+      // flush-pending still handles other sessions and catches files that
+      // disappeared later.
+      setActiveSessionProjectReady(false);
+      setDegradedReason({
+        kind: DegradedReasonKind.ProjectName,
+        message: `active session's project name is unavailable: ${projectState.reason}`,
+        projectNameRecovery: projectState.recovery,
+        cwd: sessionCwd,
+        configPath: projectState.configPath,
+      });
+      ctx.ui.setStatus(STATUS_ID, config.statusUnhealthy);
+      const configPathStr =
+        projectState.configPath ?? `${sessionCwd ?? "<cwd>"}/.pi/epimetheus/config.jsonc`;
+      const projectRecoveryAdvice =
+        projectState.recovery === "fix-config"
+          ? `Fix ${configPathStr} (see \`/hindsight config\` for details).`
+          : `Run \`/hindsight detach-project-name\` to stop requiring it, or fix ${configPathStr}.`;
+      ctx.ui.notify(
+        prefixLog(
+          `Project config unavailable: ${projectState.reason}. ` +
+            `Tools hidden and retention disabled for this session. ` +
+            projectRecoveryAdvice
+        ),
+        "warning"
+      );
+      // Register hindsight tools once (process-global) so they can be
+      // re-shown when the session recovers; then hide ALL of them via the
+      // unified visibility refresh (isOperationalReady() is false here, so
+      // refreshToolVisibility hides every registered hindsight_* tool).
+      if (!toolsRegistered) {
+        registerTools(pi, config, client);
+        toolsRegistered = true;
+      }
+      refreshToolVisibility(pi, false);
+      return;
+    }
+
+    // Active session project name OK. Mirror this in the per-session latch so
+    // message_end auto-retain and the retain tool visibility reflect the now-
+    // healthy session (a prior failed session may have left it false).
+    setActiveSessionProjectReady(true);
+    // The session is operational (server probe succeeded + project name OK):
+    // clear any prior degraded reason.
+    setDegradedReason(null);
 
     // Auto-create session metadata if none exists, using retainSessionsByDefault
     // as the default retained state. This ensures every session has explicit
     // metadata, so toggle-retain and other commands work predictably.
-    const entries = ctx.sessionManager.getEntries();
-    const existingMeta = getHindsightMeta(entries);
+    //
+    // If a valid cwd-local project config exists for an unmarked session,
+    // auto-mark usesProjectConfig:true so future flushes require it
+    // (latest value wins, so an explicit false from /hindsight
+    // detach-project-name survives — auto-mark only fires when the flag is
+    // still undefined).
     if (!existingMeta) {
       const sessionId = ctx.sessionManager.getSessionId();
-      await updateSessionMetadata(
-        pi,
-        sessionId,
-        entries,
-        { retained: config.retainSessionsByDefault },
-        config
-      );
+      const updates: Partial<{ retained: boolean; usesProjectConfig: boolean }> = {
+        retained: config.retainSessionsByDefault,
+      };
+      if (projectState.autoMark) updates.usesProjectConfig = true;
+      await updateSessionMetadata(pi, sessionId, entries, updates, config);
+    } else if (existingMeta.usesProjectConfig === undefined && projectState.autoMark) {
+      // Existing session without an explicit usesProjectConfig flag. Auto-mark
+      // true without touching pending (the flag affects future flushes and
+      // auto-recall; the user can re-flush manually if they want retroactive tag correction).
+      // Explicit user detach (usesProjectConfig:false) is preserved because
+      // latest-wins only re-marks when the flag is still undefined.
+      const sessionId = ctx.sessionManager.getSessionId();
+      await updateSessionMetadata(pi, sessionId, entries, { usesProjectConfig: true }, config);
     }
 
     // Register hindsight tools once (process-global). Late registration
@@ -328,24 +459,16 @@ export default function (pi: ExtensionAPI) {
       registerTools(pi, config, client);
       toolsRegistered = true;
     }
-    // Update hindsight_retain tool visibility based on the current session's
-    // retention state. When not retained, the tool is hidden from the LLM
-    // entirely (instead of being available but failing on execution).
-    if (isToolEnabled(config, "retain")) {
-      const isRetained = shouldSessionBeRetained(entries, config);
-      updateRetainToolVisibility(pi, isRetained);
-    }
+    // Refresh tool visibility for the unified operational state + this
+    // session's retention flag. Operational here (startupReady latched and the
+    // active-session project config just validated OK), so all registered tools
+    // are shown except hindsight_retain when the session is not retained.
+    refreshToolVisibility(pi, shouldSessionBeRetained(entries, config));
 
     // On startup, optionally flush pending work across all sessions. This is
     // reason-gated to `session_start` only — it is a best-effort cleanup of old
-    // pending sessions, not a readiness prerequisite, so `before_agent_start`'s
-    // recovery path must NOT trigger it (avoids surprising first-prompt flushes).
-    if (
-      currentProbeHealthy &&
-      event.reason === "startup" &&
-      config.autoFlushPendingOn.includes("startup") &&
-      client
-    ) {
+    // pending sessions, not a readiness prerequisite.
+    if (event.reason === "startup" && config.autoFlushPendingOn.includes("startup") && client) {
       await flushAllPending(config, client, ctx, { notifyNoWork: false, autoFlush: true });
     }
   });
@@ -366,7 +489,7 @@ export default function (pi: ExtensionAPI) {
     (value) => {
       autoRecallDisplayOverride = value;
     },
-    isStartupReady,
+    isOperationalReady,
     {
       configPath,
       envVars,
@@ -391,14 +514,16 @@ export default function (pi: ExtensionAPI) {
   pi.on("before_agent_start", async (event, ctx: ExtensionContext) => {
     if (!client || !config.autoRecallEnabled) return;
 
-    // before_agent_start can be the first lifecycle point with the user's
-    // prompt. If session_start has not latched readiness yet, check
-    // health/version on demand so first-turn recall can proceed when the server
-    // is healthy. This does not initialize the session; that remains
-    // session_start's responsibility. The extra readiness read is defensive: if
-    // another lifecycle path latched readiness while this await resolved false,
-    // don't skip an otherwise-safe first-turn recall.
-    if (!(await ensureStartupReady(ctx)) && !isStartupReady()) return;
+    // session_start is awaited before the first prompt in current Pi (interactive,
+    // print, and RPC), so by the time before_agent_start fires, startup readiness
+    // and the active session's project-name state have already been evaluated.
+    // Only check the unified operational state here and return if degraded —
+    // never probe or mutate readiness from before_agent_start (that risks
+    // surprising first-prompt side effects and is session_start's job). If the
+    // session is degraded (server unreachable/incompatible, or required-but-
+    // missing/invalid cwd-local project config), auto-recall is skipped for this
+    // turn; the first turn after recovery will recall.
+    if (!isOperationalReady()) return;
 
     // Use event.prompt directly — available before the user message is
     // persisted to the session (fixes first-message recall).
@@ -427,12 +552,27 @@ export default function (pi: ExtensionAPI) {
     }
     const sessionCwd = header?.cwd ?? ctx.cwd;
     const parentSessionId = extractParentSessionId(header?.parentSession);
+    const existingMeta = getHindsightMeta(ctx.sessionManager.getEntries());
+    // Defensive-only: session_start already validated the active session's
+    // project config before operational auto-recall can run. This catches an
+    // unexpected mid-session file/state change without probing or mutating
+    // readiness from before_agent_start.
+    const projectNameResolution = resolveProjectName(sessionCwd, existingMeta?.usesProjectConfig);
+    if (!projectNameResolution.ok) {
+      // Clear stale recall cache so /hindsight popup and status don't show a
+      // previous turn's recall for a prompt where auto-recall was skipped.
+      lastRecallMessage = null;
+      lastRecallDetails = null;
+      ctx.ui.notify(prefixLog(`auto-recall skipped: ${projectNameResolution.error}`), "warning");
+      return;
+    }
     const result = await doAutoRecall(
       query,
       ctx.signal,
       displayValue,
       sessionId,
       sessionCwd,
+      projectNameResolution.projectName,
       parentSessionId
     );
     if (result) {
@@ -497,7 +637,7 @@ export default function (pi: ExtensionAPI) {
 
   // Mark sessions as dirty on message_end event
   pi.on("message_end", async (event, ctx: ExtensionContext) => {
-    if (!config.autoRetainEnabled || !isStartupReady()) return;
+    if (!config.autoRetainEnabled || !isOperationalReady()) return;
 
     const sessionId = ctx.sessionManager.getSessionId();
     if (!sessionId) {
@@ -525,7 +665,7 @@ export default function (pi: ExtensionAPI) {
 
   /** Auto-flush: suppresses transient block notifications unless debug mode is on. */
   const autoFlush = async (ctx: ExtensionContext): Promise<void> => {
-    if (!client || !isStartupReady()) return;
+    if (!client || !isOperationalReady()) return;
     const sessionId = ctx.sessionManager.getSessionId();
     const sessionPath = ctx.sessionManager.getSessionFile();
     if (!sessionId || !sessionPath) return;
@@ -661,7 +801,7 @@ export default function (pi: ExtensionAPI) {
   // semantics: success, no-work, and block/not-retained warnings are suppressed
   // unless `debug: true` (compaction is not a final-chance event like `/quit`).
   pi.on("session_compact", async (_event, ctx: ExtensionContext) => {
-    if (!config.autoFlushSessionOn.includes("compact") || !client || !isStartupReady()) return;
+    if (!config.autoFlushSessionOn.includes("compact") || !client || !isOperationalReady()) return;
     const sessionId = ctx.sessionManager.getSessionId();
     const sessionPath = ctx.sessionManager.getSessionFile();
     if (!sessionId || !sessionPath) return;
@@ -688,7 +828,7 @@ export default function (pi: ExtensionAPI) {
   //     skipped to avoid duplicate work (see config validation warning).
   pi.on("session_shutdown", async (event, ctx: ExtensionContext) => {
     if (event.reason === "new" || event.reason === "resume" || event.reason === "fork") return;
-    if (!client || !isStartupReady()) return;
+    if (!client || !isOperationalReady()) return;
     if (event.reason === "reload") {
       if (!config.autoFlushSessionOn.includes("reload")) return;
       const sessionId = ctx.sessionManager.getSessionId();
@@ -735,14 +875,15 @@ export default function (pi: ExtensionAPI) {
     display: boolean,
     sessionId: string,
     sessionCwd: string,
+    projectName: string,
     parentSessionId?: string
   ): Promise<{ recallMessage: ReturnType<typeof formatRecallMessage> } | null> {
-    // Expand recall tag placeholders with session context
+    // Expand recall tag placeholders with the same project name used for flushing.
     const placeholderParams = {
       sessionId,
       sessionCwd,
       parentSessionId,
-      projectName: getProjectName(sessionCwd),
+      projectName,
     };
     const expandedTags = expandAutoRecallTags(config.autoRecallTags, placeholderParams);
     const expandedTagGroups = expandAutoRecallTagGroups(

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -131,6 +131,15 @@ export interface HindsightMeta {
   tags?: string[];
   /** Extra context appended to the Hindsight context field (after session name). */
   extraContext?: string;
+  /**
+   * When true, project-aware session behavior requires a valid cwd-local project
+   * config (`<cwd>/.pi/epimetheus/config.jsonc|.json`) and uses its
+   * `projectName`. Append-only: each new hindsight-meta entry carries forward
+   * the prior value unless explicitly overridden. Latest metadata value wins.
+   * The project config path and the resolved project name are deliberately NOT
+   * stored here — see `src/project-config.ts` for resolution details.
+   */
+  usesProjectConfig?: boolean;
 }
 
 /**
@@ -153,6 +162,11 @@ export function getHindsightMeta(
     }
   }
   return null;
+}
+
+/** Effective project-config flag from session metadata. */
+export function getProjectConfigFlag(meta: HindsightMeta | null): boolean | undefined {
+  return meta?.usesProjectConfig;
 }
 
 /**
@@ -178,6 +192,14 @@ export function buildMetaUpdate(
     updates.extraContext !== undefined ? updates.extraContext : existing?.extraContext;
   if (extraContext !== undefined) {
     meta.extraContext = extraContext;
+  }
+
+  const usesProjectConfig =
+    updates.usesProjectConfig !== undefined
+      ? updates.usesProjectConfig
+      : getProjectConfigFlag(existing);
+  if (usesProjectConfig !== undefined) {
+    meta.usesProjectConfig = usesProjectConfig;
   }
 
   return meta;

--- a/src/project-config.ts
+++ b/src/project-config.ts
@@ -1,0 +1,474 @@
+/**
+ * Project-local config: cwd-local project-name overrides for project-aware
+ * flush tags and `{project}` auto-recall filters.
+ *
+ * Resolution order (see `docs/architecture/config.md`):
+ *
+ * 1. If the session is marked `usesProjectConfig: true` (in its latest
+ *    `hindsight-meta` entry), a project config file MUST exist and be valid
+ *    at `<session header cwd>/.pi/epimetheus/config.jsonc` (or, for git
+ *    worktrees, the main repo's via the git commondir).
+ *    Missing/invalid (or a removed cwd) → fail closed.
+ * 2. Otherwise (not marked), derive a default project name:
+ *    - if `<cwd>/.git` exists, resolve the git common dir so worktrees
+ *      share the main repo name (e.g. `/repo` and `/repo/worktrees/foo` both → `repo`)
+ *    - else `basename(cwd)`
+ *
+ * Config lookup checks the cwd first, then falls back to the git commondir's
+ * parent (the main repo root) when `<cwd>/.git` exists. This lets git worktrees
+ * share the main repo's `.pi/epimetheus/config.jsonc` without needing their own
+ * `.pi` directory, while still allowing worktrees to override with a cwd-local
+ * config. No ancestor walk beyond this git-aware fallback is performed.
+ *
+ * The schema initially supports only `projectName`; unknown keys warn and are
+ * ignored. Invalid/missing required project config fails closed: flushes are
+ * skipped and auto-recall is skipped for the active session.
+ *
+ * Default derivation (detached / unmarked-with-no-file) is git common dir →
+ * basename (see {@link ./utils.ts deriveDefaultProjectName}). Env-var overrides
+ * were removed because env vars do not track Pi session switching.
+ */
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { type ParseError, parse as parseJsonc, printParseErrorCode } from "jsonc-parser";
+import { deriveDefaultProjectName, offsetToLineColumn, resolveGitCommonDirParent } from "./utils";
+
+/** The single supported project-config schema: a stable project name. */
+export interface ProjectConfig {
+  projectName: string;
+}
+
+/** Directory (relative to cwd) where the cwd-local project config lives. */
+const PROJECT_CONFIG_DIR = join(".pi", "epimetheus");
+
+/**
+ * Where the resolved project name came from. Used by `/hindsight config`
+ * diagnostics. Not stored anywhere; latest flush resolution wins.
+ */
+export type ProjectNameSource = "project-local-config" | "git" | "basename";
+
+/**
+ * Success result: the resolved project name and its source.
+ */
+export interface ProjectNameResolutionSuccess {
+  ok: true;
+  projectName: string;
+  source: ProjectNameSource;
+}
+
+/**
+ * Failure result: flush cannot proceed. The caller should leave pending work
+ * queued (do NOT clear the pending marker) and notify clearly.
+ */
+export interface ProjectNameResolutionFailure {
+  ok: false;
+  error: string;
+  recovery?: ProjectNameRecovery;
+  /** Path of the malformed/invalid config, when one was found. */
+  configPath?: string;
+}
+
+export type ProjectNameResolution = ProjectNameResolutionSuccess | ProjectNameResolutionFailure;
+
+/**
+ * Success: a valid cwd-local project config was loaded.
+ */
+export interface ProjectConfigLoadSuccess {
+  ok: true;
+  config: ProjectConfig;
+  /** Path of the loaded config file. */
+  path: string;
+  warnings: string[];
+}
+
+/**
+ * Failure: config missing, malformed, or structurally invalid.
+ */
+export interface ProjectConfigLoadFailure {
+  ok: false;
+  error: string;
+  /** Path of the malformed/invalid config, when one was found on disk. */
+  path?: string;
+  warnings: string[];
+}
+
+export type ProjectConfigLoadResult = ProjectConfigLoadSuccess | ProjectConfigLoadFailure;
+
+/**
+ * Build candidate config paths for a base directory (cwd or commondir parent).
+ * `.jsonc` has precedence over `.json`.
+ */
+function configCandidatesFor(base: string): string[] {
+  return [
+    join(base, PROJECT_CONFIG_DIR, "config.jsonc"),
+    join(base, PROJECT_CONFIG_DIR, "config.json"),
+  ];
+}
+
+/**
+ * Locate the project config file. `.jsonc` has precedence over `.json`.
+ *
+ * Checks the cwd first, then falls back to the git commondir's parent (the
+ * main repo root) when `<cwd>/.git` exists. This lets git worktrees share the
+ * main repo's project config without needing their own `.pi` directory, while
+ * still allowing worktrees to override with a cwd-local config.
+ *
+ * Hardened against unreadable / non-file paths: if a candidate path exists on
+ * disk but cannot be read (e.g. it is a directory, or lacks read permission),
+ * returns `{ path, content: undefined, readError }` instead of throwing. Callers
+ * decide how to surface that (typically as a fail-closed "invalid config").
+ */
+function locateProjectConfig(cwd: string): {
+  path: string | undefined;
+  content: string | undefined;
+  /** Set when a file exists on disk but could not be read. */
+  readError?: string;
+} {
+  // Build the full candidate list: cwd-local first, then commondir fallback.
+  const candidates = configCandidatesFor(cwd);
+  if (existsSync(join(cwd, ".git"))) {
+    const commonDirParent = resolveGitCommonDirParent(cwd);
+    if (commonDirParent && commonDirParent !== cwd) {
+      candidates.push(...configCandidatesFor(commonDirParent));
+    }
+  }
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) continue;
+    // existsSync is true for directories too; guard against non-files so a
+    // directory named config.jsonc doesn't crash readFileSync.
+    try {
+      const stat = statSync(candidate);
+      if (!stat.isFile()) {
+        return { path: candidate, content: undefined, readError: "not a regular file" };
+      }
+    } catch (e) {
+      return { path: candidate, content: undefined, readError: errMsg(e) };
+    }
+    try {
+      return { path: candidate, content: readFileSync(candidate, "utf-8") };
+    } catch (e) {
+      return { path: candidate, content: undefined, readError: errMsg(e) };
+    }
+  }
+  return { path: undefined, content: undefined };
+}
+
+/** Best-effort error-message extraction for caught values. */
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+/**
+ * Path of the project config file if it exists on disk (`.jsonc` preferred
+ * over `.json`). Checks cwd first, then falls back to the git commondir's
+ * parent (main repo root) when `<cwd>/.git` exists. Returns `null` when no
+ * config is found in either location.
+ *
+ * Read-only diagnostic helper for `/hindsight config`. Hardened: never throws,
+ * even if the candidate path exists but is unreadable or a non-file.
+ */
+export function findProjectConfigFile(cwd: string): string | null {
+  try {
+    return locateProjectConfig(cwd).path ?? null;
+  } catch {
+    // Defensive: locateProjectConfig is already hardened, but guard the public
+    // entrypoint against any unexpected throw so /hindsight config never crashes.
+    return null;
+  }
+}
+
+/**
+ * Load and validate the project config.
+ *
+ * `.jsonc` is preferred over `.json`. Checks cwd first, then falls back to
+ * the git commondir's parent (main repo root) when `<cwd>/.git` exists. The
+ * schema currently supports only `projectName` (non-empty string). Unknown
+ * keys produce warnings and are ignored. Malformed JSON, missing/invalid
+ * `projectName`, a non-object document, or an unreadable/non-file path all
+ * fail closed.
+ *
+ * Hardened: never throws — read/stat errors are surfaced as `ok:false` results.
+ */
+export function resolveProjectConfig(cwd: string): ProjectConfigLoadResult {
+  let located: ReturnType<typeof locateProjectConfig>;
+  try {
+    located = locateProjectConfig(cwd);
+  } catch (e) {
+    // Defensive: locateProjectConfig is hardened, but guard the public entrypoint.
+    return { ok: false, error: `could not locate project config: ${errMsg(e)}`, warnings: [] };
+  }
+  if (located.readError) {
+    return {
+      ok: false,
+      error: `could not read project config ${located.path}: ${located.readError}`,
+      path: located.path,
+      warnings: [],
+    };
+  }
+  const { path, content } = located;
+  if (path === undefined || content === undefined) {
+    return { ok: false, error: "no project config file found", warnings: [] };
+  }
+
+  const warnings: string[] = [];
+
+  const errors: ParseError[] = [];
+  const parsed = parseJsonc(content, errors, { allowTrailingComma: true });
+  if (errors.length > 0) {
+    const details = errors
+      .map((e) => {
+        const { line, character } = offsetToLineColumn(content, e.offset);
+        return `line ${line}, character ${character}: ${printParseErrorCode(e.error)}`;
+      })
+      .join("; ");
+    return {
+      ok: false,
+      error: `project config is not valid JSON: ${details}`,
+      path,
+      warnings,
+    };
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    const kind = parsed === null ? "null" : Array.isArray(parsed) ? "array" : typeof parsed;
+    return {
+      ok: false,
+      error: `project config must be a JSON object (got ${kind})`,
+      path,
+      warnings,
+    };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  for (const key of Object.keys(obj)) {
+    if (key !== "projectName") {
+      warnings.push(`unknown key "${key}" ignored (only "projectName" is supported)`);
+    }
+  }
+
+  if (typeof obj.projectName !== "string") {
+    const kind =
+      obj.projectName === undefined
+        ? "missing"
+        : Array.isArray(obj.projectName)
+          ? "array"
+          : typeof obj.projectName;
+    return {
+      ok: false,
+      error: `project config requires "projectName" to be a string (got ${kind})`,
+      path,
+      warnings,
+    };
+  }
+
+  const trimmed = obj.projectName.trim();
+  if (trimmed.length === 0) {
+    return {
+      ok: false,
+      error: `project config "projectName" must not be empty/whitespace`,
+      path,
+      warnings,
+    };
+  }
+
+  return { ok: true, config: { projectName: trimmed }, path, warnings };
+}
+
+/**
+ * Recovery hints for a failed project-name resolution.
+ */
+export const ProjectNameRecovery = {
+  DetachOrFix: "detach-or-fix",
+  FixConfig: "fix-config",
+} as const;
+
+export type ProjectNameRecovery = (typeof ProjectNameRecovery)[keyof typeof ProjectNameRecovery];
+
+/**
+ * Shared decision core for the tristate project-config matrix.
+ *
+ * Both {@link resolveProjectName} (flush/auto-recall path) and
+ * {@link evaluateActiveSessionProjectState} (session_start readiness latch)
+ * delegate to this so the "loaded config + flag → what happens?" matrix lives in
+ * exactly one place. Callers keep the cases that genuinely differ:
+ * - the `false` (detached) short-circuit (each adapter has its own success shape);
+ * - the cwd-existence pre-check (messages and undefined-cwd handling differ);
+ * - how a successful/default result is shaped for the caller.
+ *
+ * Only called with `flag !== false` (detach is resolved by callers first), so
+ * `flag` is `true | undefined` here.
+ */
+type ProjectNameDecision =
+  | { kind: "config"; projectName: string; configPath: string }
+  | { kind: "default" }
+  | { kind: "fail"; error: string; recovery: ProjectNameRecovery; configPath?: string };
+
+function decideFromLoadedConfig(
+  loaded: ProjectConfigLoadResult,
+  flag: true | undefined
+): ProjectNameDecision {
+  if (loaded.ok) {
+    return { kind: "config", projectName: loaded.config.projectName, configPath: loaded.path };
+  }
+  // A file exists on disk but is invalid/unreadable → fail closed (this covers
+  // both `true` and unmarked so an invalid config never silently falls back to a
+  // derived name and allows ingestion under a wrong project identity).
+  if (loaded.path !== undefined) {
+    return {
+      kind: "fail",
+      error: `project config ${loaded.path} is invalid: ${loaded.error}`,
+      recovery: ProjectNameRecovery.FixConfig,
+      configPath: loaded.path,
+    };
+  }
+  // No file present on disk.
+  if (flag === true) {
+    return {
+      kind: "fail",
+      error:
+        "session is marked as using project-local config, but no project config file is present",
+      recovery: ProjectNameRecovery.DetachOrFix,
+    };
+  }
+  // Unmarked, no file → default derivation (caller resolves the name/source).
+  return { kind: "default" };
+}
+
+/**
+ * Resolve the project name to use for a session whose cwd is `cwd`.
+ *
+ * `usesProjectConfig` is a tristate (`true` | `false` | `undefined`):
+ * - `false` (detached): ignore the project config entirely; default derivation
+ *   (git → basename). A cwd that no longer exists is non-fatal here.
+ * - `true`: a valid cwd-local project config is required (fail closed when the
+ *   cwd is gone, the file is missing, or the file is invalid). The config's
+ *   `projectName` is authoritative.
+ * - `undefined` (unmarked): if a project config file is present on disk, it
+ *   signals user intent — a valid one is used, an invalid one fails closed
+ *   (no silent fallback). With no file present, default derivation is used.
+ *
+ * Returns a discrete failure only when the session genuinely cannot produce a
+ * trustworthy project name for an upsert. Callers should leave pending work
+ * queued on failure and notify clearly.
+ */
+export function resolveProjectName(
+  cwd: string,
+  usesProjectConfig: boolean | undefined
+): ProjectNameResolution {
+  // Detached: explicit false ignores the project config entirely.
+  if (usesProjectConfig === false) {
+    return defaultProjectName(cwd);
+  }
+
+  // `true` requires the cwd to exist.
+  if (usesProjectConfig === true && !existsSync(cwd)) {
+    return {
+      ok: false,
+      error: `session is marked as using project-local config, but its cwd "${cwd}" no longer exists`,
+      recovery: ProjectNameRecovery.DetachOrFix,
+    };
+  }
+
+  const decision = decideFromLoadedConfig(resolveProjectConfig(cwd), usesProjectConfig);
+  if (decision.kind === "config") {
+    return { ok: true, projectName: decision.projectName, source: "project-local-config" };
+  }
+  if (decision.kind === "default") {
+    return defaultProjectName(cwd);
+  }
+  return {
+    ok: false,
+    error: decision.error,
+    recovery: decision.recovery,
+    configPath: decision.configPath,
+  };
+}
+
+/**
+ * Default project-name derivation for detached / unmarked-with-no-config sessions.
+ *
+ * git common dir (so worktrees share the main repo name) → basename. A cwd
+ * that no longer exists is non-fatal here (the git check simply does not apply
+ * and basename is used as a stable fallback).
+ */
+function defaultProjectName(cwd: string): ProjectNameResolution {
+  const derived = deriveDefaultProjectName(cwd);
+  return { ok: true, projectName: derived.name, source: derived.source };
+}
+
+export interface ActiveProjectState {
+  ready: boolean;
+  reason?: string;
+  recovery?: ProjectNameRecovery;
+  /** Path of an invalid/unreadable config file found on disk, for diagnostics. */
+  configPath?: string;
+  /**
+   * True when the active session is unmarked (`usesProjectConfig ===
+   * undefined`) AND a valid cwd-local project config is present. `session_start`
+   * uses this to append `usesProjectConfig: true` (latest-wins auto-mark).
+   * Not set (false) when already marked `true`, detached, or in any failing state.
+   */
+  autoMark?: boolean;
+}
+
+/**
+ * Evaluate the active session's project-local config state for the
+ * `session_start` readiness gate.
+ *
+ * Rules (mirror {@link resolveProjectName}'s tristate semantics, sharing the
+ * post-load decision core {@link decideFromLoadedConfig}):
+ * - `usesProjectConfig === false` (detached) → always `ready:true` (the
+ *   cwd-local project config is ignored; detach wins). No `autoMark`.
+ * - `usesProjectConfig === true` (required) → ready only if the cwd
+ *   exists AND a valid project config is present. Otherwise `ready:false`.
+ * - `usesProjectConfig === undefined` (unmarked):
+ *     - valid file present → `ready:true`, `autoMark:true`.
+ *     - invalid/unreadable file present → `ready:false` (never silently fall
+ *       back to default derivation; an invalid config is an error).
+ *     - no file present → `ready:true` (default derivation applies).
+ *
+ * `existingMeta` is the latest `hindsight-meta` (or null); only its
+ * `usesProjectConfig` field is consulted.
+ */
+export function evaluateActiveSessionProjectState(
+  cwd: string | undefined,
+  existingMeta: { usesProjectConfig?: boolean } | null
+): ActiveProjectState {
+  const flag = existingMeta?.usesProjectConfig;
+
+  // Detached wins.
+  if (flag === false) {
+    return { ready: true };
+  }
+
+  // Required (true) needs the cwd to exist.
+  if (flag === true && (!cwd || !existsSync(cwd))) {
+    return {
+      ready: false,
+      reason: `session is marked as using project-local config, but its cwd "${cwd}" does not exist`,
+      recovery: ProjectNameRecovery.DetachOrFix,
+    };
+  }
+
+  if (!cwd) {
+    // Unmarked with no cwd → default derivation (non-fatal).
+    return { ready: true };
+  }
+
+  const decision = decideFromLoadedConfig(resolveProjectConfig(cwd), flag);
+  if (decision.kind === "config") {
+    // Auto-mark only when unmarked (undefined); when already `true`, no
+    // auto-mark is needed.
+    return flag !== true ? { ready: true, autoMark: true } : { ready: true };
+  }
+  if (decision.kind === "default") {
+    return { ready: true };
+  }
+  return {
+    ready: false,
+    reason: decision.error,
+    recovery: decision.recovery,
+    configPath: decision.configPath,
+  };
+}

--- a/src/retention.ts
+++ b/src/retention.ts
@@ -32,6 +32,7 @@ import {
   writeMetaFile,
 } from "./meta";
 import { resolveParsedSessionMetadata, writeMessagesJsonl } from "./parsed-store";
+import { resolveProjectName } from "./project-config";
 import type { ClaimReadError, QueueClaim, QueueResult, ToolQueueEntry } from "./queue";
 import {
   claimPendingFlag,
@@ -62,16 +63,24 @@ export async function queueToolRetain(
   sessionCwd: string,
   parentSessionId: string | undefined,
   config: Pick<HindsightConfig, "constantTags" | "observationScopes">,
-  sessionUserTags: string[]
+  sessionUserTags: string[],
+  /**
+   * Pre-resolved project name to bake into tags and observation-scope
+   * placeholders. Callers with project-local config awareness (see
+   * `resolveProjectName`) should pass this so tool retains and session
+   * flushes share the same `project:` tag. When omitted, falls back to
+   * `getProjectName(sessionCwd)` (git common dir or cwd basename).
+   */
+  projectName?: string
 ): Promise<QueueResult> {
-  const projectName = getProjectName(sessionCwd);
+  const resolvedProjectName = projectName ?? getProjectName(sessionCwd);
   // Build complete tags at queue time
   const tags = [
     ...config.constantTags,
     `session:${sessionId}`,
     `cwd:${sessionCwd}`,
     `basedir:${getBasedir(sessionCwd)}`,
-    `project:${projectName}`,
+    `project:${resolvedProjectName}`,
     `store_method:tool`,
     `parent:${parentSessionId ?? sessionId}`,
     ...(toolTags ?? []),
@@ -84,7 +93,7 @@ export async function queueToolRetain(
     sessionId,
     parentSessionId,
     sessionCwd,
-    projectName
+    resolvedProjectName
   );
 
   const entry: ToolQueueEntry = {
@@ -296,14 +305,21 @@ export async function upsertToHindsight(
   client: HindsightClientWrapper,
   params: UpsertParams,
   config: HindsightConfig,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  /**
+   * Pre-resolved project name for `{project}` observation-scope placeholder
+   * expansion. Callers with project-local config awareness should pass this so the
+   * scopes match the document tags. When omitted, falls back to
+   * `getProjectName(params.sessionCwd)` (git common dir or cwd basename).
+   */
+  projectName?: string
 ): Promise<void> {
   const expandedScopes = expandSessionObservationScopes(
     config,
     params.sessionId,
     params.parentSessionId,
     params.sessionCwd,
-    getProjectName(params.sessionCwd)
+    projectName ?? getProjectName(params.sessionCwd)
   );
 
   const result = await client.retain(
@@ -446,7 +462,12 @@ function resolveSessionFlushMetadata(
   header: SessionHeader,
   entries: SessionEntry[],
   hindsightMeta: HindsightMeta | null,
-  config: HindsightConfig
+  config: HindsightConfig,
+  /**
+   * Pre-resolved project name (project-aware) for the `project:` tag.
+   * When omitted, `buildDocumentTags` falls back to `getProjectName(header.cwd)`.
+   */
+  projectName?: string
 ): {
   parentSessionId: string | undefined;
   sessionCwd: string;
@@ -461,6 +482,7 @@ function resolveSessionFlushMetadata(
   const tags = buildDocumentTags(header, config, {
     sessionUserTags: base.sessionUserTags,
     parentSessionId: base.parentSessionId,
+    projectName,
   });
   return {
     ...base,
@@ -676,8 +698,42 @@ export async function parseAndUpsertSession(
       return;
     }
 
+    // Resolve the project name project-aware, so document tags and
+    // observation-scope placeholders match across the upsert. If the session
+    // is marked as using project-local config and that resolution fails
+    // (cwd gone, or config missing/invalid), fail closed: leave pending work
+    // queued (restoreClaim) and notify. Auto-flush notifications are suppressed
+    // like other transient block warnings unless debug or surfaceBlocks.
+    //
+    // This re-validates FRESH (independent of the active-session latch in
+    // runtime-state) so flush-pending handles non-active sessions and catches
+    // config files that disappeared or became invalid after session_start.
+    const projectNameResult = resolveProjectName(header.cwd, hindsightMeta?.usesProjectConfig);
+    if (!projectNameResult.ok) {
+      if (claim) restoreClaim(claim);
+      if (!options?.autoFlush || debug || options?.surfaceBlocks) {
+        const recoveryAdvice =
+          projectNameResult.recovery === "fix-config"
+            ? "Fix the cwd-local project config."
+            : "Restore the cwd-local project config or run `/hindsight detach-project-name`.";
+        ctx.ui.notify(
+          `Flush blocked for session ${sessionId}: ${projectNameResult.error}. Pending work remains queued. ` +
+            recoveryAdvice,
+          "warning"
+        );
+      }
+      return;
+    }
+    const resolvedProjectName = projectNameResult.projectName;
+
     // Resolve metadata from parsed session data (session file is authority, not live state)
-    const resolved = resolveSessionFlushMetadata(header, entries, hindsightMeta, config);
+    const resolved = resolveSessionFlushMetadata(
+      header,
+      entries,
+      hindsightMeta,
+      config,
+      resolvedProjectName
+    );
 
     // Serialize messages
     const formattedStrs = messages.map((m) => JSON.stringify(m));
@@ -708,7 +764,7 @@ export async function parseAndUpsertSession(
     );
 
     // Network call
-    await upsertToHindsight(client, upsertParams, config, signal);
+    await upsertToHindsight(client, upsertParams, config, signal, resolvedProjectName);
 
     // Finalize: write parsed artifacts and complete the claim. If the claim dir
     // disappeared during the network call, queue state was concurrently cleared;

--- a/src/runtime-state.ts
+++ b/src/runtime-state.ts
@@ -2,48 +2,232 @@
  * Tiny runtime-state module shared across event handlers, tools, and slash
  * commands without threading callbacks through every subcommand creator.
  *
- * Currently holds only {@link startupReady}; the recall-display override / last
- * recall details remain in index.ts (they need index-local getters/setters that
- * tests already mock). Keeping this module minimal avoids a larger refactor.
+ * Holds two independent latches plus a unified getter:
  *
- * `startupReady` is a **latch**: it starts `false` and flips to `true` after
- * the first successful health check + version compatibility check. That probe
- * is normally triggered by `session_start`, but first-turn auto-recall can also
- * trigger it from `before_agent_start` when that event races ahead of startup
- * readiness. It is never flipped back to `false` by later failures; a later
- * health failure still sets the status-bar indicator unhealthy, but does not
- * re-disable operational handlers or re-hide tools.
+ * - `startupReady`: process-global health/version latch reflecting the most
+ *   recent probe. Starts `false`, set `true` after a healthy probe and `false`
+ *   again when a later `session_start` probe observes an unreachable/
+ *   incompatible server — so the extension re-enters the unified degraded mode
+ *   on later server failures (it is NOT a one-way latch). status HEALTHY
+ *   is independent: a failed probe sets the status-bar unhealthy regardless of
+ *   prior readiness.
  *
- * Before the first successful readiness probe, operational handlers
- * (auto-retain, auto-recall, auto-flush) and operational subcommands gate on
- * this so no operational side effects occur while startup hasn't succeeded.
- * Hindsight tools are related but separate: they are registered lazily by the
- * first healthy `session_start` (not by `before_agent_start` and not at
- * extension init), so session-specific setup remains owned by the session
- * lifecycle. The recall filter and renderer are always active regardless of
- * readiness.
+ * - `activeSessionProjectReady`: per-active-session project-local config
+ *   latch. Re-evaluated by every `session_start` (after the health/version
+ *   probe succeeds). `true` means the current session can safely retain under
+ *   a resolved project name (config is valid, detached, or unmarked with a
+ *   derivable default). `false` means the active session's cwd-local flush
+ *   config is required-but-missing/invalid, or present-but-invalid for an
+ *   unmarked session. Unlike `startupReady`, this CAN flip back to `true`
+ *   (e.g. after `/hindsight detach-project-name`, or a later `session_start` in
+ *   a fixed cwd).
  *
- * index.ts's `_resetState()` is the single reset entrypoint and calls
- * {@link resetStartupReady}(); tests already invoke `_resetState()`.
+ * - `isOperationalReady()`: the unified operational-ready getter
+ *   (`startupReady && activeSessionProjectReady`). Any single failed cause
+ *   (unreachable/incompatible server, or required-but-missing/invalid cwd-local
+ *   project config) puts the extension into the single degraded mode: unhealthy
+ *   status, ALL Hindsight tools hidden, no auto-recall/retain/flush, no queue
+ *   writes/network, and operational slash commands blocked. The flush path
+ *   (`parseAndUpsertSession`) re-validates freshly via `resolveProjectName`
+ *   and is NOT gated by this latch — it handles non-active sessions in
+ *   `flush-pending` and catches files that disappeared or became invalid after
+ *   `session_start`.
+ *
+ * Also tracks `registeredHindsightTools` (set by `registerTools`) so the unified
+ * `refreshToolVisibility` knows which tool names to show when leaving degraded
+ * mode and which to hide when entering it.
+ *
+ * Also tracks `degradedReason`: a typed degraded-mode cause plus its
+ * human-readable message (invalid global config, server/version issue, or the
+ * active session's project-name failure), or `null` when
+ * operational. Set by `index.ts` whenever readiness changes (including the
+ * fail-fast invalid-global-config path, which sets it before registering
+ * commands); read by the slash-command block path so manual operational
+ * commands can surface the SPECIFIC reason (and repeat on every attempt)
+ * instead of a one-time generic catch-all. Recovery paths compare the typed
+ * cause, never substrings of the human-readable message. The only fallback is
+ * the specific internal `"startup readiness has not completed yet"` when no
+ * reason has been classified (e.g. before the first `session_start`); there
+ * is no generic catch-all fallback.
+ *
+ * Hindsight tools are process-global and registered lazily by the first healthy
+ * `session_start` (not by `before_agent_start` and not at extension init), so
+ * session-specific setup remains owned by the session lifecycle. `before_agent_start`
+ * only READS `isOperationalReady()` and returns if degraded — it never probes or
+ * mutates readiness (session_start is awaited before the first prompt). The
+ * recall filter and renderer are always active regardless of readiness.
+ *
+ * index.ts's `_resetState()` is the single reset entrypoint and calls all the
+ * resets here; tests already invoke `_resetState()`.
  */
 
 let startupReady = false;
 
-/** Whether at least one health + version readiness probe has succeeded. */
+/** Whether the most recent health + version readiness probe succeeded. */
 export function isStartupReady(): boolean {
   return startupReady;
 }
 
 /**
- * Mark startup as ready (true). This is a one-way latch: callers only ever set
- * it to true after a successful health + version readiness check. To
- * reset (tests / module reset), use {@link resetStartupReady}.
+ * Mark startup as ready (true). Called after a successful health + version
+ * probe. Readiness is re-enterable: {@link clearStartupReady} flips it back to
+ * false when a later `session_start` probe observes an unreachable/
+ * incompatible server, so the extension re-enters the unified degraded mode.
  */
 export function markStartupReady(): void {
   startupReady = true;
 }
 
+/** Flip startup readiness back to false (a later probe failed). */
+export function clearStartupReady(): void {
+  startupReady = false;
+}
+
 /** Reset the startup-ready latch to false. Exported for testing/reset only. */
 export function resetStartupReady(): void {
   startupReady = false;
+}
+
+/**
+ * Per-active-session project-local config readiness.
+ *
+ * Defaults to `true` (assume OK) so the pre-`session_start` window is not
+ * spuriously blocked — `startupReady` (false until the first healthy probe)
+ * gates that window. `session_start` re-evaluates and sets this on every
+ * session after the health/version probe. `/hindsight detach-project-name`
+ * also sets it back to `true` (detached wins) so the retain tool is
+ * immediately re-enabled.
+ */
+let activeSessionProjectReady = true;
+
+/** Whether the active session's project-local config is usable for retention. */
+export function isActiveSessionProjectReady(): boolean {
+  return activeSessionProjectReady;
+}
+
+/**
+ * Set the active-session project-name readiness. Unlike `markStartupReady`,
+ * this is NOT a one-way latch — callers may set it false (failed session_start)
+ * and back to true (detach / fixed cwd on a later session_start).
+ */
+export function setActiveSessionProjectReady(ready: boolean): void {
+  activeSessionProjectReady = ready;
+}
+
+/** Reset the active-session project-config latch to true. Exported for testing/reset only. */
+export function resetActiveSessionProjectReady(): void {
+  activeSessionProjectReady = true;
+}
+
+/**
+ * Unified operational-ready getter for the normal (enabled, valid-config)
+ * path. The extension is operational only when BOTH the process-global
+ * health/version probe has succeeded AND the active session's project-local
+ * project config is usable. Any single failed cause (unreachable/incompatible
+ * server, or required-but-missing/invalid cwd-local project config) puts the
+ * extension into the single degraded mode (status unhealthy, no Hindsight
+ * tools active, no auto-recall/retain/flush, operational subcommands
+ * blocked). See `index.ts`'s session_start handler for the per-session
+ * evaluation.
+ *
+ * The fail-fast path (invalid global config) is separate — it never creates
+ * a client and registers commands with a constant `() => false` readiness,
+ * and sets `degradedReason` to a `global-config` cause with the specific
+ * `global config is invalid: ...` message (joined validation errors) before
+ * registering commands.
+ */
+export function isOperationalReady(): boolean {
+  return isStartupReady() && activeSessionProjectReady;
+}
+
+/**
+ * The set of Hindsight tools that have been registered (process-global, via
+ * `registerTools`). Used by `refreshToolVisibility` to know which tools to
+ * re-show after leaving degraded mode, and to hide all of them when entering
+ * it. Set by `tools.ts`'s `registerTools`; reset by `index.ts`'s `_resetState()`.
+ */
+let registeredHindsightTools: string[] = [];
+
+/** Recorded registered Hindsight tool names (set by `registerTools`). */
+export function getRegisteredHindsightTools(): string[] {
+  return registeredHindsightTools;
+}
+
+/** Record the registered Hindsight tool names. Called by `registerTools`. */
+export function setRegisteredHindsightTools(names: string[]): void {
+  registeredHindsightTools = names;
+}
+
+/** Reset the registered-tools record. Exported for testing/reset only. */
+export function resetRegisteredHindsightTools(): void {
+  registeredHindsightTools = [];
+}
+
+export const DEGRADED_REASON_PENDING = "startup readiness has not completed yet";
+
+export const DegradedReasonKind = {
+  GlobalConfig: "global-config",
+  Server: "server",
+  ProjectName: "project-name",
+} as const;
+
+export type DegradedReasonKind = (typeof DegradedReasonKind)[keyof typeof DegradedReasonKind];
+
+export interface DegradedReason {
+  kind: DegradedReasonKind;
+  message: string;
+  /**
+   * For causes that carry a list of errors (e.g. global-config validation
+   * errors). When non-empty, the block message renders them as a bulleted
+   * list below `message`. The shared `epimetheus: ` log prefix is stripped
+   * from each at render (it is redundant inside an already-epimetheus-branded
+   * block message).
+   */
+  errors?: string[];
+  projectNameRecovery?: "detach-or-fix" | "fix-config";
+  /**
+   * Session cwd captured when the reason was set, used by recovery advice to
+   * render a concrete config file path. Falls back to `<cwd>/.pi/epimetheus/config.jsonc`
+   * when unknown.
+   */
+  cwd?: string;
+  /**
+   * Path of the invalid/unreadable project config file found on disk, when
+   * known. Used by recovery advice to point the user at the exact file to fix
+   * (which may be a `.json` file or a git-worktree commondir fallback, not
+   * always `<cwd>/.pi/epimetheus/config.jsonc`).
+   */
+  configPath?: string;
+}
+
+/**
+ * Typed cause plus human-readable message for the current degraded mode, or
+ * `null` when the extension is operational (or has not yet classified the
+ * cause). Set by `index.ts` whenever the unified readiness changes: a failed
+ * startup probe sets a server/version cause; a failed active-session
+ * project-local config sets a project-name cause; a return to
+ * operational clears it. Set on the fail-fast invalid-global-config path too
+ * (before registering commands) to a global-config cause with the specific
+ * `global config is invalid: ...` message. Slash commands read this to give a
+ * specific, repeatable block message, while recovery code checks `kind` rather
+ * than matching substrings in `message`. There is no generic catch-all
+ * fallback; when no reason is classified (e.g. before the first
+ * `session_start`), the block message uses the specific internal
+ * `"startup readiness has not completed yet"` reason.
+ */
+let degradedReason: DegradedReason | null = null;
+
+/** Set the degraded-mode reason (null = operational / unknown). */
+export function setDegradedReason(reason: DegradedReason | null): void {
+  degradedReason = reason;
+}
+
+/** The current degraded-mode reason, or null if none is classified. */
+export function getDegradedReason(): DegradedReason | null {
+  return degradedReason;
+}
+
+/** Reset the degraded-reason slot. Exported for testing/reset only. */
+export function resetDegradedReason(): void {
+  degradedReason = null;
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -9,7 +9,13 @@ import { type Static, Type } from "typebox";
 import type { HindsightClientWrapper } from "./client";
 import type { HindsightConfig, MemoryType, ToolName } from "./config";
 import { getHindsightMeta, shouldSessionBeRetained, updateSessionMetadata } from "./meta";
+import { resolveProjectName } from "./project-config";
 import { queueToolRetain } from "./retention";
+import {
+  getRegisteredHindsightTools,
+  isOperationalReady,
+  setRegisteredHindsightTools,
+} from "./runtime-state";
 import { extractParentSessionId } from "./utils";
 
 // Reusable schemas
@@ -96,12 +102,10 @@ export function registerTools(
   pi: ExtensionAPI,
   config: HindsightConfig,
   client: HindsightClientWrapper | null
-): void {
-  // Register hindsight_set_extra_context when enabled.
-  // Gated by toolsEnabled like all other tools. Can be included in the array
-  // as "set_extra_context". The /hindsight set-extra-context slash command still
-  // works regardless of this setting.
+): string[] {
+  const registered: string[] = [];
   if (isToolEnabled(config, "set_extra_context")) {
+    registered.push("hindsight_set_extra_context");
     pi.registerTool({
       name: "hindsight_set_extra_context",
       label: "Hindsight Extra Context",
@@ -157,6 +161,7 @@ export function registerTools(
   }
 
   if (isToolEnabled(config, "get_extra_context")) {
+    registered.push("hindsight_get_extra_context");
     pi.registerTool({
       name: "hindsight_get_extra_context",
       label: "Hindsight Get Extra Context",
@@ -206,6 +211,7 @@ export function registerTools(
 
   // Register hindsight_retain if enabled
   if (isToolEnabled(config, "retain")) {
+    registered.push("hindsight_retain");
     // hindsight_retain - always available, just queues to disk
     pi.registerTool({
       name: "hindsight_retain",
@@ -277,15 +283,41 @@ export function registerTools(
         const meta = getHindsightMeta(entries);
         const sessionUserTags = meta?.tags ?? [];
 
+        // Resolve the project name project-aware so tool retains share the
+        // same `project:` tag as session flushes. The session's recorded cwd
+        // (header.cwd) is authoritative — matches what the upsert path uses.
+        // If the session is marked as using project-local config and the
+        // resolution fails (cwd gone, or config missing/invalid), fail closed:
+        // do not queue — the memory would otherwise be tagged with the wrong
+        // project name
+        const retainCwd = header?.cwd ?? ctx.cwd;
+        const projectNameResult = resolveProjectName(retainCwd, meta?.usesProjectConfig);
+        if (!projectNameResult.ok) {
+          const recoveryAdvice =
+            projectNameResult.recovery === "fix-config"
+              ? `Fix the config at ${retainCwd}/.pi/epimetheus/config.jsonc.`
+              : `Use /hindsight detach-project-name to stop requiring the project-local projectName override, or restore the config at ${retainCwd}/.pi/epimetheus/.`;
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Failed to store memory: ${projectNameResult.error}. ${recoveryAdvice}`,
+              },
+            ],
+            details: { success: false, error: projectNameResult.error },
+          };
+        }
+
         const result = await queueToolRetain(
           sessionId,
           params.content,
           params.tags,
           params.metadata,
-          ctx.cwd,
+          retainCwd,
           parentSessionId,
           config,
-          sessionUserTags
+          sessionUserTags,
+          projectNameResult.projectName
         );
         if (!result.success) {
           return {
@@ -303,10 +335,11 @@ export function registerTools(
   }
 
   // recall and reflect require client
-  if (!client) return;
+  if (!client) return registered;
 
   // Register hindsight_recall if enabled
   if (isToolEnabled(config, "recall")) {
+    registered.push("hindsight_recall");
     pi.registerTool({
       name: "hindsight_recall",
       label: "Hindsight Recall",
@@ -383,6 +416,7 @@ export function registerTools(
 
   // Register hindsight_reflect if enabled
   if (isToolEnabled(config, "reflect")) {
+    registered.push("hindsight_reflect");
     pi.registerTool({
       name: "hindsight_reflect",
       label: "Hindsight Reflect",
@@ -442,31 +476,44 @@ export function registerTools(
       },
     });
   }
+
+  setRegisteredHindsightTools(registered);
+  return registered;
 }
 
 /**
- * Update whether hindsight_retain is visible to the LLM based on retention state.
+ * Refresh the visibility of all registered Hindsight tools based on the
+ * unified operational state and the session's retention flag.
  *
- * When a session is not retained, hindsight_retain is removed from active tools
- * so the LLM never sees it as an option (instead of seeing it and having calls fail).
- * When retained, it's added back if it was previously removed.
+ * - Degraded (`!isOperationalReady()`): hide ALL hindsight tools so the LLM
+ *   never sees any of them (no recall/reflect/retain/extra-context). This is
+ *   the single degraded mode regardless of cause (unreachable/incompatible
+ *   server, or required-but-missing/invalid cwd-local project config).
+ * - Operational: show all registered hindsight tools, except `hindsight_retain`
+ *   is hidden when the session is not retained (so the LLM never sees a tool
+ *   whose calls would fail). `retained` has no effect on the other tools.
  *
- * Note: The execute-time check in hindsight_retain remains as a defensive
- * fallback in case the tool is called through edge cases (e.g., mid-turn toggle).
+ * Reads `isOperationalReady()` and the registered-tool list from
+ * `runtime-state`, so callers only need to pass the session's `retained` flag.
+ *
+ * Enabling/disabling tools is the only place degraded mode is enforced — there
+ * are no operational-state checks inside tool execute handlers.
  */
-export function updateRetainToolVisibility(pi: ExtensionAPI, retained: boolean): void {
-  const toolName = "hindsight_retain";
+export function refreshToolVisibility(pi: ExtensionAPI, retained: boolean): void {
   const activeNames = pi.getActiveTools();
+  // Preserve non-hindsight tools (other extensions / built-ins) unchanged.
+  const nonHindsight = activeNames.filter((n) => !n.startsWith("hindsight_"));
 
-  if (retained) {
-    // Add hindsight_retain if not already active
-    if (!activeNames.includes(toolName)) {
-      pi.setActiveTools([...activeNames, toolName]);
-    }
-  } else {
-    // Remove hindsight_retain from active tools
-    if (activeNames.includes(toolName)) {
-      pi.setActiveTools(activeNames.filter((n) => n !== toolName));
-    }
+  if (!isOperationalReady()) {
+    // Degraded: hide all hindsight tools.
+    pi.setActiveTools(nonHindsight);
+    return;
   }
+
+  // Operational: show all registered hindsight tools except retain when not
+  // retained.
+  const toShow = getRegisteredHindsightTools().filter(
+    (name) => name !== "hindsight_retain" || retained
+  );
+  pi.setActiveTools([...nonHindsight, ...toShow]);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,8 +2,27 @@
  * Shared utility functions.
  */
 
-import { existsSync, readFileSync } from "node:fs";
-import { basename } from "node:path";
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { basename, dirname, isAbsolute, join } from "node:path";
+
+/** Convert a parser/string offset into a 1-based line/character location. */
+export function offsetToLineColumn(
+  content: string,
+  offset: number
+): { line: number; character: number } {
+  let line = 1;
+  let character = 1;
+  for (let i = 0; i < offset && i < content.length; i++) {
+    if (content[i] === "\n") {
+      line++;
+      character = 1;
+    } else {
+      character++;
+    }
+  }
+  return { line, character };
+}
 
 /**
  * Truncate a string to max character count (code points, not code units).
@@ -98,14 +117,189 @@ export function getBasedir(cwd: string): string {
 }
 
 /**
- * Get the project name, falling back to basedir if not set via env var.
- * Reads `EPIMETHEUS_PROJECT_NAME` if set, with `PI_HINDSIGHT_PROJECT_NAME` as a
- * legacy fallback; otherwise derives from the cwd basename.
+ * Resolve the git common dir for `cwd`, returning the absolute path of the
+ * common dir (e.g. `/repo/.git` for both `/repo` and `/repo/worktrees/foo`).
+ *
+ * Uses `git rev-parse --git-common-dir`. Returns `null` when `git` is
+ * unavailable, the commondir cannot be resolved, or the result is degenerate.
+ *
+ * Single-slot per-cwd cache: project-config lookup, default project-name
+ * derivation, and the active-session project-name cache all call this for the
+ * same cwd, so caching avoids redundant `git rev-parse` spawns. Cleared by
+ * {@link clearProjectNameCache}.
+ *
+ * Callers should guard this with `existsSync(join(cwd, ".git"))` to avoid
+ * spawning git for directories that are not git repos.
+ */
+export function resolveGitCommonDir(cwd: string): string | null {
+  if (commonDirCache?.cwd === cwd) return commonDirCache.commonDir;
+  let result: ReturnType<typeof spawnSync>;
+  try {
+    result = spawnSync("git", ["rev-parse", "--git-common-dir"], {
+      cwd,
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+  } catch {
+    return null;
+  }
+  if (result.error) return null;
+  if (typeof result.status !== "number" || result.status !== 0) return null;
+  const raw = typeof result.stdout === "string" ? result.stdout.trim() : "";
+  if (!raw) return null;
+
+  const abs = isAbsolute(raw) ? raw : join(cwd, raw);
+  const resolved = realpathOrSelf(abs);
+  commonDirCache = { cwd, commonDir: resolved };
+  return resolved;
+}
+
+/**
+ * Resolve the git commondir's parent path (the main repo root) for `cwd`.
+ *
+ * For a main repo `/repo` the commondir is `/repo/.git` and the parent is `/repo`.
+ * For a worktree `/repo/wt/foo` the commondir is also `/repo/.git` → parent `/repo`.
+ *
+ * Submodules are excluded: their commondir is `<super>/.git/modules/<name>`
+ * (basename is not `.git`), so taking its parent would resolve to `modules`
+ * instead of the submodule working tree. Only a commondir whose basename is
+ * `.git` — a real main-repo or linked-worktree shared dir — yields a parent.
+ *
+ * Returns `null` when the commondir cannot be resolved, is not a `.git` dir
+ * (e.g. a submodule), or the parent is degenerate (e.g. `/`). Callers can use
+ * this to look for `.pi` config in the main repo when a worktree doesn't have
+ * its own.
+ *
+ * Callers should guard this with `existsSync(join(cwd, ".git"))` to avoid
+ * spawning git for directories that are not git repos.
+ */
+export function resolveGitCommonDirParent(cwd: string): string | null {
+  const commonDir = resolveGitCommonDir(cwd);
+  // Only a `.git` commondir (main repo or linked worktree shared dir) has a
+  // meaningful parent. A submodule's commondir is `<super>/.git/modules/<name>`
+  // — its basename is not `.git`, so skip it and let callers fall back to
+  // basename(cwd).
+  const parent = !commonDir || basename(commonDir) !== ".git" ? null : dirname(commonDir);
+  return !parent || parent === "/" || parent === "." ? null : parent;
+}
+
+/**
+ * Derive the main repo name from `<cwd>/.git`'s git common dir, so worktrees
+ * share the main repo name instead of each getting their worktree dir name.
+ *
+ * Uses `git rev-parse --git-common-dir`, then derives a name based on the
+ * commondir's layout:
+ *   - main repo `/repo`         → commondir `/repo/.git` → `repo`
+ *   - worktree `/repo/wt/foo`   → commondir `/repo/.git` → `repo` (shared)
+ *   - submodule `/super/mysub`  → commondir `/super/.git/modules/mysub` → `mysub`
+ *   - submodule worktree        → same commondir            → `mysub` (shared)
+ *
+ * For a `.git` commondir (main repo or linked worktree), the name is
+ * `basename(dirname(commonDir))`. For a submodule commondir (basename is not
+ * `.git`, e.g. `<super>/.git/modules/<name>`), the name is
+ * `basename(commonDir)` — the submodule name — so submodule worktrees share it.
+ *
+ * Returns `null` when `git` is unavailable, the commondir cannot be resolved,
+ * or the derived name is empty / degenerate. Callers fall back to basename.
+ *
+ * Callers should guard this with `existsSync(join(cwd, ".git"))` to avoid
+ * spawning git for directories that are not git repos.
+ */
+export function deriveGitProjectName(cwd: string): string | null {
+  const commonDir = resolveGitCommonDir(cwd);
+  if (!commonDir) return null;
+  const base = basename(commonDir);
+  // `.git` commondir (main repo / linked worktree) → name is the parent dir.
+  // Submodule commondir (`<super>/.git/modules/<name>`) → name is the
+  // commondir basename (the submodule name), so worktrees share it.
+  const name = base === ".git" ? basename(dirname(commonDir)) : base;
+  if (!name || name === "/" || name === ".") return null;
+  return name;
+}
+
+/**
+ * Resolve a symlink'd path to its real target. Falls back to the input path
+ * when realpath fails (e.g., the path was already removed between the
+ * `existsSync` check and the realpath call).
+ */
+function realpathOrSelf(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
+}
+
+/**
+ * Derive the default project name for a cwd and report its source, WITHOUT
+ * caching. If `<cwd>/.git` exists and {@link deriveGitProjectName} returns a
+ * name, returns `{ name, source: "git" }` (so a main repo and its worktrees
+ * share the main repo name); otherwise returns `{ name: basename(cwd),
+ * source: "basename" }`.
+ *
+ * This is the uncached primitive underneath {@link getProjectName}. The flush
+ * path calls this directly (via `project-config.ts`'s `defaultProjectName`) rather
+ * than {@link getProjectName}, because `flush-pending` resolves many session
+ * cwds per run and must NOT go through the active-session-oriented single-slot
+ * cache.
+ */
+export function deriveDefaultProjectName(cwd: string): {
+  name: string;
+  source: "git" | "basename";
+} {
+  if (existsSync(join(cwd, ".git"))) {
+    const gitName = deriveGitProjectName(cwd);
+    if (gitName !== null) return { name: gitName, source: "git" };
+    // fall through to basename on any git failure
+  }
+  return { name: basename(cwd), source: "basename" };
+}
+
+/**
+ * Single-slot cache for the default project name, keyed by cwd. The active
+ * session's cwd is stable within a session, so the (potentially slow) git
+ * derivation runs at most once per cwd instead of on every turn (auto-recall
+ * builds `{project}` placeholder params on every `before_agent_start`).
+ * Cleared by {@link clearProjectNameCache} (tests / module reset).
+ *
+ * Only the *active* session's name is cached here — batch flushers that resolve
+ * many cwds (flush-pending) should call {@link deriveDefaultProjectName} directly.
+ */
+let projectNameCache: { cwd: string; name: string } | null = null;
+
+/**
+ * Single-slot per-cwd cache for {@link resolveGitCommonDir}, so the
+ * project-config fallback lookup and default project-name derivation share one
+ * `git rev-parse` spawn per cwd. Cleared alongside the project-name cache.
+ */
+let commonDirCache: { cwd: string; commonDir: string } | null = null;
+
+/** Clear the project-name and commondir caches. Exported for tests/reset via `_resetState()`. */
+export function clearProjectNameCache(): void {
+  projectNameCache = null;
+  commonDirCache = null;
+}
+
+/**
+ * Get the default project name for a cwd: git common dir (so worktrees share
+ * the main repo name) → basename. Cached per cwd (single-slot, active-session
+ * oriented).
+ *
+ * This is the default derivation shared by the flush path (via
+ * {@link ./project-config.ts resolveProjectName}'s detached/unmarked case)
+ * and the auto-recall `{project}` placeholder. Project-local project config can
+ * override the project name for flush/tool-retain tagging. Env-var overrides
+ * (`EPIMETHEUS_PROJECT_NAME` / legacy `PI_HINDSIGHT_PROJECT_NAME`) were removed
+ * because env vars do not track Pi session switching.
+ *
+ * Callers resolving many cwds per run (e.g. flush-pending) should call
+ * {@link deriveDefaultProjectName} directly to bypass the active-session cache.
  */
 export function getProjectName(cwd: string): string {
-  return (
-    process.env.EPIMETHEUS_PROJECT_NAME || process.env.PI_HINDSIGHT_PROJECT_NAME || basename(cwd)
-  );
+  if (projectNameCache?.cwd === cwd) return projectNameCache.name;
+  const name = deriveDefaultProjectName(cwd).name;
+  projectNameCache = { cwd, name };
+  return name;
 }
 
 /**

--- a/tests/bootstrap.test.ts
+++ b/tests/bootstrap.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
@@ -369,6 +369,279 @@ describe("real entrypoint bootstrap", () => {
     await handler({ type: "session_start" }, ctx);
 
     expect(pi.appendedEntries).toHaveLength(0);
+  });
+
+  it("session_start auto-marks usesProjectConfig:true when cwd has a valid project config (new session)", async () => {
+    // New session, no existing metadata, but cwd has a valid cwd-local flush
+    // config: session_start should mint both retained:true AND
+    // usesProjectConfig:true in the new hindsight-meta entry.
+    const { withTempDir } = await import("./fixtures");
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    await withTempDir(async (tmpCwd) => {
+      mkdirSync(join(tmpCwd, ".pi", "epimetheus"), { recursive: true });
+      writeFileSync(
+        join(tmpCwd, ".pi", "epimetheus", "config.jsonc"),
+        JSON.stringify({ projectName: "marked-project" }),
+        "utf-8"
+      );
+
+      const pi = createMockPi();
+      const extension = await import("../src/index");
+      extension.default(pi);
+
+      const baseCtx = createMockContext();
+      const ctx = {
+        ...baseCtx,
+        cwd: tmpCwd,
+        sessionManager: {
+          ...baseCtx.sessionManager,
+          getHeader: mock(() => ({
+            id: "auto-mark-sess",
+            timestamp: "2026-01-01T00:00:00Z",
+            cwd: tmpCwd,
+            parentSession: undefined,
+          })),
+          getEntries: mock(() => []),
+        },
+      } as unknown as ExtensionContext;
+      const handler = pi.handlers.get("session_start")!;
+      await handler({ type: "session_start" }, ctx);
+
+      const metaEntries = pi.appendedEntries.filter((e) => e.customType === "hindsight-meta");
+      expect(metaEntries).toHaveLength(1);
+      const data = metaEntries[0]?.data as {
+        retained?: boolean;
+        usesProjectConfig?: boolean;
+      };
+      expect(data.retained).toBe(true);
+      expect(data.usesProjectConfig).toBe(true);
+    });
+  });
+
+  it("session_start preserves an explicit usesProjectConfig:false detach on resume (latest-wins; no auto-remark)", async () => {
+    // Resumed session with an explicit usesProjectConfig:false (after a
+    // /hindsight detach-project-name). cwd still has a valid project config.
+    // session_start must NOT append a new true entry that would override the
+    // detach (latest-wins means we leave an explicit value alone).
+    const { withTempDir } = await import("./fixtures");
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    await withTempDir(async (tmpCwd) => {
+      mkdirSync(join(tmpCwd, ".pi", "epimetheus"), { recursive: true });
+      writeFileSync(
+        join(tmpCwd, ".pi", "epimetheus", "config.jsonc"),
+        JSON.stringify({ projectName: "marked-project" }),
+        "utf-8"
+      );
+
+      const pi = createMockPi();
+      const extension = await import("../src/index");
+      extension.default(pi);
+
+      const baseCtx = createMockContext();
+      const ctx = {
+        ...baseCtx,
+        cwd: tmpCwd,
+        sessionManager: {
+          ...baseCtx.sessionManager,
+          getHeader: mock(() => ({
+            id: "detach-resume-sess",
+            timestamp: "2026-01-01T00:00:00Z",
+            cwd: tmpCwd,
+            parentSession: undefined,
+          })),
+          getEntries: mock(() => [
+            {
+              type: "custom",
+              customType: "hindsight-meta",
+              data: { retained: true, usesProjectConfig: false },
+            },
+          ]),
+        },
+      } as unknown as ExtensionContext;
+      const handler = pi.handlers.get("session_start")!;
+      await handler({ type: "session_start" }, ctx);
+
+      // Existing meta already has usesProjectConfig:false explicit. No new
+      // hindsight-meta entry should be appended auto-marking true.
+      const metaEntries = pi.appendedEntries.filter((e) => e.customType === "hindsight-meta");
+      expect(metaEntries).toHaveLength(0);
+    });
+  });
+
+  it("session_start enters failed/unhealthy mode when the cwd-local project config is invalid (unmarked active session)", async () => {
+    // Single degraded mode: an invalid cwd-local project config at the active
+    // session's cwd hard-fails the active session: unhealthy status, ALL
+    // Hindsight tools hidden (not just retain), no auto-retain, no metadata
+    // auto-mark, no startup flush. Diagnostic commands + detach-project-name
+    // remain available.
+    const { withTempDir } = await import("./fixtures");
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    await withTempDir(async (tmpCwd) => {
+      mkdirSync(join(tmpCwd, ".pi", "epimetheus"), { recursive: true });
+      // Invalid: missing required projectName.
+      writeFileSync(
+        join(tmpCwd, ".pi", "epimetheus", "config.jsonc"),
+        JSON.stringify({ notProjectName: "x" }),
+        "utf-8"
+      );
+
+      const pi = createMockPi();
+      const extension = await import("../src/index");
+      extension.default(pi);
+
+      const baseCtx = createMockContext();
+      const ctx = {
+        ...baseCtx,
+        cwd: tmpCwd,
+        sessionManager: {
+          ...baseCtx.sessionManager,
+          getHeader: mock(() => ({
+            id: "invalid-flush-sess",
+            timestamp: "2026-01-01T00:00:00Z",
+            cwd: tmpCwd,
+            parentSession: undefined,
+          })),
+          getEntries: mock(() => []), // unmarked (no existing meta)
+        },
+      } as unknown as ExtensionContext;
+      const handler = pi.handlers.get("session_start")!;
+      await handler({ type: "session_start" }, ctx);
+
+      // Failed mode: unhealthy status, no metadata appended.
+      expect(ctx.ui.setStatus).toHaveBeenCalledWith("epimetheus", "🤯");
+      const metaEntries = pi.appendedEntries.filter((e) => e.customType === "hindsight-meta");
+      expect(metaEntries).toHaveLength(0);
+      // ALL Hindsight tools were hidden (degraded hides every hindsight_* tool):
+      // the last setActiveTools call must contain no hindsight_* tool names.
+      const lastSetActive = pi.setActiveToolsCalls[pi.setActiveToolsCalls.length - 1] ?? [];
+      expect(lastSetActive.filter((n) => n.startsWith("hindsight_"))).toHaveLength(0);
+      // The active-session flush latch is false → the extension is not operational.
+      const { isActiveSessionProjectReady, isOperationalReady } =
+        require("../src/runtime-state") as typeof import("../src/runtime-state");
+      expect(isActiveSessionProjectReady()).toBe(false);
+      expect(isOperationalReady()).toBe(false);
+      // A clear warning was surfaced pointing at the invalid config, without
+      // suggesting detach for an invalid config file.
+      const notifyCalls = (ctx.ui.notify as ReturnType<typeof mock>).mock.calls.map((c) =>
+        String(c[0])
+      );
+      expect(
+        notifyCalls.some((m) => m.includes("Project config unavailable") && m.includes("Fix "))
+      ).toBe(true);
+      expect(notifyCalls.some((m) => m.includes("detach-project-name"))).toBe(false);
+    });
+  });
+
+  it("message_end auto-retain is blocked when the active session is in failed project-name mode", async () => {
+    const { withTempDir } = await import("./fixtures");
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    await withTempDir(async (tmpCwd) => {
+      mkdirSync(join(tmpCwd, ".pi", "epimetheus"), { recursive: true });
+      writeFileSync(
+        join(tmpCwd, ".pi", "epimetheus", "config.jsonc"),
+        JSON.stringify({ notProjectName: "x" }),
+        "utf-8"
+      );
+
+      const pi = createMockPi();
+      const extension = await import("../src/index");
+      extension.default(pi);
+
+      const sessionId = BOOTSTRAP_SESSION;
+      const { removePendingFlag, hasPendingFlag } =
+        require("../src/queue") as typeof import("../src/queue");
+      removePendingFlag(sessionId);
+
+      const baseCtx = createMockContext();
+      const ctx = {
+        ...baseCtx,
+        cwd: tmpCwd,
+        sessionManager: {
+          ...baseCtx.sessionManager,
+          getSessionId: mock(() => sessionId),
+          getHeader: mock(() => ({
+            id: sessionId,
+            timestamp: "2026-01-01T00:00:00Z",
+            cwd: tmpCwd,
+            parentSession: undefined,
+          })),
+          getEntries: mock(() => []),
+        },
+      } as unknown as ExtensionContext;
+
+      // session_start: failed mode (invalid project config).
+      const startHandler = pi.handlers.get("session_start")!;
+      await startHandler({ type: "session_start" }, ctx);
+      expect(ctx.ui.setStatus).toHaveBeenCalledWith("epimetheus", "🤯");
+
+      // message_end must NOT queue (active session failed project-name state).
+      const messageEndHandler = pi.handlers.get("message_end")!;
+      await messageEndHandler(
+        { type: "message_end", message: { role: "user", content: [{ type: "text", text: "Hi" }] } },
+        ctx
+      );
+      expect(hasPendingFlag(sessionId)).toBe(false);
+
+      removePendingFlag(sessionId);
+    });
+  });
+
+  it("session_start preserves a valid active session (usesProjectConfig:false detached) even when cwd has an invalid project config", async () => {
+    // Detached wins: when the session has an explicit usesProjectConfig:false,
+    // an invalid cwd-local project config must NOT fail the active session.
+    const { withTempDir } = await import("./fixtures");
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    await withTempDir(async (tmpCwd) => {
+      mkdirSync(join(tmpCwd, ".pi", "epimetheus"), { recursive: true });
+      writeFileSync(
+        join(tmpCwd, ".pi", "epimetheus", "config.jsonc"),
+        JSON.stringify({ notProjectName: "x" }),
+        "utf-8"
+      );
+
+      const pi = createMockPi();
+      const extension = await import("../src/index");
+      extension.default(pi);
+      await runHealthySessionStart(pi); // latch startupReady on a healthy (no-project-config) session first
+
+      const baseCtx = createMockContext();
+      const ctx = {
+        ...baseCtx,
+        cwd: tmpCwd,
+        sessionManager: {
+          ...baseCtx.sessionManager,
+          getHeader: mock(() => ({
+            id: "detached-despite-invalid",
+            timestamp: "2026-01-01T00:00:00Z",
+            cwd: tmpCwd,
+            parentSession: undefined,
+          })),
+          getEntries: mock(() => [
+            {
+              type: "custom",
+              customType: "hindsight-meta",
+              data: { retained: true, usesProjectConfig: false },
+            },
+          ]),
+        },
+      } as unknown as ExtensionContext;
+      const handler = pi.handlers.get("session_start")!;
+      await handler({ type: "session_start" }, ctx);
+
+      // Detached wins: NOT unhealthy (server probe succeeds → healthy; flush state ready).
+      expect(ctx.ui.setStatus).toHaveBeenCalledWith("epimetheus", "🧠");
+      const { isActiveSessionProjectReady } =
+        require("../src/runtime-state") as typeof import("../src/runtime-state");
+      expect(isActiveSessionProjectReady()).toBe(true);
+      // No new hindsight-meta appended (existing meta already present; detach preserved).
+      const metaEntries = pi.appendedEntries.filter((e) => e.customType === "hindsight-meta");
+      expect(metaEntries).toHaveLength(0);
+    });
   });
 
   it("session_start handler sets unhealthy status when server version is incompatible", async () => {
@@ -1628,6 +1901,83 @@ describe("real entrypoint bootstrap", () => {
     }
   });
 
+  it("operational subcommands are blocked on the unified getter when the active session's project config is invalid", async () => {
+    // Point 3: operational commands gate on the unified operational-ready getter
+    // (startupReady && activeSessionProjectReady), not just startupReady. When the
+    // active session fails the project-name check, operational commands are
+    // blocked even though the server is healthy (startupReady latched).
+    const { withTempDir } = await import("./fixtures");
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    await withTempDir(async (tmpCwd) => {
+      mkdirSync(join(tmpCwd, ".pi", "epimetheus"), { recursive: true });
+      writeFileSync(
+        join(tmpCwd, ".pi", "epimetheus", "config.jsonc"),
+        JSON.stringify({ notProjectName: "x" }),
+        "utf-8"
+      );
+
+      const pi = createMockPi();
+      const extension = await import("../src/index");
+      extension.default(pi);
+
+      const sessionId = BOOTSTRAP_SESSION;
+      const { removePendingFlag, hasPendingFlag, touchPendingFlag, clearSessionQueueState } =
+        require("../src/queue") as typeof import("../src/queue");
+      removePendingFlag(sessionId);
+
+      const baseCtx = createMockContext({ _sessionId: sessionId });
+      const ctx = {
+        ...baseCtx,
+        cwd: tmpCwd,
+        sessionManager: {
+          ...baseCtx.sessionManager,
+          getSessionId: mock(() => sessionId),
+          getHeader: mock(() => ({
+            id: sessionId,
+            timestamp: "2026-01-01T00:00:00Z",
+            cwd: tmpCwd,
+            parentSession: undefined,
+          })),
+          getEntries: mock(() => []), // unmarked + invalid config → failed
+        },
+      } as unknown as ExtensionContext;
+
+      // session_start: server healthy (latches startupReady) but project config
+      // invalid → activeSessionProjectReady=false → not operational.
+      const startHandler = pi.handlers.get("session_start")!;
+      await startHandler({ type: "session_start" }, ctx);
+      const { isStartupReady, isOperationalReady } =
+        require("../src/runtime-state") as typeof import("../src/runtime-state");
+      expect(isStartupReady()).toBe(true);
+      expect(isOperationalReady()).toBe(false);
+
+      // An operational subcommand (/hindsight flush) must be blocked by the
+      // unified getter → blocked message, no side effects.
+      await touchPendingFlag(sessionId);
+      const commandHandler = (
+        pi.commands.get("hindsight") as {
+          handler: (a: string, ctx: ExtensionContext) => Promise<void>;
+        }
+      ).handler;
+      const ctxCmd = createMockContext({ _sessionId: sessionId });
+      await commandHandler("flush", ctxCmd);
+      const msgs = (ctxCmd.ui.notify as ReturnType<typeof mock>).mock.calls.map((c) =>
+        String(c[0])
+      );
+      expect(msgs.some((m) => m.includes("epimetheus: operational commands"))).toBe(true);
+      // The SPECIFIC project-name cause is surfaced, not the generic
+      // "not ready" catch-all.
+      expect(msgs.some((m) => m.includes("project config") && m.includes("invalid"))).toBe(true);
+      // No flush ran: the pending marker survives.
+      expect(hasPendingFlag(sessionId)).toBe(true);
+
+      removePendingFlag(sessionId);
+      clearSessionQueueState(sessionId);
+      cleanupParsedArtifacts(sessionId);
+    });
+  });
+
   it("session_before_switch handler flushes queued messages", async () => {
     const pi = createMockPi();
     const extension = await import("../src/index");
@@ -1678,6 +2028,51 @@ describe("real entrypoint bootstrap", () => {
 
     // Recall renderer still registered so persisted recall messages display/filter.
     expect(pi.renderers.has("hindsight-recall")).toBe(true);
+  });
+
+  it("invalid config: manual /hindsight flush surfaces the specific invalid-config reason and does NOT suggest detach", async () => {
+    // Invalid global config → fail-fast path. Manual operational commands must
+    // surface the SPECIFIC invalid-config reason (the validation errors) on
+    // every attempt, must NOT mention detach-project-name, and must NOT emit
+    // the old all-encompassing "not ready" catch-all.
+    activeConfig = { ...testConfig, apiUrl: "", apiKey: "" };
+
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+
+    const commandHandler = (
+      pi.commands.get("hindsight") as {
+        handler: (args: string, ctx: ExtensionContext) => Promise<void>;
+      }
+    ).handler;
+
+    const sessionId = BOOTSTRAP_SESSION;
+    const { removePendingFlag, hasPendingFlag, touchPendingFlag } =
+      require("../src/queue") as typeof import("../src/queue");
+    removePendingFlag(sessionId);
+    await touchPendingFlag(sessionId);
+
+    const ctx = createMockContext({ _sessionId: sessionId });
+    await commandHandler("flush", ctx);
+    const msgs = (ctx.ui.notify as ReturnType<typeof mock>).mock.calls.map((c) => String(c[0]));
+    expect(msgs.some((m) => m.includes("blocked while in degraded mode"))).toBe(true);
+    expect(msgs.some((m) => m.includes("global config is invalid"))).toBe(true);
+    // Validation errors render as a bulleted list (one per error), with the
+    // redundant `epimetheus: ` per-error log prefix stripped at render.
+    expect(msgs.some((m) => m.includes("  - apiUrl is required"))).toBe(true);
+    expect(msgs.some((m) => m.includes("  - apiKey is required"))).toBe(true);
+    expect(msgs.some((m) => m.includes("epimetheus: apiUrl"))).toBe(false);
+    // Points to /hindsight config (not detach/status).
+    expect(msgs.some((m) => m.includes("/hindsight config"))).toBe(true);
+    // NO detach-project-name advice for an invalid-config cause.
+    expect(msgs.some((m) => m.includes("detach-project-name"))).toBe(false);
+    // NO old generic catch-all.
+    expect(msgs.some((m) => m.includes("not ready"))).toBe(false);
+    // No flush ran: the pending marker survives.
+    expect(hasPendingFlag(sessionId)).toBe(true);
+
+    removePendingFlag(sessionId);
   });
 
   it("invalid config: session_start sets unhealthy status with no metadata/state/queue side effects", async () => {
@@ -2676,16 +3071,17 @@ describe("real entrypoint bootstrap", () => {
     // Verifies that auto-recall uses event.prompt instead of scanning entries.
     // getEntries() returns empty here (first message of session), confirming
     // the handler doesn't depend on entries being populated.
+    const recall = mock(() =>
+      Promise.resolve({
+        success: true,
+        response: { results: [{ id: "1", text: "First message memory" }] },
+      })
+    );
     activeClientFactory = () => ({
       healthCheck: mock(() => Promise.resolve({ success: true })),
       retain: mock(() => Promise.resolve({ success: true })),
       retainBatch: mock(() => Promise.resolve({ success: true })),
-      recall: mock(() =>
-        Promise.resolve({
-          success: true,
-          response: { results: [{ id: "1", text: "First message memory" }] },
-        })
-      ),
+      recall,
       reflect: mock(() => Promise.resolve({ success: true, response: { text: "" } })),
     });
 
@@ -2704,6 +3100,10 @@ describe("real entrypoint bootstrap", () => {
 
     // event.prompt is available even though entries are empty
     await basHandler({ type: "before_agent_start", prompt: "Hello from first message" }, ctxBas);
+
+    expect(recall).toHaveBeenCalledTimes(1);
+    const recallCalls = recall.mock.calls as unknown as Array<[Record<string, unknown>]>;
+    expect(recallCalls[0]?.[0]).toMatchObject({ query: "Hello from first message" });
 
     // Recall was performed and cached — context handler re-injects it
     const contextHandler = pi.handlers.get("context")!;
@@ -2750,8 +3150,69 @@ describe("real entrypoint bootstrap", () => {
   // the real first-turn ordering rather than masking it with a pre-latched
   // readiness.
 
-  it("before_agent_start recalls on the first turn even before a healthy session_start has latched readiness", async () => {
-    // Healthy server. Readiness is NOT pre-latched (no runHealthySessionStart).
+  it("before_agent_start skips recall and does NOT probe/mutate readiness when not operational", async () => {
+    // New contract: session_start is awaited before the first prompt, so
+    // before_agent_start only checks the unified operational state and returns
+    // if degraded. It must NOT call ensureStartupReady() or mutate readiness
+    // (no on-demand health/version probe, no status mutation). Here no healthy
+    // session_start has latched readiness, so recall is skipped for this turn.
+    activeClientFactory = () => ({
+      healthCheck: mock(() => Promise.resolve({ success: true })),
+      getServerVersion: mock(() => Promise.resolve({ success: true, version: "0.9.0" })),
+      retain: mock(() => Promise.resolve({ success: true })),
+      retainBatch: mock(() => Promise.resolve({ success: true })),
+      recall: mock(() =>
+        Promise.resolve({
+          success: true,
+          response: { results: [{ id: "1", text: "should not be used" }] },
+        })
+      ),
+      reflect: mock(() => Promise.resolve({ success: true, response: { text: "" } })),
+    });
+
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+
+    const { isStartupReady, isActiveSessionProjectReady } =
+      require("../src/runtime-state") as typeof import("../src/runtime-state");
+    expect(isStartupReady()).toBe(false);
+    expect(isActiveSessionProjectReady()).toBe(true); // default, but startup not latched
+
+    const basHandler = pi.handlers.get("before_agent_start")!;
+    const ctx = createMockContext();
+    await basHandler({ type: "before_agent_start", prompt: "Hello" }, ctx);
+
+    // before_agent_start did NOT probe or mutate readiness: startup stays
+    // unlatched, and NO status call was made (session_start owns status).
+    expect(isStartupReady()).toBe(false);
+    expect(ctx.ui.setStatus).not.toHaveBeenCalled();
+    // No operational side effects: no metadata, no tools registered, no recall.
+    expect(pi.appendedEntries.filter((e) => e.customType === "hindsight-meta")).toHaveLength(0);
+    expect(pi.tools.filter((t) => t.name.startsWith("hindsight_"))).toHaveLength(0);
+
+    // Recall was skipped: the context handler has no cached memory to inject.
+    const contextHandler = pi.handlers.get("context")!;
+    const contextResult = (await contextHandler(
+      {
+        type: "context",
+        messages: [
+          { role: "user", content: [{ type: "text", text: "Hello" }], customType: undefined },
+        ],
+      },
+      createMockContext()
+    )) as Record<string, unknown> | undefined;
+    const messages = (contextResult?.messages ?? []) as Array<{ content?: unknown }>;
+    const leaked = messages.find(
+      (m) => typeof m.content === "string" && m.content.includes("should not be used")
+    );
+    expect(leaked).toBeUndefined();
+  });
+
+  it("before_agent_start recalls when operational (after a healthy session_start)", async () => {
+    // Once a healthy session_start has latched startup readiness and validated
+    // the active session's project config, the extension is operational and
+    // before_agent_start recalls from event.prompt.
     activeClientFactory = () => ({
       healthCheck: mock(() => Promise.resolve({ success: true })),
       getServerVersion: mock(() => Promise.resolve({ success: true, version: "0.9.0" })),
@@ -2770,31 +3231,20 @@ describe("real entrypoint bootstrap", () => {
     const extension = await import("../src/index");
     extension.default(pi);
 
-    const { isStartupReady } =
-      require("../src/runtime-state") as typeof import("../src/runtime-state");
-    expect(isStartupReady()).toBe(false);
+    // Latch readiness + validate the active session via a healthy session_start.
+    await runHealthySessionStart(pi);
 
-    // First turn: no healthy session_start yet. before_agent_start must
-    // establish health/version readiness on demand (so recall is allowed even
-    // before a healthy session_start has latched it), then recall using
-    // event.prompt. It deliberately does NOT initialize session metadata/tools/
-    // retain visibility — that stays owned by session_start (which will run on
-    // the real lifecycle event). Here we only assert recall works from
-    // event.prompt despite empty entries.
     const basHandler = pi.handlers.get("before_agent_start")!;
     const ctxBas = createMockContext({
       sessionManager: {
         ...createMockContext().sessionManager,
-        getEntries: mock(() => []), // First message — no entries yet
+        getEntries: mock(() => []),
       },
     });
     await basHandler({ type: "before_agent_start", prompt: "Hello from first turn" }, ctxBas);
 
-    // Readiness was latched by the on-demand health/version establish.
-    expect(isStartupReady()).toBe(true);
-
-    // Recall ran (query from event.prompt despite empty entries): the context
-    // handler re-injects the cached memory.
+    // Recall ran (query from event.prompt): the context handler re-injects
+    // the cached memory.
     const contextHandler = pi.handlers.get("context")!;
     const contextResult = (await contextHandler(
       {
@@ -2818,74 +3268,11 @@ describe("real entrypoint bootstrap", () => {
     expect(recallMsg?.content).toContain("First-turn memory");
   });
 
-  it("before_agent_start skips recall when the first-turn health check genuinely fails (safety preserved)", async () => {
-    // Server is genuinely unreachable — health check fails on the on-demand
-    // verify too. Recall must be skipped and readiness must NOT latch.
-    activeClientFactory = () => ({
-      healthCheck: mock(() => Promise.resolve({ success: false, error: "Connection refused" })),
-      getServerVersion: mock(() => Promise.resolve({ success: true, version: "0.9.0" })),
-      retain: mock(() => Promise.resolve({ success: true })),
-      retainBatch: mock(() => Promise.resolve({ success: true })),
-      recall: mock(() =>
-        Promise.resolve({
-          success: true,
-          response: { results: [{ id: "1", text: "should not be used" }] },
-        })
-      ),
-      reflect: mock(() => Promise.resolve({ success: true, response: { text: "" } })),
-    });
-
-    const pi = createMockPi();
-    const extension = await import("../src/index");
-    extension.default(pi);
-
-    const { isStartupReady } =
-      require("../src/runtime-state") as typeof import("../src/runtime-state");
-    expect(isStartupReady()).toBe(false);
-
-    const basHandler = pi.handlers.get("before_agent_start")!;
-    const ctx = createMockContext();
-    await basHandler({ type: "before_agent_start", prompt: "Hello" }, ctx);
-
-    // Readiness was NOT latched (on-demand verify failed).
-    expect(isStartupReady()).toBe(false);
-    expect(ctx.ui.setStatus).toHaveBeenCalledWith("epimetheus", "🤯");
-    // Safety: no operational init ran on the failed probe — no metadata, no
-    // tools, no recall. (Health/version readiness gated recall here; session
-    // init is session_start-owned and a healthy session_start never ran.)
-    expect(pi.appendedEntries.filter((e) => e.customType === "hindsight-meta")).toHaveLength(0);
-    expect(pi.tools.filter((t) => t.name.startsWith("hindsight_"))).toHaveLength(0);
-
-    // Recall was skipped: no memory is available for the context handler to
-    // re-inject (the returned messages are the original user message only).
-    const contextHandler = pi.handlers.get("context")!;
-    const contextResult = (await contextHandler(
-      {
-        type: "context",
-        messages: [
-          {
-            role: "user",
-            content: [{ type: "text", text: "Hello" }],
-            customType: undefined,
-          },
-        ],
-      },
-      createMockContext()
-    )) as Record<string, unknown> | undefined;
-    const messages = (contextResult?.messages ?? []) as Array<{ content?: unknown }>;
-    const leaked = messages.find(
-      (m) => typeof m.content === "string" && m.content.includes("should not be used")
-    );
-    expect(leaked).toBeUndefined();
-  });
-
-  it("ensureStartupReady is single-flight: overlapping session_start and before_agent_start share one probe pass", async () => {
-    // If session_start and before_agent_start both try to establish readiness
-    // concurrently (before the first latch), they must join the same in-flight
-    // health/version probe rather than running duplicate/concurrent probes.
-    // (`ensureStartupReady` does health/version readiness only; session init is
-    // owned by session_start. The init-once assertions below cover session_start's
-    // path, which the winning — healthy — readiness attempt then runs into.)
+  it("ensureStartupReady is single-flight across overlapping session_starts; before_agent_start does not probe at all", async () => {
+    // New contract: before_agent_start no longer calls ensureStartupReady() — it
+    // only reads isOperationalReady() and returns if degraded, so it must NOT
+    // trigger or join any health/version probe. ensureStartupReady remains
+    // single-flight for overlapping session_starts (they share one probe pass).
     let probeCount = 0;
     let resolveHealth: (v: { success: boolean }) => void = () => {};
     activeClientFactory = () => ({
@@ -2914,9 +3301,6 @@ describe("real entrypoint bootstrap", () => {
     const startHandler = pi.handlers.get("session_start")!;
     const basHandler = pi.handlers.get("before_agent_start")!;
 
-    // Both ctxs return no existing hindsight-meta so the single shared probe's
-    // session_start winner always appends exactly one (deterministic regardless
-    // of which caller wins).
     const ctxNoMeta = () =>
       createMockContext({
         sessionManager: {
@@ -2925,32 +3309,37 @@ describe("real entrypoint bootstrap", () => {
         },
       });
 
-    // Kick off both WITHOUT awaiting, so both see isStartupReady()===false and
-    // both try to establish readiness before the first one completes.
-    const startPromise = startHandler({ type: "session_start" }, ctxNoMeta());
-    const basPromise = basHandler({ type: "before_agent_start", prompt: "overlap" }, ctxNoMeta());
-
-    // Let the microtask queue settle so both callers have entered their
-    // ensureStartupReady() (first sets the promise, second joins it).
-    await Promise.resolve();
-    await Promise.resolve();
-
-    // Only ONE health probe should be in flight (single-flight shared).
-    expect(probeCount).toBe(1);
-
-    // Resolve the single probe healthy → both promises resolve ready.
-    resolveHealth({ success: true });
-    await Promise.all([startPromise, basPromise]);
-
-    const { isStartupReady } =
+    // Fire a before_agent_start while no session_start has run (not ready).
+    // It must NOT call ensureStartupReady: no probe is triggered, and recall is
+    // skipped (degraded). So probeCount stays 0.
+    await basHandler({ type: "before_agent_start", prompt: "overlap" }, ctxNoMeta());
+    expect(probeCount).toBe(0);
+    const { isStartupReady, isOperationalReady } =
       require("../src/runtime-state") as typeof import("../src/runtime-state");
+    expect(isStartupReady()).toBe(false);
+    expect(isOperationalReady()).toBe(false);
+
+    // Now kick off two overlapping session_starts. They must share ONE probe.
+    const startPromise1 = startHandler({ type: "session_start" }, ctxNoMeta());
+    const startPromise2 = startHandler({ type: "session_start" }, ctxNoMeta());
+    await Promise.resolve();
+    await Promise.resolve();
+    // A before_agent_start fired while the probe is in flight must also not
+    // trigger a second probe (it only reads operational state, still false).
+    const basInFlight = basHandler(
+      { type: "before_agent_start", prompt: "in-flight" },
+      ctxNoMeta()
+    );
+    expect(probeCount).toBe(1); // only the single shared session_start probe
+
+    resolveHealth({ success: true });
+    await Promise.all([startPromise1, startPromise2, basInFlight]);
+
     expect(isStartupReady()).toBe(true);
-    // Session init ran exactly once (via session_start, after readiness): only
-    // one hindsight-meta append and one set of tools. before_agent_start does no
-    // session init, so the dedupe is of the health/version probe above.
-    expect(pi.appendedEntries.filter((e) => e.customType === "hindsight-meta")).toHaveLength(1);
+    expect(isOperationalReady()).toBe(true);
+    // Both session_starts ran session init (tools registered once; one meta each).
     expect(pi.tools.filter((t) => t.name === "hindsight_retain").length).toBe(1);
-    // Only the single in-flight probe ran throughout (no duplicate re-probe).
+    // No additional probes ran from before_agent_start.
     expect(probeCount).toBe(1);
   });
 
@@ -3324,6 +3713,7 @@ describe("real entrypoint bootstrap", () => {
     const pi = createMockPi();
     const extension = await import("../src/index");
     extension.default(pi);
+    await runHealthySessionStart(pi);
 
     const commandHandler = (
       pi.commands.get("hindsight") as {
@@ -3354,6 +3744,7 @@ describe("real entrypoint bootstrap", () => {
     const pi = createMockPi();
     const extension = await import("../src/index");
     extension.default(pi);
+    await runHealthySessionStart(pi);
 
     const basHandler = pi.handlers.get("before_agent_start")!;
     const switchHandler = pi.handlers.get("session_before_switch")!;
@@ -3404,6 +3795,7 @@ describe("real entrypoint bootstrap", () => {
     const pi = createMockPi();
     const extension = await import("../src/index");
     extension.default(pi);
+    await runHealthySessionStart(pi);
 
     const basHandler = pi.handlers.get("before_agent_start")!;
     const forkHandler = pi.handlers.get("session_before_fork")!;
@@ -3732,6 +4124,74 @@ describe("real entrypoint bootstrap", () => {
       { tags: ["project:myapp"], match: "any_strict" },
       { not: { tags: ["session:test-session-123"], match: "any_strict" } },
     ]);
+  });
+
+  it("before_agent_start expands {project} from project-local config", async () => {
+    activeConfig = {
+      ...testConfig,
+      autoRecallPersist: false,
+      autoRecallTags: ["{project}"],
+      autoRecallTagsMatch: "any_strict",
+      autoRecallTagGroups: [{ tags: ["{project}"], match: "any_strict" }],
+    };
+
+    const tmpCwd = mkdtempSync(join(tmpdir(), "epimetheus-autorecall-project-"));
+    try {
+      mkdirSync(join(tmpCwd, ".pi", "epimetheus"), { recursive: true });
+      writeFileSync(
+        join(tmpCwd, ".pi", "epimetheus", "config.jsonc"),
+        JSON.stringify({ projectName: "stable-project" }),
+        "utf-8"
+      );
+
+      let receivedTags: string[] | undefined;
+      let receivedTagGroups: unknown;
+      activeClientFactory = () => ({
+        healthCheck: mock(() => Promise.resolve({ success: true })),
+        retain: mock(() => Promise.resolve({ success: true })),
+        retainBatch: mock(() => Promise.resolve({ success: true })),
+        recall: mock((opts: { tags?: string[]; tagGroups?: unknown }) => {
+          receivedTags = opts.tags;
+          receivedTagGroups = opts.tagGroups;
+          return Promise.resolve({
+            success: true,
+            response: { results: [{ id: "1", text: "Memory" }] },
+          });
+        }),
+        reflect: mock(() => Promise.resolve({ success: true, response: { text: "" } })),
+      });
+
+      const pi = createMockPi();
+      const extension = await import("../src/index");
+      extension.default(pi);
+
+      const ctx = createMockContext({
+        cwd: tmpCwd,
+        sessionManager: {
+          ...createMockContext().sessionManager,
+          getEntries: mock(() => []),
+          getHeader: mock(() => ({
+            id: "test-session-123",
+            timestamp: "2026-01-01T00:00:00Z",
+            cwd: tmpCwd,
+            parentSession: undefined,
+          })),
+        },
+      });
+
+      const startHandler = pi.handlers.get("session_start")!;
+      await startHandler({ type: "session_start" }, ctx);
+
+      const recallHandler = pi.handlers.get("before_agent_start")!;
+      await recallHandler({ type: "before_agent_start", prompt: "Hello" }, ctx);
+
+      expect(receivedTags).toEqual(["project:stable-project"]);
+      expect(receivedTagGroups).toEqual([
+        { tags: ["project:stable-project"], match: "any_strict" },
+      ]);
+    } finally {
+      rmSync(tmpCwd, { recursive: true, force: true });
+    }
   });
 
   // ============================================
@@ -4522,12 +4982,13 @@ describe("real entrypoint bootstrap", () => {
     cleanupParsedArtifacts(sessionId);
   });
 
-  it("a later failed session_start after a healthy one does not turn readiness off or re-hide tools", async () => {
-    // Latch invariant: once the first healthy startup completes, readiness is
-    // true and is never flipped back to false by later session_start failures.
-    // A later failure still sets the status-bar indicator unhealthy, but must
-    // NOT re-disable operational handlers or re-hide tools.
-    const { isStartupReady } =
+  it("a later failed session_start after a healthy one re-enters degraded mode and re-hides all tools", async () => {
+    // Re-enterable readiness: once the first healthy session_start completes,
+    // a later session_start observing an unreachable/incompatible server must
+    // flip startupReady back to false → unified degraded mode (isOperationalReady
+    // false, ALL hindsight tools hidden, auto-retain skipped, operational
+    // commands blocked). Status is unhealthy.
+    const { isStartupReady, isOperationalReady } =
       require("../src/runtime-state") as typeof import("../src/runtime-state");
     let healthSuccess = true;
     activeClientFactory = () => ({
@@ -4545,30 +5006,27 @@ describe("real entrypoint bootstrap", () => {
 
     const startHandler = pi.handlers.get("session_start")!;
     const healthyCtx = createMockContext();
-
-    // First start: healthy → readiness latches on, tools registered lazily.
     await startHandler({ type: "session_start" }, healthyCtx);
     expect(isStartupReady()).toBe(true);
+    expect(isOperationalReady()).toBe(true);
     const activeAfterHealthy = pi.getActiveTools().filter((n) => n.startsWith("hindsight_"));
     expect(activeAfterHealthy).toContain("hindsight_retain");
     expect(healthyCtx.ui.setStatus).toHaveBeenCalledWith("epimetheus", "🧠");
 
-    // Now a later session_start fails (server became unreachable).
+    // A later session_start fails (server became unreachable).
     healthSuccess = false;
     const failingCtx = createMockContext();
     await startHandler({ type: "session_start" }, failingCtx);
 
-    // Readiness stays on (latch not flipped back).
-    expect(isStartupReady()).toBe(true);
-    // The later failure set the status-bar indicator unhealthy...
+    // Re-entered degraded mode.
+    expect(isStartupReady()).toBe(false);
+    expect(isOperationalReady()).toBe(false);
     expect(failingCtx.ui.setStatus).toHaveBeenCalledWith("epimetheus", "🤯");
-    // ...but tools were NOT unregistered or re-hidden (still registered/active
-    // from the healthy startup).
+    // ALL hindsight tools are now hidden.
     const activeAfterFailure = pi.getActiveTools().filter((n) => n.startsWith("hindsight_"));
-    expect(activeAfterFailure).toEqual(activeAfterHealthy);
-    expect(activeAfterFailure).toContain("hindsight_retain");
+    expect(activeAfterFailure).toHaveLength(0);
 
-    // Operational handlers still run after the later failure (readiness on).
+    // Auto-retain is now skipped (degraded).
     const sessionId = BOOTSTRAP_SESSION;
     const { removePendingFlag, hasPendingFlag } =
       require("../src/queue") as typeof import("../src/queue");
@@ -4579,16 +5037,56 @@ describe("real entrypoint bootstrap", () => {
       { type: "message_end", message: { role: "user", content: [{ type: "text", text: "Hi" }] } },
       retainCtx
     );
-    expect(hasPendingFlag(sessionId)).toBe(true);
+    expect(hasPendingFlag(sessionId)).toBe(false);
 
     removePendingFlag(sessionId);
   });
 
+  it("a subsequent healthy session_start after a server failure restores operational readiness and re-shows tools", async () => {
+    // Recovery: after re-entering degraded mode due to a server failure, a
+    // subsequent healthy session_start (project name OK) must make the
+    // extension operational again and re-show tools per retention.
+    const { isStartupReady, isOperationalReady } =
+      require("../src/runtime-state") as typeof import("../src/runtime-state");
+    let healthSuccess = false;
+    activeClientFactory = () => ({
+      healthCheck: mock(() => Promise.resolve({ success: healthSuccess })),
+      getServerVersion: mock(() => Promise.resolve({ success: true, version: "0.9.0" })),
+      retain: mock(() => Promise.resolve({ success: true })),
+      retainBatch: mock(() => Promise.resolve({ success: true })),
+      recall: mock(() => Promise.resolve({ success: true, response: { results: [] } })),
+      reflect: mock(() => Promise.resolve({ success: true, response: { text: "" } })),
+    });
+
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+
+    const startHandler = pi.handlers.get("session_start")!;
+    // First start: server unreachable → degraded.
+    await startHandler({ type: "session_start" }, createMockContext());
+    expect(isStartupReady()).toBe(false);
+    expect(isOperationalReady()).toBe(false);
+    expect(pi.getActiveTools().filter((n) => n.startsWith("hindsight_"))).toHaveLength(0);
+
+    // Recovery: server is healthy again → operational, tools re-shown.
+    healthSuccess = true;
+    const recoveredCtx = createMockContext();
+    await startHandler({ type: "session_start" }, recoveredCtx);
+    expect(isStartupReady()).toBe(true);
+    expect(isOperationalReady()).toBe(true);
+    expect(recoveredCtx.ui.setStatus).toHaveBeenCalledWith("epimetheus", "🧠");
+    const activeAfterRecovery = pi.getActiveTools().filter((n) => n.startsWith("hindsight_"));
+    // Session is retained by default in createMockContext → retain visible too.
+    expect(activeAfterRecovery).toContain("hindsight_retain");
+    expect(activeAfterRecovery).toContain("hindsight_recall");
+  });
+
   it("startup auto-flush skips when a latched session_start refresh probe fails", async () => {
-    // Readiness is one-way, so a later failed probe should not undo metadata or
-    // tool visibility work. Startup auto-flush is different: it is automatic
-    // network work, so skip it when this same session_start just observed the
-    // server as unhealthy.
+    // Readiness is re-enterable, so a later failed probe re-enters degraded
+    // mode (returning before any startup auto-flush). Startup auto-flush is
+    // automatic network work, so skip it when this same session_start just
+    // observed the server as unhealthy.
     activeConfig = { ...testConfig, autoFlushPendingOn: ["startup"] };
     let healthSuccess = true;
     activeClientFactory = () => ({
@@ -4630,7 +5128,54 @@ describe("real entrypoint bootstrap", () => {
     clearSessionQueueState(sessionId);
   });
 
-  it("operational subcommand is blocked with an unavailable message and no side effects when not ready", async () => {
+  it("manual operational command surfaces the specific server-degraded reason on every attempt", async () => {
+    // When degraded because the startup probe failed (server unreachable), the
+    // manual operational-command block message must surface the SPECIFIC reason
+    // (not the generic catch-all) and REPEAT on every attempt (no dedup).
+    activeClientFactory = () => ({
+      healthCheck: mock(() => Promise.resolve({ success: false, error: "conn refused" })),
+      getServerVersion: mock(() => Promise.resolve({ success: true, version: "0.9.0" })),
+      retain: mock(() => Promise.resolve({ success: true })),
+      retainBatch: mock(() => Promise.resolve({ success: true })),
+      recall: mock(() => Promise.resolve({ success: true, response: { results: [] } })),
+      reflect: mock(() => Promise.resolve({ success: true, response: { text: "" } })),
+    });
+
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+
+    // A failed session_start → degraded with the server-unreachable reason.
+    await pi.handlers.get("session_start")!({ type: "session_start" }, createMockContext());
+
+    const commandHandler = (
+      pi.commands.get("hindsight") as {
+        handler: (args: string, ctx: ExtensionContext) => Promise<void>;
+      }
+    ).handler;
+
+    // First attempt: surfaces the SPECIFIC server reason.
+    const ctx1 = createMockContext();
+    await commandHandler("flush", ctx1);
+    const msg1 = (ctx1.ui.notify as ReturnType<typeof mock>).mock.calls.map((c) => String(c[0]));
+    expect(msg1.some((m) => m.includes("epimetheus: operational commands"))).toBe(true);
+    expect(msg1.some((m) => m.includes("server is unreachable"))).toBe(true);
+    // The generic catch-all phrase must NOT appear when a specific reason is set.
+    expect(msg1.some((m) => m.includes("not ready"))).toBe(false);
+    // Server cause → NO detach-project-name advice (recovery advice must match
+    // the cause); instead it points to /hindsight status / server config.
+    expect(msg1.some((m) => m.includes("detach-project-name"))).toBe(false);
+    expect(msg1.some((m) => m.includes("server"))).toBe(true);
+
+    // Repeated attempt: the message is NOT deduped (surfaces again).
+    const ctx2 = createMockContext();
+    await commandHandler("flush", ctx2);
+    const msg2 = (ctx2.ui.notify as ReturnType<typeof mock>).mock.calls.map((c) => String(c[0]));
+    expect(msg2.some((m) => m.includes("server is unreachable"))).toBe(true);
+    expect(msg2.some((m) => m.includes("detach-project-name"))).toBe(false);
+  });
+
+  it("operational subcommand is blocked with a specific message and no side effects when not ready", async () => {
     // No healthy session_start → not ready → operational subcommands blocked.
     const pi = createMockPi();
     const extension = await import("../src/index");
@@ -4654,27 +5199,29 @@ describe("real entrypoint bootstrap", () => {
 
     const notifyCalls = (ctx.ui.notify as ReturnType<typeof mock>).mock.calls;
     const messages = notifyCalls.map((c: unknown[]) => String(c[0]));
-    expect(messages.some((m: string) => m.includes("not ready"))).toBe(true);
+    // No generic catch-all: this is a fresh extension with no session_start
+    // yet AND no classified degraded reason, so the block surfaces the specific
+    // internal "startup readiness has not completed yet" reason instead of the
+    // old all-encompassing list.
+    expect(messages.some((m: string) => m.includes("epimetheus: operational commands"))).toBe(true);
+    expect(messages.some((m: string) => m.includes("\nReason: "))).toBe(true);
+    expect(
+      messages.some((m: string) => m.includes("startup readiness has not completed yet"))
+    ).toBe(true);
+    expect(messages.some((m: string) => m.includes("not ready"))).toBe(false);
+    // No detach advice for a non-project-name cause.
+    expect(messages.some((m: string) => m.includes("detach-project-name"))).toBe(false);
     // No flush ran — the pending marker survives.
     expect(hasPendingFlag(sessionId)).toBe(true);
 
-    // Dedup: a second blocked operational command must not repeat the warning.
+    // Manual command blocking REPEATS on every attempt (no dedup) so the user
+    // is reminded why the command is unavailable.
     const ctx2 = createMockContext({ _sessionId: sessionId });
     await commandHandler("flush", ctx2);
     const notifyCalls2 = (ctx2.ui.notify as ReturnType<typeof mock>).mock.calls;
-    expect(notifyCalls2.length).toBe(0);
-    expect(hasPendingFlag(sessionId)).toBe(true);
-
-    // _resetState() should also reset the command module's warning dedupe state
-    // for tests that reset without re-registering commands.
-    const { _resetState } = require("../src/index") as typeof import("../src/index");
-    _resetState();
-    const ctx3 = createMockContext({ _sessionId: sessionId });
-    await commandHandler("flush", ctx3);
-    const notifyCalls3 = (ctx3.ui.notify as ReturnType<typeof mock>).mock.calls;
-    expect(
-      notifyCalls3.map((c: unknown[]) => String(c[0])).some((m) => m.includes("not ready"))
-    ).toBe(true);
+    expect(notifyCalls2.length).toBe(1);
+    expect(notifyCalls2[0]?.[1]).toBe("warning");
+    expect(String(notifyCalls2[0]?.[0])).toContain("startup readiness has not completed yet");
     expect(hasPendingFlag(sessionId)).toBe(true);
 
     removePendingFlag(sessionId);
@@ -4707,5 +5254,465 @@ describe("real entrypoint bootstrap", () => {
     );
     expect(configMessages.some((m: string) => m.includes("== Config Source =="))).toBe(true);
     expect(configMessages.some((m: string) => m.includes("not ready"))).toBe(false);
+  });
+
+  it("degraded mode keeps diagnostic/display/recovery commands while blocking operational commands", async () => {
+    activeConfig = { ...testConfig, autoRecallPersist: true, autoRecallDisplay: false };
+    const { withTempDir } = await import("./fixtures");
+    await withTempDir(async (tmpCwd) => {
+      mkdirSync(join(tmpCwd, ".pi", "epimetheus"), { recursive: true });
+      writeFileSync(
+        join(tmpCwd, ".pi", "epimetheus", "config.jsonc"),
+        JSON.stringify({ notProjectName: "x" }),
+        "utf-8"
+      );
+
+      const pi = createMockPi();
+      const extension = await import("../src/index");
+      extension.default(pi);
+
+      const sessionId = BOOTSTRAP_SESSION;
+      const baseCtx = createMockContext({ _sessionId: sessionId });
+      const ctx = {
+        ...baseCtx,
+        cwd: tmpCwd,
+        ui: {
+          ...baseCtx.ui,
+          confirm: mock(() => Promise.resolve(true)),
+        },
+        sessionManager: {
+          ...baseCtx.sessionManager,
+          getSessionId: mock(() => sessionId),
+          getHeader: mock(() => ({
+            id: sessionId,
+            timestamp: "2026-01-01T00:00:00Z",
+            cwd: tmpCwd,
+            parentSession: undefined,
+          })),
+          getEntries: mock(() => [
+            {
+              type: "custom",
+              customType: "hindsight-meta",
+              data: { retained: true, usesProjectConfig: true },
+            },
+          ]),
+        },
+      } as unknown as ExtensionContext;
+
+      const startHandler = pi.handlers.get("session_start")!;
+      await startHandler({ type: "session_start" }, ctx);
+
+      const { isOperationalReady } =
+        require("../src/runtime-state") as typeof import("../src/runtime-state");
+      expect(isOperationalReady()).toBe(false);
+
+      const commandHandler = (
+        pi.commands.get("hindsight") as {
+          handler: (args: string, ctx: ExtensionContext) => Promise<void>;
+        }
+      ).handler;
+
+      // Diagnostic commands remain available.
+      const statusCtx = createMockContext({ _sessionId: sessionId });
+      await commandHandler("status", statusCtx);
+      expect(
+        (statusCtx.ui.notify as ReturnType<typeof mock>).mock.calls.some((c) =>
+          String(c[0]).includes("== Connection ==")
+        )
+      ).toBe(true);
+
+      const configCtx = createMockContext({ _sessionId: sessionId });
+      await commandHandler("config", configCtx);
+      expect(
+        (configCtx.ui.notify as ReturnType<typeof mock>).mock.calls.some((c) =>
+          String(c[0]).includes("== Config Source ==")
+        )
+      ).toBe(true);
+
+      // Display command remains available and affects persisted recall rendering.
+      const renderer = pi.renderers.get("hindsight-recall") as (
+        message: Record<string, unknown>,
+        options: { expanded: boolean },
+        theme: Record<string, unknown>
+      ) => { render: (width: number) => string[] } | undefined;
+      const component = renderer(
+        { details: { count: 1, snippet: "memory", memories: "memory" } },
+        { expanded: false },
+        { fg: (_color: unknown, text: string) => text, bg: (_color: unknown, text: string) => text }
+      );
+      expect(component?.render(80)).toHaveLength(0);
+      await commandHandler("toggle-display", createMockContext({ _sessionId: sessionId }));
+      expect(component?.render(80).join("\n")).toContain("Hindsight recalled");
+
+      // Operational commands are blocked while degraded. The block message must
+      // surface the SPECIFIC degraded cause (here: the active session's invalid
+      // cwd-local project config), not the generic catch-all.
+      const { hasPendingFlag, removePendingFlag, touchPendingFlag } =
+        require("../src/queue") as typeof import("../src/queue");
+      removePendingFlag(sessionId);
+      await touchPendingFlag(sessionId);
+      const flushCtx = createMockContext({ _sessionId: sessionId });
+      await commandHandler("flush", flushCtx);
+      expect(hasPendingFlag(sessionId)).toBe(true);
+      const flushMsgs = (flushCtx.ui.notify as ReturnType<typeof mock>).mock.calls.map((c) =>
+        String(c[0])
+      );
+      // Specific reason is surfaced (no generic "not ready" catch-all).
+      expect(flushMsgs.some((m) => m.includes("epimetheus: operational commands"))).toBe(true);
+      expect(flushMsgs.some((m) => m.includes("\nReason: "))).toBe(true);
+      expect(flushMsgs.some((m) => m.includes("see `/hindsight config` for details"))).toBe(true);
+      expect(flushMsgs.some((m) => m.includes("project config") && m.includes("invalid"))).toBe(
+        true
+      );
+      // Invalid project config → fix-config advice only (concrete config path,
+      // no detach suggestion).
+      expect(flushMsgs.some((m) => m.includes(`Fix ${tmpCwd}/.pi/epimetheus/config.jsonc`))).toBe(
+        true
+      );
+      expect(flushMsgs.some((m) => m.includes("detach-project-name"))).toBe(false);
+
+      // Recovery command remains available and clears the active-session failure.
+      await commandHandler("detach-project-name", ctx);
+      expect(isOperationalReady()).toBe(true);
+      expect(
+        pi.appendedEntries.some(
+          (e) =>
+            e.customType === "hindsight-meta" &&
+            (e.data as { usesProjectConfig?: boolean }).usesProjectConfig === false
+        )
+      ).toBe(true);
+      removePendingFlag(sessionId);
+    });
+  });
+
+  it("manual /hindsight flush surfaces the specific missing-config reason (detach-or-fix)", async () => {
+    // Marked session whose cwd has no project config file: the block message
+    // must surface the SPECIFIC "no project config file is present"
+    // reason and suggest detach-project-name (detach-or-fix recovery advice).
+    const { withTempDir } = await import("./fixtures");
+    await withTempDir(async (tmpCwd) => {
+      // No .pi/epimetheus/config.jsonc at tmpCwd.
+      const pi = createMockPi();
+      const extension = await import("../src/index");
+      extension.default(pi);
+
+      const baseCtx = createMockContext();
+      const startCtx = {
+        ...baseCtx,
+        cwd: tmpCwd,
+        sessionManager: {
+          ...baseCtx.sessionManager,
+          getHeader: mock(() => ({
+            id: BOOTSTRAP_SESSION,
+            timestamp: "2026-01-01T00:00:00Z",
+            cwd: tmpCwd,
+            parentSession: undefined,
+          })),
+          getEntries: mock(() => [
+            {
+              type: "custom",
+              customType: "hindsight-meta",
+              data: { retained: true, usesProjectConfig: true },
+            },
+          ]),
+        },
+      } as unknown as ExtensionContext;
+      await pi.handlers.get("session_start")!({ type: "session_start" }, startCtx);
+
+      const commandHandler = (
+        pi.commands.get("hindsight") as {
+          handler: (args: string, ctx: ExtensionContext) => Promise<void>;
+        }
+      ).handler;
+      const { removePendingFlag, hasPendingFlag, touchPendingFlag } =
+        require("../src/queue") as typeof import("../src/queue");
+      removePendingFlag(BOOTSTRAP_SESSION);
+      await touchPendingFlag(BOOTSTRAP_SESSION);
+
+      const flushCtx = createMockContext({ _sessionId: BOOTSTRAP_SESSION });
+      await commandHandler("flush", flushCtx);
+      const flushMsgs = (flushCtx.ui.notify as ReturnType<typeof mock>).mock.calls.map((c) =>
+        String(c[0])
+      );
+      expect(flushMsgs.some((m) => m.includes("epimetheus: operational commands"))).toBe(true);
+      expect(flushMsgs.some((m) => m.includes("no project config file is present"))).toBe(true);
+      // detach-or-fix advice suggests detach-project-name.
+      expect(flushMsgs.some((m) => m.includes("detach-project-name"))).toBe(true);
+      // No flush ran: the pending marker survives.
+      expect(hasPendingFlag(BOOTSTRAP_SESSION)).toBe(true);
+      removePendingFlag(BOOTSTRAP_SESSION);
+    });
+  });
+
+  it("manual /hindsight flush surfaces the specific incompatible-version reason", async () => {
+    // Server version incompatibility (distinct from unreachable) must surface
+    // its own specific reason on the manual block message, with server recovery
+    // advice (no detach-project-name).
+    activeClientFactory = () => ({
+      healthCheck: mock(() => Promise.resolve({ success: true })),
+      getServerVersion: mock(() => Promise.resolve({ success: true, version: "0.7.0" })),
+      retain: mock(() => Promise.resolve({ success: true })),
+      retainBatch: mock(() => Promise.resolve({ success: true })),
+      recall: mock(() => Promise.resolve({ success: true, response: { results: [] } })),
+      reflect: mock(() => Promise.resolve({ success: true, response: { text: "" } })),
+    });
+
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+    await pi.handlers.get("session_start")!({ type: "session_start" }, createMockContext());
+
+    const commandHandler = (
+      pi.commands.get("hindsight") as {
+        handler: (args: string, ctx: ExtensionContext) => Promise<void>;
+      }
+    ).handler;
+    const { removePendingFlag, hasPendingFlag, touchPendingFlag } =
+      require("../src/queue") as typeof import("../src/queue");
+    removePendingFlag(BOOTSTRAP_SESSION);
+    await touchPendingFlag(BOOTSTRAP_SESSION);
+
+    const ctx = createMockContext({ _sessionId: BOOTSTRAP_SESSION });
+    await commandHandler("flush", ctx);
+    const msgs = (ctx.ui.notify as ReturnType<typeof mock>).mock.calls.map((c) => String(c[0]));
+    expect(msgs.some((m) => m.includes("server version is incompatible"))).toBe(true);
+    expect(msgs.some((m) => m.includes("/hindsight status"))).toBe(true);
+    expect(msgs.some((m) => m.includes("detach-project-name"))).toBe(false);
+    expect(hasPendingFlag(BOOTSTRAP_SESSION)).toBe(true);
+    removePendingFlag(BOOTSTRAP_SESSION);
+  });
+
+  it("session_start enters failed/unhealthy mode when a marked session's project config is missing", async () => {
+    // Distinct from the invalid-config variant: a marked session whose cwd
+    // has NO config file. The session_start warning must surface the specific
+    // "no project config file is present" reason and suggest detach.
+    const { withTempDir } = await import("./fixtures");
+    await withTempDir(async (tmpCwd) => {
+      // No .pi/epimetheus/config.jsonc at tmpCwd.
+      const pi = createMockPi();
+      const extension = await import("../src/index");
+      extension.default(pi);
+
+      const baseCtx = createMockContext();
+      const ctx = {
+        ...baseCtx,
+        cwd: tmpCwd,
+        sessionManager: {
+          ...baseCtx.sessionManager,
+          getHeader: mock(() => ({
+            id: "missing-cfg-sess",
+            timestamp: "2026-01-01T00:00:00Z",
+            cwd: tmpCwd,
+            parentSession: undefined,
+          })),
+          getEntries: mock(() => [
+            {
+              type: "custom",
+              customType: "hindsight-meta",
+              data: { retained: true, usesProjectConfig: true },
+            },
+          ]),
+        },
+      } as unknown as ExtensionContext;
+      const handler = pi.handlers.get("session_start")!;
+      await handler({ type: "session_start" }, ctx);
+
+      expect(ctx.ui.setStatus).toHaveBeenCalledWith("epimetheus", "🤯");
+      const { isOperationalReady } =
+        require("../src/runtime-state") as typeof import("../src/runtime-state");
+      expect(isOperationalReady()).toBe(false);
+      const notifyCalls = (ctx.ui.notify as ReturnType<typeof mock>).mock.calls.map((c) =>
+        String(c[0])
+      );
+      expect(notifyCalls.some((m) => m.includes("no project config file is present"))).toBe(true);
+      // Missing config (detach-or-fix) suggests detach-project-name.
+      expect(notifyCalls.some((m) => m.includes("detach-project-name"))).toBe(true);
+    });
+  });
+
+  it("session_start enters failed/unhealthy mode when a marked session's cwd no longer exists", async () => {
+    // Marked session whose recorded cwd is gone: fail closed with the
+    // "cwd ... does not exist" reason and detach-or-fix recovery advice.
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+
+    const goneCwd = "/nonexistent/removed-project-xyz";
+    const baseCtx = createMockContext();
+    const ctx = {
+      ...baseCtx,
+      cwd: goneCwd,
+      sessionManager: {
+        ...baseCtx.sessionManager,
+        getHeader: mock(() => ({
+          id: "gone-cwd-sess",
+          timestamp: "2026-01-01T00:00:00Z",
+          cwd: goneCwd,
+          parentSession: undefined,
+        })),
+        getEntries: mock(() => [
+          {
+            type: "custom",
+            customType: "hindsight-meta",
+            data: { retained: true, usesProjectConfig: true },
+          },
+        ]),
+      },
+    } as unknown as ExtensionContext;
+    const handler = pi.handlers.get("session_start")!;
+    await handler({ type: "session_start" }, ctx);
+
+    expect(ctx.ui.setStatus).toHaveBeenCalledWith("epimetheus", "🤯");
+    const { isOperationalReady } =
+      require("../src/runtime-state") as typeof import("../src/runtime-state");
+    expect(isOperationalReady()).toBe(false);
+    const notifyCalls = (ctx.ui.notify as ReturnType<typeof mock>).mock.calls.map((c) =>
+      String(c[0])
+    );
+    expect(notifyCalls.some((m) => m.includes("does not exist"))).toBe(true);
+    expect(notifyCalls.some((m) => m.includes(goneCwd))).toBe(true);
+    expect(notifyCalls.some((m) => m.includes("detach-project-name"))).toBe(true);
+  });
+
+  it("before_agent_start skips recall with a project-name warning when the config breaks mid-session", async () => {
+    // The before_agent_start handler re-resolves the project name fresh. If a
+    // valid config was present at session_start (so the session is operational)
+    // but becomes invalid before the next turn, recall is skipped with a
+    // specific "auto-recall skipped: ..." warning and the recall client is
+    // never called.
+    const tmpCwd = mkdtempSync(join(tmpdir(), "epimetheus-autorecall-midsession-"));
+    try {
+      mkdirSync(join(tmpCwd, ".pi", "epimetheus"), { recursive: true });
+      writeFileSync(
+        join(tmpCwd, ".pi", "epimetheus", "config.jsonc"),
+        JSON.stringify({ projectName: "stable-project" }),
+        "utf-8"
+      );
+
+      let recallCalled = false;
+      activeClientFactory = () => ({
+        healthCheck: mock(() => Promise.resolve({ success: true })),
+        getServerVersion: mock(() => Promise.resolve({ success: true, version: "0.9.0" })),
+        retain: mock(() => Promise.resolve({ success: true })),
+        retainBatch: mock(() => Promise.resolve({ success: true })),
+        recall: mock(() => {
+          recallCalled = true;
+          return Promise.resolve({
+            success: true,
+            response: { results: [{ id: "1", text: "Memory" }] },
+          });
+        }),
+        reflect: mock(() => Promise.resolve({ success: true, response: { text: "" } })),
+      });
+
+      const pi = createMockPi();
+      const extension = await import("../src/index");
+      extension.default(pi);
+
+      const metaEntry = {
+        type: "custom",
+        customType: "hindsight-meta",
+        data: { retained: true, usesProjectConfig: true },
+      };
+      const ctx = createMockContext({
+        cwd: tmpCwd,
+        sessionManager: {
+          ...createMockContext().sessionManager,
+          getEntries: mock(() => [metaEntry]),
+          getHeader: mock(() => ({
+            id: "midsession-sess",
+            timestamp: "2026-01-01T00:00:00Z",
+            cwd: tmpCwd,
+            parentSession: undefined,
+          })),
+        },
+      });
+
+      // Healthy session_start with a valid config -> operational (latch true).
+      await pi.handlers.get("session_start")!({ type: "session_start" }, ctx);
+
+      // Config becomes invalid before the next turn.
+      writeFileSync(
+        join(tmpCwd, ".pi", "epimetheus", "config.jsonc"),
+        JSON.stringify({ notProjectName: "x" }),
+        "utf-8"
+      );
+
+      await pi.handlers.get("before_agent_start")!(
+        { type: "before_agent_start", prompt: "Hi" },
+        ctx
+      );
+
+      expect(recallCalled).toBe(false);
+      const notifyCalls = (ctx.ui.notify as ReturnType<typeof mock>).mock.calls.map((c) =>
+        String(c[0])
+      );
+      expect(notifyCalls.some((m) => m.includes("auto-recall skipped"))).toBe(true);
+      expect(notifyCalls.some((m) => m.includes("project config"))).toBe(true);
+    } finally {
+      rmSync(tmpCwd, { recursive: true, force: true });
+    }
+  });
+
+  it("/hindsight popup is unavailable in degraded mode (no recall to inspect) even if recall details are cached", async () => {
+    // Degraded (server unreachable) → auto-recall is skipped, so there is no
+    // current recall for the popup to inspect. It must surface the SPECIFIC
+    // server-degraded reason (not the old generic "not ready" wording) with
+    // cause-specific recovery advice (no detach-project-name for a server
+    // cause), and NOT invoke the overlay, even when a cached recall from a
+    // prior operational turn is present.
+    activeClientFactory = () => ({
+      healthCheck: mock(() => Promise.resolve({ success: false, error: "connection refused" })),
+      getServerVersion: mock(() => Promise.resolve({ success: true, version: "0.9.0" })),
+      retain: mock(() => Promise.resolve({ success: true })),
+      retainBatch: mock(() => Promise.resolve({ success: true })),
+      recall: mock(() =>
+        Promise.resolve({
+          success: true,
+          response: { results: [{ id: "1", text: "cached recall" }] },
+        })
+      ),
+      reflect: mock(() => Promise.resolve({ success: true, response: { text: "" } })),
+    });
+    activeConfig = { ...testConfig, autoRecallPersist: true };
+
+    const pi = createMockPi();
+    const extension = await import("../src/index");
+    extension.default(pi);
+
+    // A failed (unhealthy) session_start → degraded (not operational) with the
+    // server-unreachable reason classified.
+    const startHandler = pi.handlers.get("session_start")!;
+    await startHandler({ type: "session_start" }, createMockContext());
+
+    const commandHandler = (
+      pi.commands.get("hindsight") as {
+        handler: (args: string, ctx: ExtensionContext) => Promise<void>;
+      }
+    ).handler;
+
+    let overlayCalled = false;
+    const ctx = {
+      ...createMockContext(),
+      ui: {
+        ...createMockContext().ui,
+        custom: mock(async () => {
+          overlayCalled = true;
+        }),
+      },
+    } as unknown as ExtensionContext;
+    await commandHandler("popup", ctx);
+
+    expect(overlayCalled).toBe(false);
+    const msgs = (ctx.ui.notify as ReturnType<typeof mock>).mock.calls.map((c: unknown[]) =>
+      String(c[0])
+    );
+    expect(msgs.some((m: string) => m.includes("auto-recall is skipped"))).toBe(true);
+    // Specific server reason is surfaced.
+    expect(msgs.some((m: string) => m.includes("server is unreachable"))).toBe(true);
+    // NO old generic "not ready" wording.
+    expect(msgs.some((m: string) => m.includes("not ready"))).toBe(false);
+    // Server cause → NO detach-project-name advice.
+    expect(msgs.some((m: string) => m.includes("detach-project-name"))).toBe(false);
   });
 });

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -9,6 +9,12 @@ import type { HindsightClientWrapper } from "../src/client";
 import { registerCommands } from "../src/commands";
 import type { RecallMessageDetails } from "../src/index";
 import {
+  markStartupReady,
+  resetRegisteredHindsightTools,
+  resetStartupReady,
+  setRegisteredHindsightTools,
+} from "../src/runtime-state";
+import {
   createMockClient,
   readToolQueueFromDisk,
   setupTempAgentDir,
@@ -41,6 +47,10 @@ afterEach(() => {
   } catch {
     // best-effort
   }
+  // Reset runtime-state so tests start/leave operational state clean (these
+  // tests call registerCommands directly, without a session_start).
+  resetStartupReady();
+  resetRegisteredHindsightTools();
 });
 
 interface RegisteredCmd {
@@ -109,6 +119,14 @@ describe("registerCommands", () => {
   });
 
   function register(config = statusTestConfig, client = mockClient) {
+    registerWithReady(config, client, () => true);
+  }
+
+  function registerWithReady(
+    config = statusTestConfig,
+    client = mockClient,
+    isReady: () => boolean = () => true
+  ) {
     registerCommands(
       mockPi as unknown as import("@earendil-works/pi-coding-agent").ExtensionAPI,
       config,
@@ -118,7 +136,7 @@ describe("registerCommands", () => {
       () => {
         autoRecallDisplayOverride = !autoRecallDisplayOverride;
       },
-      () => true,
+      isReady,
       { configPath: undefined, envVars: [], warning: undefined, validationWarnings: [] }
     );
   }
@@ -814,6 +832,19 @@ describe("registerCommands", () => {
         { type: "custom", customType: "hindsight-meta", data: { retained: false } },
       ];
       register({ ...statusTestConfig, retainSessionsByDefault: false });
+
+      // refreshToolVisibility reads the unified operational state + the
+      // registered-tools list from runtime-state. These registerCommands
+      // tests bypass session_start, so latch operational + record the
+      // registered tools manually.
+      markStartupReady();
+      setRegisteredHindsightTools([
+        "hindsight_set_extra_context",
+        "hindsight_get_extra_context",
+        "hindsight_retain",
+        "hindsight_recall",
+        "hindsight_reflect",
+      ]);
 
       // Simulate session_start hiding the tool
       mockActiveTools.length = 0;
@@ -2233,6 +2264,68 @@ describe("registerCommands", () => {
       await getHandler()("popup", ctx);
 
       expect((overlayDetails as RecallMessageDetails | null)?.count).toBe(1);
+    });
+
+    it("is unavailable in degraded mode: surfaces the specific reason, no overlay, no recall to inspect", async () => {
+      // Degraded mode skips auto-recall, so there is no current recall to
+      // inspect. /hindsight popup must short-circuit with an info message and
+      // NOT invoke the overlay — even when recall details are cached from a
+      // prior operational turn. The message must use the specific degraded
+      // reason (the internal "startup readiness has not completed yet"
+      // fallback here, since no reason was classified) instead of the old
+      // generic "not ready" wording, with cause-specific recovery advice.
+      recallDetails = {
+        count: 2,
+        snippet: "cached",
+        memories: "cached",
+      };
+      registerWithReady(statusTestConfig, mockClient, () => false);
+
+      let overlayCalled = false;
+      const ctx = {
+        ...makeCtx(),
+        ui: {
+          ...makeCtx().ui,
+          custom: mock(async () => {
+            overlayCalled = true;
+          }),
+        },
+      } as unknown as ExtensionContext;
+
+      await getHandler()("popup", ctx);
+
+      expect(overlayCalled).toBe(false);
+      expect(lastNotification?.message).toContain("auto-recall is skipped");
+      // Specific internal reason, not the old generic "not ready" catch-all.
+      expect(lastNotification?.message).toContain("startup readiness has not completed yet");
+      expect(lastNotification?.message).not.toContain("not ready");
+      // Not a project-name cause here, so no detach advice.
+      expect(lastNotification?.message).not.toContain("detach-project-name");
+    });
+
+    it("reports it requires autoRecallEnabled when auto-recall is disabled", async () => {
+      recallDetails = {
+        count: 2,
+        snippet: "cached",
+        memories: "cached",
+      };
+      registerWithReady({ ...statusTestConfig, autoRecallEnabled: false }, mockClient, () => true);
+
+      let overlayCalled = false;
+      const ctx = {
+        ...makeCtx(),
+        ui: {
+          ...makeCtx().ui,
+          custom: mock(async () => {
+            overlayCalled = true;
+          }),
+        },
+      } as unknown as ExtensionContext;
+
+      await getHandler()("popup", ctx);
+
+      expect(overlayCalled).toBe(false);
+      expect(lastNotification?.message).toContain("autoRecallEnabled is false");
     });
   });
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -737,7 +737,7 @@ describe("loadConfig", () => {
     expect(warning).toContain('(value: "value")');
   });
 
-  it("rejects projectName in config file (EPIMETHEUS_PROJECT_NAME is env-only)", () => {
+  it("rejects projectName in global config file (project-local setting only)", () => {
     writeFileSync(
       join(TEST_DIR, "config.json"),
       JSON.stringify({

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -339,8 +339,8 @@ export function setupTempAgentDir(label: string): string {
  *
  * Includes both the current `EPIMETHEUS_*` (preferred) and legacy
  * `PI_HINDSIGHT_*` fallback names so tests that set either get cleaned up.
- * `HINDSIGHT_API_URL` / `HINDSIGHT_API_KEY` (official Hindsight service vars)
- * and `EPIMETHEUS_PROJECT_NAME` / `PI_HINDSIGHT_PROJECT_NAME` are included too.
+ * `HINDSIGHT_API_URL` / `HINDSIGHT_API_KEY` are official Hindsight service vars.
+ * Removed project-name env vars are still listed so tests can verify they are ignored.
  */
 export const HINDSIGHT_ENV_KEYS = [
   "EPIMETHEUS_ENABLED",
@@ -463,6 +463,12 @@ export async function withTempDir<T>(fn: (tmpDir: string) => Promise<T>): Promis
  * @param options.parentSession - Optional parent session path (for forked sessions)
  * @param options.messages - Messages to include. Defaults to a single user message.
  *   Pass an empty array to write a header-only file (e.g. for fork-without-messages tests).
+ * @param options.cwd - Optional cwd to record in the session header (defaults to
+ *   "/test" for backward compat with existing tests).
+ * @param options.retained - Defaults to true; sets the hindsight-meta retained flag.
+ * @param options.extraContext - Optional hindsight-meta extraContext string.
+ * @param options.usesProjectConfig - Optional hindsight-meta flag marking
+ *   the session as requiring a cwd-local project config.
  */
 export function writeSessionFile(
   dir: string,
@@ -470,8 +476,10 @@ export function writeSessionFile(
   options: {
     parentSession?: string;
     messages?: Array<{ role: string; content: unknown }>;
+    cwd?: string;
     retained?: boolean;
     extraContext?: string;
+    usesProjectConfig?: boolean;
   } = {}
 ): string {
   const sessionPath = join(dir, `${sessionId}.jsonl`);
@@ -479,7 +487,7 @@ export function writeSessionFile(
     type: "session",
     id: sessionId,
     timestamp: new Date().toISOString(),
-    cwd: "/test",
+    cwd: options.cwd ?? "/test",
   };
   if (options.parentSession) {
     header.parentSession = options.parentSession;
@@ -492,6 +500,9 @@ export function writeSessionFile(
   const metaData: Record<string, unknown> = { retained };
   if (options.extraContext !== undefined) {
     metaData.extraContext = options.extraContext;
+  }
+  if (options.usesProjectConfig !== undefined) {
+    metaData.usesProjectConfig = options.usesProjectConfig;
   }
   lines.push(
     JSON.stringify({

--- a/tests/project-config.test.ts
+++ b/tests/project-config.test.ts
@@ -1,0 +1,1814 @@
+/**
+ * Tests for the project-local config feature.
+ *
+ * Covers `resolveProjectConfig` (load + validate cwd-local config), the default
+ * project name derivation (inclusive of git common dir handling so worktrees
+ * share the main repo name), fail-closed behavior for marked sessions whose
+ * config is missing/invalid, the `/hindsight detach-project-name` command,
+ * flush-pending handling each session independently, and the `/hindsight config`
+ * session-specific diagnostics.
+ *
+ * Adheres to AGENTS.md: never modifies the real pi agent directory (uses
+ * setupTempAgentDir to redirect PI_CODING_AGENT_DIR), exercises real handlers
+ * (no simulation of production logic), and tests behavior — not implementation.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { HindsightClientWrapper } from "../src/client";
+import { registerCommands } from "../src/commands";
+import type { RecallMessageDetails } from "../src/index";
+import { getHindsightMeta, updateSessionMetadata } from "../src/meta";
+import { getMessagesPath, getMetaPath } from "../src/parsed-store";
+import {
+  evaluateActiveSessionProjectState,
+  findProjectConfigFile,
+  resolveProjectConfig,
+  resolveProjectName,
+} from "../src/project-config";
+import {
+  clearSessionQueueState,
+  hasPendingFlag,
+  removePendingFlag,
+  touchPendingFlag,
+} from "../src/queue";
+import { parseAndUpsertSession } from "../src/retention";
+import { getSessionStatePath } from "../src/session-state";
+import {
+  cleanupParsedArtifacts,
+  createMockClient,
+  HINDSIGHT_ENV_KEYS,
+  makeNotifyCtx,
+  saveEnvKeys,
+  setupTempAgentDir,
+  testConfig,
+  withTempDir,
+  writeSessionFile,
+} from "./fixtures";
+
+setupTempAgentDir("project-config");
+
+let restoreEnv: () => void;
+
+beforeEach(() => {
+  restoreEnv = saveEnvKeys(HINDSIGHT_ENV_KEYS);
+});
+
+afterEach(() => {
+  restoreEnv();
+});
+
+// ============================================
+// Helpers
+// ============================================
+
+/**
+ * Write a config file (`.jsonc` or `.json`) under `<cwd>/.pi/epimetheus/`.
+ */
+function writeProjectConfig(cwd: string, ext: "jsonc" | "json", content: string): string {
+  const dir = join(cwd, ".pi", "epimetheus");
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `config.${ext}`);
+  writeFileSync(path, content, "utf-8");
+  return path;
+}
+
+/**
+ * Run a `git` command in `cwd`. Throws (failing the test) only on spawnSync error;
+ * non-zero exit leaves it to the caller to assert — but for setup we expect 0.
+ */
+function git(cwd: string, args: string[]): void {
+  const result = spawnSync("git", args, { cwd, encoding: "utf-8", timeout: 30_000 });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} (cwd=${cwd}) failed with status ${result.status}: ${result.stderr}`
+    );
+  }
+}
+
+/**
+ * Capture the call args passed to client.retain by returning a mock client
+ * and a `retainCalls` array mirroring production test helpers.
+ */
+function capturingClient(): {
+  client: HindsightClientWrapper;
+  retainCalls: { tags?: string[] }[];
+} {
+  const retainCalls: { tags?: string[] }[] = [];
+  const client = {
+    retain: mock(async (opts: { tags?: string[] }) => {
+      retainCalls.push(opts);
+      return { success: true };
+    }),
+    retainBatch: mock(async () => ({ success: true })),
+  } as unknown as HindsightClientWrapper;
+  return { client, retainCalls };
+}
+
+// ============================================
+// resolveProjectConfig (load + schema)
+// ============================================
+
+describe("resolveProjectConfig", () => {
+  it("fails closed (not ok) when no cwd-local config exists", async () => {
+    await withTempDir(async (cwd) => {
+      const r = resolveProjectConfig(cwd);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/no project config file found/);
+    });
+  });
+
+  it("loads .jsonc (preferred over .json)", async () => {
+    await withTempDir(async (cwd) => {
+      writeProjectConfig(cwd, "jsonc", JSON.stringify({ projectName: "from-jsonc" }));
+      writeProjectConfig(cwd, "json", JSON.stringify({ projectName: "from-json" }));
+      const r = resolveProjectConfig(cwd);
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.config.projectName).toBe("from-jsonc");
+        expect(r.path.endsWith("config.jsonc")).toBe(true);
+      }
+    });
+  });
+
+  it("loads .json when no .jsonc exists", async () => {
+    await withTempDir(async (cwd) => {
+      writeProjectConfig(cwd, "json", JSON.stringify({ projectName: "from-json" }));
+      const r = resolveProjectConfig(cwd);
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.config.projectName).toBe("from-json");
+    });
+  });
+
+  it("parses JSONC with comments and trailing commas", async () => {
+    await withTempDir(async (cwd) => {
+      writeProjectConfig(
+        cwd,
+        "jsonc",
+        // Leading comment, inline comment, trailing comma
+        `// project-local config
+{
+  "projectName": "commented", // inline comment
+}`
+      );
+      const r = resolveProjectConfig(cwd);
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.config.projectName).toBe("commented");
+    });
+  });
+
+  it("fails closed when projectName is missing", async () => {
+    await withTempDir(async (cwd) => {
+      writeProjectConfig(cwd, "jsonc", JSON.stringify({ other: "x" }));
+      const r = resolveProjectConfig(cwd);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/projectName/);
+    });
+  });
+
+  it("fails closed when projectName is not a string", async () => {
+    await withTempDir(async (cwd) => {
+      writeProjectConfig(cwd, "jsonc", JSON.stringify({ projectName: 42 }));
+      const r = resolveProjectConfig(cwd);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/projectName/);
+    });
+  });
+
+  it("fails closed when projectName is empty/whitespace", async () => {
+    await withTempDir(async (cwd) => {
+      writeProjectConfig(cwd, "jsonc", JSON.stringify({ projectName: "   " }));
+      const r = resolveProjectConfig(cwd);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/empty\/whitespace/);
+    });
+  });
+
+  it("fails closed when top-level is not an object", async () => {
+    await withTempDir(async (cwd) => {
+      writeProjectConfig(cwd, "jsonc", `["not", "an", "object"]`);
+      const r = resolveProjectConfig(cwd);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/JSON object/);
+    });
+  });
+
+  it("fails closed when JSON is malformed", async () => {
+    await withTempDir(async (cwd) => {
+      writeProjectConfig(cwd, "jsonc", `{ "projectName": "x" `); // missing close
+      const r = resolveProjectConfig(cwd);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/not valid JSON/);
+    });
+  });
+
+  it("warns and ignores unknown keys while keeping projectName", async () => {
+    await withTempDir(async (cwd) => {
+      writeProjectConfig(
+        cwd,
+        "jsonc",
+        JSON.stringify({ projectName: "stable", destination: "x", mode: "y" })
+      );
+      const r = resolveProjectConfig(cwd);
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.config.projectName).toBe("stable");
+        expect(r.warnings.some((w) => w.includes(`"destination"`))).toBe(true);
+        expect(r.warnings.some((w) => w.includes(`"mode"`))).toBe(true);
+      }
+    });
+  });
+
+  it("trims whitespace around projectName", async () => {
+    await withTempDir(async (cwd) => {
+      writeProjectConfig(cwd, "jsonc", JSON.stringify({ projectName: "  stable  " }));
+      const r = resolveProjectConfig(cwd);
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.config.projectName).toBe("stable");
+    });
+  });
+
+  it("findProjectConfigFile returns the path when jsonc present, null otherwise", async () => {
+    await withTempDir(async (cwd) => {
+      expect(findProjectConfigFile(cwd)).toBeNull();
+      writeProjectConfig(cwd, "jsonc", JSON.stringify({ projectName: "x" }));
+      expect(findProjectConfigFile(cwd)).not.toBeNull();
+      expect(findProjectConfigFile(cwd)?.endsWith("config.jsonc")).toBe(true);
+    });
+  });
+
+  it("does not walk ancestors (only cwd-local and git commondir checked)", async () => {
+    await withTempDir(async (dir) => {
+      const ancestor = join(dir, "ancestor");
+      mkdirSync(ancestor, { recursive: true });
+      writeProjectConfig(ancestor, "jsonc", JSON.stringify({ projectName: "ancestor-name" }));
+      const child = join(ancestor, "child");
+      mkdirSync(child, { recursive: true });
+      // Child has no project-config of its own; ancestor does. Should NOT find any
+      // (no .git in child, so no commondir fallback either).
+      expect(findProjectConfigFile(child)).toBeNull();
+      expect(resolveProjectConfig(child).ok).toBe(false);
+    });
+  });
+
+  it("worktree finds main repo's project config via commondir fallback", async () => {
+    await withTempDir(async (dir) => {
+      const mainRepo = join(dir, "mainrepo");
+      mkdirSync(mainRepo, { recursive: true });
+      git(mainRepo, ["init", "-q", "--initial-branch=main"]);
+      git(mainRepo, ["config", "user.email", "test@test.local"]);
+      git(mainRepo, ["config", "user.name", "Test"]);
+      writeFileSync(join(mainRepo, "README.md"), "init\n", "utf-8");
+      git(mainRepo, ["add", "."]);
+      git(mainRepo, ["commit", "-q", "-m", "init"]);
+
+      // Put project config only in the main repo.
+      writeProjectConfig(mainRepo, "jsonc", JSON.stringify({ projectName: "shared-project" }));
+
+      const worktree = join(dir, "wt-fallback");
+      git(mainRepo, ["worktree", "add", "-q", worktree]);
+
+      try {
+        // Worktree has no .pi dir — should find main repo's config.
+        expect(findProjectConfigFile(worktree)).not.toBeNull();
+        const loaded = resolveProjectConfig(worktree);
+        expect(loaded.ok).toBe(true);
+        if (loaded.ok) {
+          expect(loaded.config.projectName).toBe("shared-project");
+        }
+      } finally {
+        try {
+          git(mainRepo, ["worktree", "remove", "--force", worktree]);
+        } catch {
+          rmSync(worktree, { recursive: true, force: true });
+        }
+      }
+    });
+  });
+
+  it("worktree's own project config takes precedence over main repo's", async () => {
+    await withTempDir(async (dir) => {
+      const mainRepo = join(dir, "mainrepo");
+      mkdirSync(mainRepo, { recursive: true });
+      git(mainRepo, ["init", "-q", "--initial-branch=main"]);
+      git(mainRepo, ["config", "user.email", "test@test.local"]);
+      git(mainRepo, ["config", "user.name", "Test"]);
+      writeFileSync(join(mainRepo, "README.md"), "init\n", "utf-8");
+      git(mainRepo, ["add", "."]);
+      git(mainRepo, ["commit", "-q", "-m", "init"]);
+
+      writeProjectConfig(mainRepo, "jsonc", JSON.stringify({ projectName: "main-project" }));
+
+      const worktree = join(dir, "wt-override");
+      git(mainRepo, ["worktree", "add", "-q", worktree]);
+
+      try {
+        // Worktree has its own config — should use that, not main repo's.
+        writeProjectConfig(worktree, "jsonc", JSON.stringify({ projectName: "wt-project" }));
+        const loaded = resolveProjectConfig(worktree);
+        expect(loaded.ok).toBe(true);
+        if (loaded.ok) {
+          expect(loaded.config.projectName).toBe("wt-project");
+        }
+      } finally {
+        try {
+          git(mainRepo, ["worktree", "remove", "--force", worktree]);
+        } catch {
+          rmSync(worktree, { recursive: true, force: true });
+        }
+      }
+    });
+  });
+
+  it("submodule (and its worktrees) resolve to the submodule name, not the commondir parent", async () => {
+    // A submodule's commondir is <super>/.git/modules/<name>, whose basename is
+    // not `.git`. resolveGitCommonDirParent must return null so the submodule
+    // falls back to its own cwd basename instead of resolving to `modules`.
+    await withTempDir(async (dir) => {
+      const superRepo = join(dir, "superrepo");
+      mkdirSync(superRepo, { recursive: true });
+      git(superRepo, ["init", "-q", "--initial-branch=main"]);
+      git(superRepo, ["config", "user.email", "test@test.local"]);
+      git(superRepo, ["config", "user.name", "Test"]);
+      writeFileSync(join(superRepo, "README.md"), "init\n", "utf-8");
+      git(superRepo, ["add", "."]);
+      git(superRepo, ["commit", "-q", "-m", "init"]);
+
+      // Create a sub-repo to add as a submodule.
+      const subRepo = join(dir, "subrepo-src");
+      mkdirSync(subRepo, { recursive: true });
+      git(subRepo, ["init", "-q", "--initial-branch=main"]);
+      git(subRepo, ["config", "user.email", "test@test.local"]);
+      git(subRepo, ["config", "user.name", "Test"]);
+      writeFileSync(join(subRepo, "README.md"), "sub\n", "utf-8");
+      git(subRepo, ["add", "."]);
+      git(subRepo, ["commit", "-q", "-m", "sub"]);
+
+      git(superRepo, [
+        "-c",
+        "protocol.file.allow=always",
+        "submodule",
+        "add",
+        "-q",
+        subRepo,
+        "mysub",
+      ]);
+      git(superRepo, ["commit", "-q", "-m", "add submodule"]);
+
+      const submodCwd = join(superRepo, "mysub");
+      // Add a worktree of the submodule to verify worktrees share the name.
+      const submodWt = join(dir, "wt-submod");
+      git(submodCwd, ["-c", "protocol.file.allow=always", "worktree", "add", "-q", submodWt]);
+      try {
+        // resolveProjectConfig should NOT find the superproject's .pi via
+        // the commondir fallback (the submodule's commondir is not a `.git`).
+        const loaded = resolveProjectConfig(submodCwd);
+        expect(loaded.ok).toBe(false);
+
+        // Default project name should be the submodule name (`mysub`), not
+        // `modules` or the superproject name. Source is `git` because the
+        // commondir basename (`mysub`) is used directly.
+        const r = resolveProjectName(submodCwd, false);
+        expect(r.ok).toBe(true);
+        if (r.ok) {
+          expect(r.projectName).toBe("mysub");
+          expect(r.source).toBe("git");
+        }
+
+        // A worktree of the submodule shares the submodule name (not the
+        // worktree dir name `wt-submod`).
+        const wtR = resolveProjectName(submodWt, false);
+        expect(wtR.ok).toBe(true);
+        if (wtR.ok) {
+          expect(wtR.projectName).toBe("mysub");
+          expect(wtR.source).toBe("git");
+        }
+      } finally {
+        try {
+          git(submodCwd, ["worktree", "remove", "--force", submodWt]);
+        } catch {
+          rmSync(submodWt, { recursive: true, force: true });
+        }
+        try {
+          git(superRepo, [
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "deinit",
+            "-f",
+            "mysub",
+          ]);
+          git(superRepo, ["rm", "-f", "mysub"]);
+        } catch {
+          // best-effort cleanup
+        }
+      }
+    });
+  });
+});
+
+// ============================================
+// resolveProjectName
+// ============================================
+
+describe("resolveProjectName (default / non-marked)", () => {
+  // Env-var overrides were removed; default derivation is git common dir -> basename.
+  it("ignores EPIMETHEUS_PROJECT_NAME and falls back to basename", () => {
+    process.env.EPIMETHEUS_PROJECT_NAME = "env-override";
+    try {
+      const r = resolveProjectName("/some/path/myapp", false);
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.projectName).toBe("myapp");
+        expect(r.source).toBe("basename");
+      }
+    } finally {
+      delete process.env.EPIMETHEUS_PROJECT_NAME;
+    }
+  });
+
+  it("ignores legacy PI_HINDSIGHT_PROJECT_NAME and falls back to basename", () => {
+    process.env.PI_HINDSIGHT_PROJECT_NAME = "legacy-override";
+    try {
+      const r = resolveProjectName("/some/path/myapp", false);
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.projectName).toBe("myapp");
+        expect(r.source).toBe("basename");
+      }
+    } finally {
+      delete process.env.PI_HINDSIGHT_PROJECT_NAME;
+    }
+  });
+
+  it("falls back to basename when no env var and no .git", () => {
+    const r = resolveProjectName("/some/path/myapp", false);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.projectName).toBe("myapp");
+      expect(r.source).toBe("basename");
+    }
+  });
+
+  it("derives basename for non-existent cwd with no .git (no fail-closed)", () => {
+    const r = resolveProjectName("/totally/nonexistent/path-xyz", false);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.projectName).toBe("path-xyz");
+      expect(r.source).toBe("basename");
+    }
+  });
+
+  it("derives main-repo name from git common dir (basename of common dir parent)", async () => {
+    await withTempDir(async (dir) => {
+      const mainRepo = join(dir, "realrepo");
+      mkdirSync(mainRepo, { recursive: true });
+      git(mainRepo, ["init", "-q", "--initial-branch=main"]);
+      git(mainRepo, ["config", "user.email", "test@test.local"]);
+      git(mainRepo, ["config", "user.name", "Test"]);
+      writeFileSync(join(mainRepo, "README.md"), "init\n", "utf-8");
+      git(mainRepo, ["add", "."]);
+      git(mainRepo, ["commit", "-q", "-m", "init"]);
+
+      const r = resolveProjectName(mainRepo, false);
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.projectName).toBe("realrepo");
+        expect(r.source).toBe("git");
+      }
+    });
+  });
+
+  it("worktrees share the main repo name (git common dir handles this)", async () => {
+    await withTempDir(async (dir) => {
+      const mainRepo = join(dir, "mainshared");
+      mkdirSync(mainRepo, { recursive: true });
+      git(mainRepo, ["init", "-q", "--initial-branch=main"]);
+      git(mainRepo, ["config", "user.email", "test@test.local"]);
+      git(mainRepo, ["config", "user.name", "Test"]);
+      writeFileSync(join(mainRepo, "README.md"), "init\n", "utf-8");
+      git(mainRepo, ["add", "."]);
+      git(mainRepo, ["commit", "-q", "-m", "init"]);
+
+      const worktree = join(dir, "wt-should-share-name");
+      git(mainRepo, ["worktree", "add", "-q", worktree]);
+
+      try {
+        const mainR = resolveProjectName(mainRepo, false);
+        const wtR = resolveProjectName(worktree, false);
+        expect(mainR.ok).toBe(true);
+        expect(wtR.ok).toBe(true);
+        if (mainR.ok && wtR.ok) {
+          expect(mainR.projectName).toBe("mainshared");
+          expect(wtR.projectName).toBe("mainshared"); // shared with main repo
+          expect(mainR.source).toBe("git");
+          expect(wtR.source).toBe("git");
+        }
+      } finally {
+        try {
+          git(mainRepo, ["worktree", "remove", "--force", worktree]);
+        } catch {
+          // best-effort cleanup
+          rmSync(worktree, { recursive: true, force: true });
+        }
+      }
+    });
+  });
+});
+
+describe("resolveProjectName (marked case)", () => {
+  it("uses cwd-local project config projectName when marked", async () => {
+    await withTempDir(async (cwd) => {
+      writeProjectConfig(cwd, "jsonc", JSON.stringify({ projectName: "marked-stable" }));
+      const r = resolveProjectName(cwd, true);
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.projectName).toBe("marked-stable");
+        expect(r.source).toBe("project-local-config");
+      }
+    });
+  });
+
+  it("does not fall back to env var when marked (config projectName is authoritative)", async () => {
+    process.env.EPIMETHEUS_PROJECT_NAME = "env-should-be-ignored";
+    await withTempDir(async (cwd) => {
+      writeProjectConfig(cwd, "json", JSON.stringify({ projectName: "from-config" }));
+      const r = resolveProjectName(cwd, true);
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.projectName).toBe("from-config");
+        expect(r.source).toBe("project-local-config");
+      }
+    });
+  });
+
+  it("fails closed when marked but cwd no longer exists", () => {
+    const r = resolveProjectName("/nonexistent/path/abc", true);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/cwd .* no longer exists/);
+  });
+
+  it("fails closed when marked and cwd-local config is missing", async () => {
+    await withTempDir(async (cwd) => {
+      // No project config written.
+      const r = resolveProjectName(cwd, true);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/marked .* using project-local config/);
+    });
+  });
+
+  it("fails closed when marked and cwd-local config is invalid (missing projectName)", async () => {
+    await withTempDir(async (cwd) => {
+      writeProjectConfig(cwd, "jsonc", JSON.stringify({ other: "x" }));
+      const r = resolveProjectName(cwd, true);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/invalid/);
+    });
+  });
+
+  it("fails closed when marked and no cwd-local config even though an ancestor has one (no ancestor walk)", async () => {
+    await withTempDir(async (dir) => {
+      const ancestor = join(dir, "ancestor");
+      mkdirSync(ancestor, { recursive: true });
+      writeProjectConfig(ancestor, "jsonc", JSON.stringify({ projectName: "ancestor-name" }));
+      const child = join(ancestor, "child");
+      mkdirSync(child, { recursive: true });
+      // Marked, cwd-local missing, ancestor has one — must fail closed.
+      const r = resolveProjectName(child, true);
+      expect(r.ok).toBe(false);
+    });
+  });
+
+  it("marked worktree finds main repo's config via commondir fallback", async () => {
+    await withTempDir(async (dir) => {
+      const mainRepo = join(dir, "mainrepo");
+      mkdirSync(mainRepo, { recursive: true });
+      git(mainRepo, ["init", "-q", "--initial-branch=main"]);
+      git(mainRepo, ["config", "user.email", "test@test.local"]);
+      git(mainRepo, ["config", "user.name", "Test"]);
+      writeFileSync(join(mainRepo, "README.md"), "init\n", "utf-8");
+      git(mainRepo, ["add", "."]);
+      git(mainRepo, ["commit", "-q", "-m", "init"]);
+
+      writeProjectConfig(mainRepo, "jsonc", JSON.stringify({ projectName: "marked-wt" }));
+
+      const worktree = join(dir, "wt-marked");
+      git(mainRepo, ["worktree", "add", "-q", worktree]);
+
+      try {
+        const r = resolveProjectName(worktree, true);
+        expect(r.ok).toBe(true);
+        if (r.ok) {
+          expect(r.projectName).toBe("marked-wt");
+          expect(r.source).toBe("project-local-config");
+        }
+      } finally {
+        try {
+          git(mainRepo, ["worktree", "remove", "--force", worktree]);
+        } catch {
+          rmSync(worktree, { recursive: true, force: true });
+        }
+      }
+    });
+  });
+
+  it("marked worktree fails closed when commondir config is invalid (no silent fallback)", async () => {
+    await withTempDir(async (dir) => {
+      const mainRepo = join(dir, "mainrepo");
+      mkdirSync(mainRepo, { recursive: true });
+      git(mainRepo, ["init", "-q", "--initial-branch=main"]);
+      git(mainRepo, ["config", "user.email", "test@test.local"]);
+      git(mainRepo, ["config", "user.name", "Test"]);
+      writeFileSync(join(mainRepo, "README.md"), "init\n", "utf-8");
+      git(mainRepo, ["add", "."]);
+      git(mainRepo, ["commit", "-q", "-m", "init"]);
+
+      // Invalid config in main repo (missing projectName).
+      writeProjectConfig(mainRepo, "jsonc", JSON.stringify({ other: "x" }));
+
+      const worktree = join(dir, "wt-marked-invalid");
+      git(mainRepo, ["worktree", "add", "-q", worktree]);
+
+      try {
+        const r = resolveProjectName(worktree, true);
+        expect(r.ok).toBe(false);
+        if (!r.ok) expect(r.error).toMatch(/invalid/);
+      } finally {
+        try {
+          git(mainRepo, ["worktree", "remove", "--force", worktree]);
+        } catch {
+          rmSync(worktree, { recursive: true, force: true });
+        }
+      }
+    });
+  });
+});
+
+// ============================================
+// resolveProjectName (unmarked / undefined tristate)
+// ============================================
+
+describe("resolveProjectName (unmarked / undefined)", () => {
+  it("uses cwd-local config projectName when a valid file is present (unmarked)", async () => {
+    await withTempDir(async (cwd) => {
+      writeProjectConfig(cwd, "jsonc", JSON.stringify({ projectName: "stable-name" }));
+      // unmarked = undefined (NOT false) → valid config is used (mirrors session_start auto-mark intent)
+      const r = resolveProjectName(cwd, undefined);
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.projectName).toBe("stable-name");
+        expect(r.source).toBe("project-local-config");
+      }
+    });
+  });
+
+  it("fails closed when a file is present but invalid (unmarked — no silent fallback)", async () => {
+    // Point 4 regression: an invalid cwd-local project-config for an unmarked
+    // session must NOT silently fall back to env/git/basename and allow ingestion.
+    await withTempDir(async (cwd) => {
+      writeProjectConfig(cwd, "jsonc", JSON.stringify({ notProjectName: "x" }));
+      const r = resolveProjectName(cwd, undefined);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/invalid/);
+    });
+  });
+
+  it("uses default derivation when no file is present (unmarked)", () => {
+    const r = resolveProjectName("/some/path/myapp", undefined);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.projectName).toBe("myapp");
+      expect(r.source).toBe("basename");
+    }
+  });
+
+  it("detached (false) ignores a present invalid file (detached wins, not fail-closed)", async () => {
+    await withTempDir(async (cwd) => {
+      writeProjectConfig(cwd, "jsonc", JSON.stringify({ notProjectName: "x" }));
+      // false (detached) → ignore the project config entirely → default derivation.
+      const r = resolveProjectName(cwd, false);
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.projectName).toBe(cwd.split("/").pop() ?? "");
+        expect(r.source).toBe("basename");
+      }
+    });
+  });
+
+  it("unmarked worktree picks up main repo's config via commondir fallback", async () => {
+    await withTempDir(async (dir) => {
+      const mainRepo = join(dir, "mainrepo");
+      mkdirSync(mainRepo, { recursive: true });
+      git(mainRepo, ["init", "-q", "--initial-branch=main"]);
+      git(mainRepo, ["config", "user.email", "test@test.local"]);
+      git(mainRepo, ["config", "user.name", "Test"]);
+      writeFileSync(join(mainRepo, "README.md"), "init\n", "utf-8");
+      git(mainRepo, ["add", "."]);
+      git(mainRepo, ["commit", "-q", "-m", "init"]);
+
+      writeProjectConfig(mainRepo, "jsonc", JSON.stringify({ projectName: "wt-unmarked" }));
+
+      const worktree = join(dir, "wt-unmarked");
+      git(mainRepo, ["worktree", "add", "-q", worktree]);
+
+      try {
+        const r = resolveProjectName(worktree, undefined);
+        expect(r.ok).toBe(true);
+        if (r.ok) {
+          expect(r.projectName).toBe("wt-unmarked");
+          expect(r.source).toBe("project-local-config");
+        }
+      } finally {
+        try {
+          git(mainRepo, ["worktree", "remove", "--force", worktree]);
+        } catch {
+          rmSync(worktree, { recursive: true, force: true });
+        }
+      }
+    });
+  });
+
+  it("unmarked worktree fails closed when commondir config is invalid (no silent fallback)", async () => {
+    await withTempDir(async (dir) => {
+      const mainRepo = join(dir, "mainrepo");
+      mkdirSync(mainRepo, { recursive: true });
+      git(mainRepo, ["init", "-q", "--initial-branch=main"]);
+      git(mainRepo, ["config", "user.email", "test@test.local"]);
+      git(mainRepo, ["config", "user.name", "Test"]);
+      writeFileSync(join(mainRepo, "README.md"), "init\n", "utf-8");
+      git(mainRepo, ["add", "."]);
+      git(mainRepo, ["commit", "-q", "-m", "init"]);
+
+      // Invalid config in main repo (missing projectName).
+      writeProjectConfig(mainRepo, "jsonc", JSON.stringify({ notProjectName: "x" }));
+
+      const worktree = join(dir, "wt-unmarked-invalid");
+      git(mainRepo, ["worktree", "add", "-q", worktree]);
+
+      try {
+        const r = resolveProjectName(worktree, undefined);
+        expect(r.ok).toBe(false);
+        if (!r.ok) expect(r.error).toMatch(/invalid/);
+      } finally {
+        try {
+          git(mainRepo, ["worktree", "remove", "--force", worktree]);
+        } catch {
+          rmSync(worktree, { recursive: true, force: true });
+        }
+      }
+    });
+  });
+});
+
+// ============================================
+// evaluateActiveSessionProjectState (session_start readiness gate)
+// ============================================
+
+describe("evaluateActiveSessionProjectState", () => {
+  it("detached (false) is always ready, no auto-mark", () => {
+    const r = evaluateActiveSessionProjectState("/anything", { usesProjectConfig: false });
+    expect(r.ready).toBe(true);
+    expect(r.autoMark).toBeUndefined();
+  });
+
+  it("detached (false) is ready even with cwd undefined", () => {
+    const r = evaluateActiveSessionProjectState(undefined, { usesProjectConfig: false });
+    expect(r.ready).toBe(true);
+  });
+
+  it("detached (false) is ready even when cwd has an invalid project config (detach wins)", async () => {
+    await withTempDir(async (cwd) => {
+      writeProjectConfig(cwd, "jsonc", JSON.stringify({ notProjectName: "x" }));
+      const r = evaluateActiveSessionProjectState(cwd, { usesProjectConfig: false });
+      expect(r.ready).toBe(true);
+      expect(r.autoMark).toBeUndefined();
+      expect(r.reason).toBeUndefined();
+    });
+  });
+
+  it("marked (true) + valid config → ready, no auto-mark", async () => {
+    await withTempDir(async (cwd) => {
+      writeProjectConfig(cwd, "jsonc", JSON.stringify({ projectName: "marked" }));
+      const r = evaluateActiveSessionProjectState(cwd, { usesProjectConfig: true });
+      expect(r.ready).toBe(true);
+      expect(r.autoMark).toBeUndefined();
+    });
+  });
+
+  it("marked (true) + invalid config → failed", async () => {
+    await withTempDir(async (cwd) => {
+      writeProjectConfig(cwd, "jsonc", JSON.stringify({ x: 1 }));
+      const r = evaluateActiveSessionProjectState(cwd, { usesProjectConfig: true });
+      expect(r.ready).toBe(false);
+      expect(r.reason).toMatch(/invalid/);
+      expect(r.configPath).toBeTruthy();
+    });
+  });
+
+  it("marked (true) + no config → failed (required but missing)", async () => {
+    await withTempDir(async (cwd) => {
+      const r = evaluateActiveSessionProjectState(cwd, { usesProjectConfig: true });
+      expect(r.ready).toBe(false);
+      expect(r.reason).toMatch(/no project config file is present/);
+    });
+  });
+
+  it("marked (true) + cwd does not exist → failed", () => {
+    const r = evaluateActiveSessionProjectState("/nonexistent/abc/xyz", {
+      usesProjectConfig: true,
+    });
+    expect(r.ready).toBe(false);
+    expect(r.reason).toMatch(/cwd .* does not exist/);
+  });
+
+  it("unmarked (undefined) + valid config → ready + autoMark", async () => {
+    await withTempDir(async (cwd) => {
+      writeProjectConfig(cwd, "jsonc", JSON.stringify({ projectName: "auto" }));
+      const r = evaluateActiveSessionProjectState(cwd, null);
+      expect(r.ready).toBe(true);
+      expect(r.autoMark).toBe(true);
+    });
+  });
+
+  it("unmarked (undefined) + invalid config → failed (no silent fallback)", async () => {
+    await withTempDir(async (cwd) => {
+      writeProjectConfig(cwd, "jsonc", JSON.stringify({ nope: true }));
+      const r = evaluateActiveSessionProjectState(cwd, null);
+      expect(r.ready).toBe(false);
+      expect(r.autoMark).toBeUndefined();
+      expect(r.reason).toMatch(/invalid/);
+    });
+  });
+
+  it("unmarked (undefined) + no config → ready (default derivation), no autoMark", async () => {
+    await withTempDir(async (cwd) => {
+      const r = evaluateActiveSessionProjectState(cwd, null);
+      expect(r.ready).toBe(true);
+      expect(r.autoMark).toBeUndefined();
+    });
+  });
+
+  it("unmarked (undefined) + cwd undefined → ready (non-fatal)", () => {
+    const r = evaluateActiveSessionProjectState(undefined, null);
+    expect(r.ready).toBe(true);
+  });
+
+  it("unmarked worktree with commondir config → ready + autoMark", async () => {
+    await withTempDir(async (dir) => {
+      const mainRepo = join(dir, "mainrepo");
+      mkdirSync(mainRepo, { recursive: true });
+      git(mainRepo, ["init", "-q", "--initial-branch=main"]);
+      git(mainRepo, ["config", "user.email", "test@test.local"]);
+      git(mainRepo, ["config", "user.name", "Test"]);
+      writeFileSync(join(mainRepo, "README.md"), "init\n", "utf-8");
+      git(mainRepo, ["add", "."]);
+      git(mainRepo, ["commit", "-q", "-m", "init"]);
+
+      writeProjectConfig(mainRepo, "jsonc", JSON.stringify({ projectName: "wt-auto" }));
+
+      const worktree = join(dir, "wt-auto");
+      git(mainRepo, ["worktree", "add", "-q", worktree]);
+
+      try {
+        const r = evaluateActiveSessionProjectState(worktree, null);
+        expect(r.ready).toBe(true);
+        expect(r.autoMark).toBe(true);
+      } finally {
+        try {
+          git(mainRepo, ["worktree", "remove", "--force", worktree]);
+        } catch {
+          rmSync(worktree, { recursive: true, force: true });
+        }
+      }
+    });
+  });
+
+  it("marked worktree with valid commondir config → ready, no autoMark", async () => {
+    await withTempDir(async (dir) => {
+      const mainRepo = join(dir, "mainrepo");
+      mkdirSync(mainRepo, { recursive: true });
+      git(mainRepo, ["init", "-q", "--initial-branch=main"]);
+      git(mainRepo, ["config", "user.email", "test@test.local"]);
+      git(mainRepo, ["config", "user.name", "Test"]);
+      writeFileSync(join(mainRepo, "README.md"), "init\n", "utf-8");
+      git(mainRepo, ["add", "."]);
+      git(mainRepo, ["commit", "-q", "-m", "init"]);
+
+      writeProjectConfig(mainRepo, "jsonc", JSON.stringify({ projectName: "wt-marked-ready" }));
+
+      const worktree = join(dir, "wt-marked-ready");
+      git(mainRepo, ["worktree", "add", "-q", worktree]);
+
+      try {
+        const r = evaluateActiveSessionProjectState(worktree, { usesProjectConfig: true });
+        expect(r.ready).toBe(true);
+        expect(r.autoMark).toBeUndefined();
+      } finally {
+        try {
+          git(mainRepo, ["worktree", "remove", "--force", worktree]);
+        } catch {
+          rmSync(worktree, { recursive: true, force: true });
+        }
+      }
+    });
+  });
+
+  it("marked worktree with invalid commondir config → failed (no silent fallback)", async () => {
+    await withTempDir(async (dir) => {
+      const mainRepo = join(dir, "mainrepo");
+      mkdirSync(mainRepo, { recursive: true });
+      git(mainRepo, ["init", "-q", "--initial-branch=main"]);
+      git(mainRepo, ["config", "user.email", "test@test.local"]);
+      git(mainRepo, ["config", "user.name", "Test"]);
+      writeFileSync(join(mainRepo, "README.md"), "init\n", "utf-8");
+      git(mainRepo, ["add", "."]);
+      git(mainRepo, ["commit", "-q", "-m", "init"]);
+
+      writeProjectConfig(mainRepo, "jsonc", JSON.stringify({ broken: true }));
+
+      const worktree = join(dir, "wt-marked-failed");
+      git(mainRepo, ["worktree", "add", "-q", worktree]);
+
+      try {
+        const r = evaluateActiveSessionProjectState(worktree, { usesProjectConfig: true });
+        expect(r.ready).toBe(false);
+        expect(r.autoMark).toBeUndefined();
+        expect(r.reason).toMatch(/invalid/);
+        expect(r.configPath).toBeTruthy();
+      } finally {
+        try {
+          git(mainRepo, ["worktree", "remove", "--force", worktree]);
+        } catch {
+          rmSync(worktree, { recursive: true, force: true });
+        }
+      }
+    });
+  });
+});
+
+// ============================================
+// Hardened reads: findProjectConfigFile / resolveProjectConfig never throw
+// ============================================
+
+describe("project-config hardened reads", () => {
+  it("findProjectConfigFile returns the path for a directory named like the config (does not throw)", async () => {
+    await withTempDir(async (cwd) => {
+      // Create a DIRECTORY at the config.jsonc path (existsSync is true
+      // for dirs). findProjectConfigFile must not throw — it returns the path.
+      const dir = join(cwd, ".pi", "epimetheus", "config.jsonc");
+      mkdirSync(dir, { recursive: true });
+      const path = findProjectConfigFile(cwd);
+      expect(path).not.toBeNull();
+      expect(path?.endsWith("config.jsonc")).toBe(true);
+    });
+  });
+
+  it("resolveProjectConfig fails closed (ok:false) for a directory instead of throwing", async () => {
+    await withTempDir(async (cwd) => {
+      const dir = join(cwd, ".pi", "epimetheus", "config.jsonc");
+      mkdirSync(dir, { recursive: true });
+      let threw = false;
+      let r: ReturnType<typeof resolveProjectConfig> | undefined;
+      try {
+        r = resolveProjectConfig(cwd);
+      } catch {
+        threw = true;
+      }
+      expect(threw).toBe(false);
+      expect(r?.ok).toBe(false);
+      if (r && !r.ok) {
+        expect(r.path).toBeTruthy();
+        expect(r.error).toMatch(/could not read|not a regular file/);
+      }
+    });
+  });
+
+  it("findProjectConfigFile returns null when cwd doesn't exist (no throw)", () => {
+    let threw = false;
+    let path: string | null = null;
+    try {
+      path = findProjectConfigFile("/totally/nonexistent/xyz");
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(false);
+    expect(path).toBeNull();
+  });
+});
+
+// ============================================
+// parseAndUpsertSession integration (fail-closed + project-config)
+// ============================================
+
+describe("parseAndUpsertSession: project-local config", () => {
+  const SESSION_ID = "project-config-session";
+
+  async function setupSession(
+    tmpDir: string,
+    options: { usesProjectConfig?: boolean }
+  ): Promise<void> {
+    // writeSessionFile's `cwd` option lets the session header point at a real
+    // tmpdir (so existsSync checks behave realistically).
+    writeSessionFile(tmpDir, SESSION_ID, {
+      cwd: tmpDir,
+      messages: [{ role: "user", content: "Hello" }],
+      retained: true,
+      usesProjectConfig: options.usesProjectConfig,
+    });
+    await touchPendingFlag(SESSION_ID);
+  }
+
+  afterEach(() => {
+    removePendingFlag(SESSION_ID);
+    clearSessionQueueState(SESSION_ID);
+    cleanupParsedArtifacts(SESSION_ID);
+    rmSync(getMetaPath(SESSION_ID), { force: true });
+    rmSync(getMessagesPath(SESSION_ID), { force: true });
+    rmSync(getSessionStatePath(SESSION_ID), { force: true });
+  });
+
+  it("uses cwd-local project config projectName when session is marked and config is valid", async () => {
+    await withTempDir(async (tmpDir) => {
+      writeProjectConfig(tmpDir, "jsonc", JSON.stringify({ projectName: "from-project-config" }));
+      await setupSession(tmpDir, { usesProjectConfig: true });
+
+      const ctx = makeNotifyCtx();
+      const { client, retainCalls } = capturingClient();
+      await parseAndUpsertSession(
+        join(tmpDir, `${SESSION_ID}.jsonl`),
+        SESSION_ID,
+        testConfig,
+        client,
+        ctx
+      );
+
+      expect(retainCalls).toHaveLength(1);
+      const tags = retainCalls[0]?.tags ?? [];
+      expect(tags).toContain("project:from-project-config");
+      // Pending marker cleared on successful flush.
+      expect(hasPendingFlag(SESSION_ID)).toBe(false);
+    });
+  });
+
+  it("fails closed (no upsert, pending stays queued) when marked and cwd-local config is missing", async () => {
+    await withTempDir(async (tmpDir) => {
+      // No project config at tmpDir.
+      await setupSession(tmpDir, { usesProjectConfig: true });
+
+      const ctx = makeNotifyCtx();
+      const { client, retainCalls } = capturingClient();
+      await parseAndUpsertSession(
+        join(tmpDir, `${SESSION_ID}.jsonl`),
+        SESSION_ID,
+        testConfig,
+        client,
+        ctx
+      );
+
+      expect(retainCalls).toHaveLength(0); // no upsert
+      expect(hasPendingFlag(SESSION_ID)).toBe(true); // pending left queued
+      const notify = (ctx.ui.notify as ReturnType<typeof mock>).mock.calls.map((c) => String(c[0]));
+      expect(notify.some((m) => m.includes("Flush blocked for session"))).toBe(true);
+      expect(notify.some((m) => m.includes("/hindsight detach-project-name"))).toBe(true);
+    });
+  });
+
+  it("fails closed (no upsert, pending stays queued) when marked and project config is invalid", async () => {
+    await withTempDir(async (tmpDir) => {
+      writeProjectConfig(tmpDir, "jsonc", JSON.stringify({ notProjectName: "x" }));
+      await setupSession(tmpDir, { usesProjectConfig: true });
+
+      const ctx = makeNotifyCtx();
+      const { client, retainCalls } = capturingClient();
+      await parseAndUpsertSession(
+        join(tmpDir, `${SESSION_ID}.jsonl`),
+        SESSION_ID,
+        testConfig,
+        client,
+        ctx
+      );
+
+      expect(retainCalls).toHaveLength(0);
+      expect(hasPendingFlag(SESSION_ID)).toBe(true);
+    });
+  });
+
+  it("non-marked session still uses default derivation (basename) and flushes normally", async () => {
+    await withTempDir(async (tmpDir) => {
+      // No project config, not marked → default derivation uses basename(tmpDir)
+      // (no env var, no .git in the temp dir).
+      await setupSession(tmpDir, { usesProjectConfig: false });
+
+      const ctx = makeNotifyCtx();
+      const { client, retainCalls } = capturingClient();
+      await parseAndUpsertSession(
+        join(tmpDir, `${SESSION_ID}.jsonl`),
+        SESSION_ID,
+        testConfig,
+        client,
+        ctx
+      );
+
+      expect(retainCalls).toHaveLength(1);
+      const tags = retainCalls[0]?.tags ?? [];
+      const expectedBasename = tmpDir.split("/").pop();
+      expect(expectedBasename).toBeTruthy();
+      expect(tags).toContain(`project:${expectedBasename}`);
+      expect(hasPendingFlag(SESSION_ID)).toBe(false);
+    });
+  });
+
+  it("uses cwd-local config projectName per session (flush-pending handles sessions independently)", async () => {
+    // Two sessions in two different cwds, each marked usesProjectConfig
+    // with its own project config and its own projectName. parseAndUpsertSession
+    // per session must use each cwd's config independently.
+    const SESSION_A = `${SESSION_ID}-a`;
+    const SESSION_B = `${SESSION_ID}-b`;
+
+    try {
+      await withTempDir(async (dirA) => {
+        await withTempDir(async (dirB) => {
+          writeProjectConfig(dirA, "jsonc", JSON.stringify({ projectName: "project-a" }));
+          writeProjectConfig(dirB, "jsonc", JSON.stringify({ projectName: "project-b" }));
+
+          for (const [sid, dir, _name] of [
+            [SESSION_A, dirA, "project-a"],
+            [SESSION_B, dirB, "project-b"],
+          ] as const) {
+            writeSessionFile(dir, sid, {
+              cwd: dir,
+              messages: [{ role: "user", content: "Hello" }],
+              retained: true,
+              usesProjectConfig: true,
+            });
+            await touchPendingFlag(sid);
+          }
+
+          const ctx = makeNotifyCtx();
+          const { client, retainCalls } = capturingClient();
+
+          // Flush each session independently — like flush-pending iterates.
+          await parseAndUpsertSession(
+            join(dirA, `${SESSION_A}.jsonl`),
+            SESSION_A,
+            testConfig,
+            client,
+            ctx
+          );
+          await parseAndUpsertSession(
+            join(dirB, `${SESSION_B}.jsonl`),
+            SESSION_B,
+            testConfig,
+            client,
+            ctx
+          );
+
+          expect(retainCalls).toHaveLength(2);
+          expect(retainCalls[0]?.tags ?? []).toContain("project:project-a");
+          expect(retainCalls[1]?.tags ?? []).toContain("project:project-b");
+          expect(hasPendingFlag(SESSION_A)).toBe(false);
+          expect(hasPendingFlag(SESSION_B)).toBe(false);
+        });
+      });
+    } finally {
+      for (const sid of [SESSION_A, SESSION_B]) {
+        removePendingFlag(sid);
+        clearSessionQueueState(sid);
+        cleanupParsedArtifacts(sid);
+        rmSync(getMetaPath(sid), { force: true });
+        rmSync(getMessagesPath(sid), { force: true });
+        rmSync(getSessionStatePath(sid), { force: true });
+      }
+    }
+  });
+
+  it("auto-flush suppresses the project-name block warning in non-debug mode", async () => {
+    // Like other transient block warnings (extra-context guard, not-retained),
+    // the project-name fail-closed block is suppressed during auto-flushes
+    // unless debug: true. Pending work stays queued either way.
+    await withTempDir(async (tmpDir) => {
+      // No project config at tmpDir -> marked + missing -> fail closed.
+      await setupSession(tmpDir, { usesProjectConfig: true });
+      const ctx = makeNotifyCtx();
+      const { client, retainCalls } = capturingClient();
+      await parseAndUpsertSession(
+        join(tmpDir, `${SESSION_ID}.jsonl`),
+        SESSION_ID,
+        testConfig,
+        client,
+        ctx,
+        undefined,
+        { autoFlush: true }
+      );
+      expect(retainCalls).toHaveLength(0); // no upsert
+      expect(hasPendingFlag(SESSION_ID)).toBe(true); // pending stays queued
+      const notify = (ctx.ui.notify as ReturnType<typeof mock>).mock.calls.map((c) => String(c[0]));
+      expect(notify.some((m) => m.includes("Flush blocked for session"))).toBe(false);
+    });
+  });
+
+  it("auto-flush surfaces the project-name block warning in debug mode", async () => {
+    await withTempDir(async (tmpDir) => {
+      await setupSession(tmpDir, { usesProjectConfig: true });
+      const ctx = makeNotifyCtx();
+      const { client, retainCalls } = capturingClient();
+      await parseAndUpsertSession(
+        join(tmpDir, `${SESSION_ID}.jsonl`),
+        SESSION_ID,
+        { ...testConfig, debug: true },
+        client,
+        ctx,
+        undefined,
+        { autoFlush: true }
+      );
+      expect(retainCalls).toHaveLength(0); // no upsert
+      expect(hasPendingFlag(SESSION_ID)).toBe(true); // pending stays queued
+      const notify = (ctx.ui.notify as ReturnType<typeof mock>).mock.calls.map((c) => String(c[0]));
+      expect(notify.some((m) => m.includes("Flush blocked for session"))).toBe(true);
+    });
+  });
+});
+
+// ============================================
+// /hindsight detach-project-name command
+// ============================================
+
+describe("/hindsight detach-project-name", () => {
+  const SESSION_ID = "detach-project-name-session";
+
+  it("appends usesProjectConfig:false (latest-wins overrides true) and marks pending", async () => {
+    // Use the fixtures' createMockPi builder so the command registration captures
+    // the real /hindsight command handler + appendedEntries.
+    const { createMockPi } = await import("./fixtures");
+    const pi = createMockPi();
+    registerCommands(
+      pi,
+      { ...testConfig, apiUrl: "https://x", apiKey: "y", bankId: "b", observationScopes: [] },
+      createMockClient(),
+      () => null as RecallMessageDetails | null,
+      () => null,
+      () => {},
+      () => true,
+      { configPath: undefined, envVars: [], warning: undefined, validationWarnings: [] }
+    );
+
+    const entries = [
+      {
+        type: "custom",
+        customType: "hindsight-meta",
+        data: { retained: true, usesProjectConfig: true },
+      },
+    ];
+    const ctx = {
+      sessionManager: {
+        getSessionId: () => SESSION_ID,
+        getEntries: () => entries,
+        getSessionFile: () => null,
+        getHeader: () => ({ id: SESSION_ID, cwd: tmpdir() }),
+        getSessionName: () => undefined,
+      },
+      ui: {
+        notify: mock(),
+        confirm: mock(async () => true),
+        select: mock(),
+      },
+      signal: undefined,
+      cwd: "/test",
+    } as unknown as ExtensionContext;
+
+    try {
+      // createMockPi exposes `.commands` (a Map) on the ExtensionAPI mock.
+      const cmd = (
+        pi as unknown as {
+          commands: Map<string, { handler: (a: string, ctx: ExtensionContext) => Promise<void> }>;
+        }
+      ).commands.get("hindsight");
+      expect(cmd).toBeDefined();
+      await cmd!.handler("detach-project-name", ctx);
+
+      // The latest hindsight-meta entry is built by buildMetaUpdate({retained:true,usesProjectConfig:true}, {usesProjectConfig:false}).
+      // Latest value wins → false.
+      const metaEntries = pi.appendedEntries.filter((e) => e.customType === "hindsight-meta");
+      expect(metaEntries.length).toBeGreaterThan(0);
+      const latestData = metaEntries[metaEntries.length - 1]?.data as {
+        retained?: boolean;
+        usesProjectConfig?: boolean;
+      };
+      expect(latestData.retained).toBe(true); // carried forward
+      expect(latestData.usesProjectConfig).toBe(false); // latest-wins overrides true
+
+      // Detach marks the session pending for a re-flush (project tag may change).
+      expect(hasPendingFlag(SESSION_ID)).toBe(true);
+
+      // The notification makes clear the file is not deleted.
+      const notify = (ctx.ui.notify as ReturnType<typeof mock>).mock.calls.map((c) => String(c[0]));
+      expect(notify.some((m) => m.includes("not deleted"))).toBe(true);
+    } finally {
+      removePendingFlag(SESSION_ID);
+      clearSessionQueueState(SESSION_ID);
+    }
+  });
+
+  it("bails cleanly when the user declines confirmation", async () => {
+    const { createMockPi } = await import("./fixtures");
+    const pi = createMockPi();
+    registerCommands(
+      pi,
+      { ...testConfig, apiUrl: "https://x", apiKey: "y", bankId: "b", observationScopes: [] },
+      createMockClient(),
+      () => null as RecallMessageDetails | null,
+      () => null,
+      () => {},
+      () => true,
+      { configPath: undefined, envVars: [], warning: undefined, validationWarnings: [] }
+    );
+
+    const ctx = {
+      sessionManager: {
+        getSessionId: () => SESSION_ID,
+        getEntries: () => [
+          {
+            type: "custom",
+            customType: "hindsight-meta",
+            data: { retained: true, usesProjectConfig: true },
+          },
+        ],
+        getSessionFile: () => null,
+        getHeader: () => ({ id: SESSION_ID, cwd: tmpdir() }),
+        getSessionName: () => undefined,
+      },
+      ui: {
+        notify: mock(),
+        confirm: mock(async () => false), // decline
+        select: mock(),
+      },
+      signal: undefined,
+      cwd: "/test",
+    } as unknown as ExtensionContext;
+
+    try {
+      const cmd = (
+        pi as unknown as {
+          commands: Map<string, { handler: (a: string, ctx: ExtensionContext) => Promise<void> }>;
+        }
+      ).commands.get("hindsight");
+      await cmd!.handler("detach-project-name", ctx);
+      expect(pi.appendedEntries.filter((e) => e.customType === "hindsight-meta")).toHaveLength(0);
+      expect(hasPendingFlag(SESSION_ID)).toBe(false);
+      const notify = (ctx.ui.notify as ReturnType<typeof mock>).mock.calls.map((c) => String(c[0]));
+      expect(notify.some((m) => m.includes("not detached"))).toBe(true);
+    } finally {
+      removePendingFlag(SESSION_ID);
+      clearSessionQueueState(SESSION_ID);
+    }
+  });
+
+  it("remains available when not ready (failed/not-ready state) and clears the flush latch; does NOT re-enable tools if another degraded cause still applies", async () => {
+    // Point 3: detach-project-name is a recovery command that must remain
+    // available even when isReady() returns false (NOT in
+    // OPERATIONAL_SUBCOMMANDS). It clears the per-session flush latch. But
+    // detach does NOT mark the extension operational if another degraded cause
+    // still applies — here startup has not been latched (server degraded), so
+    // tools stay hidden even after detach clears the project-local failure.
+    const { createMockPi } = await import("./fixtures");
+    const {
+      setActiveSessionProjectReady,
+      isActiveSessionProjectReady,
+      resetStartupReady,
+      resetRegisteredHindsightTools,
+      setDegradedReason,
+      DegradedReasonKind,
+    } = await import("../src/runtime-state");
+    const pi = createMockPi();
+    // isReady returns false (simulating the operational-command gate blocked).
+    registerCommands(
+      pi,
+      { ...testConfig, apiUrl: "https://x", apiKey: "y", bankId: "b", observationScopes: [] },
+      createMockClient(),
+      () => null as RecallMessageDetails | null,
+      () => null,
+      () => {},
+      () => false, // not ready
+      { configPath: undefined, envVars: [], warning: undefined, validationWarnings: [] }
+    );
+
+    // startup NOT latched (another degraded cause: server unreachable/incompat).
+    resetStartupReady();
+    // Simulate the failed active-session project-name state from session_start.
+    // The degraded reason must be ProjectName so detach-project-name (a
+    // project-name recovery command) is not blocked by the global-config gate.
+    setActiveSessionProjectReady(false);
+    setDegradedReason({
+      kind: DegradedReasonKind.ProjectName,
+      message: "project config is invalid",
+    });
+    expect(isActiveSessionProjectReady()).toBe(false);
+
+    const ctx = {
+      sessionManager: {
+        getSessionId: () => SESSION_ID,
+        getEntries: () => [
+          {
+            type: "custom",
+            customType: "hindsight-meta",
+            data: { retained: true, usesProjectConfig: true },
+          },
+        ],
+        getSessionFile: () => null,
+        getHeader: () => ({ id: SESSION_ID, cwd: tmpdir() }),
+        getSessionName: () => undefined,
+      },
+      ui: {
+        notify: mock(),
+        confirm: mock(async () => true),
+        select: mock(),
+        setStatus: mock(),
+      },
+      signal: undefined,
+      cwd: "/test",
+    } as unknown as ExtensionContext;
+
+    try {
+      const cmd = (
+        pi as unknown as {
+          commands: Map<string, { handler: (a: string, ctx: ExtensionContext) => Promise<void> }>;
+        }
+      ).commands.get("hindsight");
+      // detach-project-name must NOT be blocked by the not-ready gate (it's the
+      // recovery command). It runs and writes metadata despite isReady()=false.
+      await cmd!.handler("detach-project-name", ctx);
+
+      const metaEntries = pi.appendedEntries.filter((e) => e.customType === "hindsight-meta");
+      expect(metaEntries.length).toBeGreaterThan(0);
+      const latestData = metaEntries[metaEntries.length - 1]?.data as {
+        usesProjectConfig?: boolean;
+      };
+      expect(latestData.usesProjectConfig).toBe(false);
+
+      // Detach clears the failed active-session flush latch (detached wins).
+      expect(isActiveSessionProjectReady()).toBe(true);
+      // But the extension is NOT operational (startup not latched), so tools
+      // must NOT be re-enabled: no setActiveTools call re-adds hindsight_retain.
+      const enableCalls = pi.setActiveToolsCalls.filter((names) =>
+        names.includes("hindsight_retain")
+      );
+      expect(enableCalls.length).toBe(0);
+      expect(hasPendingFlag(SESSION_ID)).toBe(true);
+    } finally {
+      removePendingFlag(SESSION_ID);
+      clearSessionQueueState(SESSION_ID);
+      setActiveSessionProjectReady(true);
+      resetStartupReady();
+      resetRegisteredHindsightTools();
+      setDegradedReason(null);
+    }
+  });
+
+  it("re-enables tools when detach clears the flush failure and the extension is otherwise operational", async () => {
+    // When the ONLY degraded cause is the active-session project config (startup
+    // is latched), detach clears it and the extension becomes operational — so
+    // tools are re-shown (retain visible because the session is retained:true).
+    const { createMockPi } = await import("./fixtures");
+    const {
+      setActiveSessionProjectReady,
+      isActiveSessionProjectReady,
+      markStartupReady,
+      resetStartupReady,
+      resetRegisteredHindsightTools,
+    } = await import("../src/runtime-state");
+    const { registerTools } = await import("../src/tools");
+    const pi = createMockPi();
+    registerCommands(
+      pi,
+      { ...testConfig, apiUrl: "https://x", apiKey: "y", bankId: "b", observationScopes: [] },
+      createMockClient(),
+      () => null as RecallMessageDetails | null,
+      () => null,
+      () => {},
+      () => true,
+      { configPath: undefined, envVars: [], warning: undefined, validationWarnings: [] }
+    );
+    // Register tools so there's something to re-show, and latch startup.
+    registerTools(pi, testConfig, createMockClient());
+    markStartupReady();
+    // Project config failed (the only degraded cause).
+    setActiveSessionProjectReady(false);
+    expect(isActiveSessionProjectReady()).toBe(false);
+
+    const ctx = {
+      sessionManager: {
+        getSessionId: () => SESSION_ID,
+        getEntries: () => [
+          {
+            type: "custom",
+            customType: "hindsight-meta",
+            data: { retained: true, usesProjectConfig: true },
+          },
+        ],
+        getSessionFile: () => null,
+        getHeader: () => ({ id: SESSION_ID, cwd: tmpdir() }),
+        getSessionName: () => undefined,
+      },
+      ui: {
+        notify: mock(),
+        confirm: mock(async () => true),
+        select: mock(),
+        setStatus: mock(),
+      },
+      signal: undefined,
+      cwd: "/test",
+    } as unknown as ExtensionContext;
+
+    try {
+      const cmd = (
+        pi as unknown as {
+          commands: Map<string, { handler: (a: string, ctx: ExtensionContext) => Promise<void> }>;
+        }
+      ).commands.get("hindsight");
+      await cmd!.handler("detach-project-name", ctx);
+
+      // Detach clears the flush latch → now operational (startup was latched).
+      expect(isActiveSessionProjectReady()).toBe(true);
+      // Tools re-shown: a setActiveTools call re-adds hindsight_retain
+      // (session is retained:true).
+      const enableCalls = pi.setActiveToolsCalls.filter((names) =>
+        names.includes("hindsight_retain")
+      );
+      expect(enableCalls.length).toBeGreaterThan(0);
+      // Status bar restored to healthy (detach cleared the only degraded cause).
+      const statusCalls = (ctx.ui.setStatus as ReturnType<typeof mock>).mock.calls.map((c) =>
+        String(c[1])
+      );
+      expect(statusCalls.some((s) => s.includes("🧠"))).toBe(true);
+    } finally {
+      removePendingFlag(SESSION_ID);
+      clearSessionQueueState(SESSION_ID);
+      setActiveSessionProjectReady(true);
+      resetStartupReady();
+      resetRegisteredHindsightTools();
+    }
+  });
+
+  it("is blocked when the degraded cause is global config (no session writes)", async () => {
+    // When global config is invalid, the fail-fast bootstrap path promises no
+    // metadata/session-state/queue writes. detach-project-name writes session
+    // metadata + a pending marker, so it must be blocked for global-config
+    // degraded mode — even though it is not in OPERATIONAL_SUBCOMMANDS.
+    const { createMockPi } = await import("./fixtures");
+    const {
+      setActiveSessionProjectReady,
+      resetStartupReady,
+      resetRegisteredHindsightTools,
+      setDegradedReason,
+      DegradedReasonKind,
+    } = await import("../src/runtime-state");
+    const pi = createMockPi();
+    registerCommands(
+      pi,
+      { ...testConfig, apiUrl: "https://x", apiKey: "y", bankId: "b", observationScopes: [] },
+      createMockClient(),
+      () => null as RecallMessageDetails | null,
+      () => null,
+      () => {},
+      () => false, // not ready (global config invalid)
+      { configPath: undefined, envVars: [], warning: undefined, validationWarnings: [] }
+    );
+
+    resetStartupReady();
+    setActiveSessionProjectReady(false);
+    setDegradedReason({
+      kind: DegradedReasonKind.GlobalConfig,
+      message: "global config is invalid",
+    });
+
+    const notifyMock = mock();
+    const ctx = {
+      sessionManager: {
+        getSessionId: () => SESSION_ID,
+        getEntries: () => [
+          {
+            type: "custom",
+            customType: "hindsight-meta",
+            data: { retained: true, usesProjectConfig: true },
+          },
+        ],
+        getSessionFile: () => null,
+        getHeader: () => ({ id: SESSION_ID, cwd: tmpdir() }),
+        getSessionName: () => undefined,
+      },
+      ui: {
+        notify: notifyMock,
+        confirm: mock(async () => true),
+        select: mock(),
+      },
+      signal: undefined,
+      cwd: "/test",
+    } as unknown as ExtensionContext;
+
+    try {
+      const cmd = (
+        pi as unknown as {
+          commands: Map<string, { handler: (a: string, ctx: ExtensionContext) => Promise<void> }>;
+        }
+      ).commands.get("hindsight");
+      await cmd!.handler("detach-project-name", ctx);
+
+      // No metadata was written (detach was blocked).
+      const metaEntries = pi.appendedEntries.filter((e) => e.customType === "hindsight-meta");
+      expect(metaEntries.length).toBe(0);
+      // No pending marker was touched.
+      expect(hasPendingFlag(SESSION_ID)).toBe(false);
+      // A blocked message was shown.
+      const notifyMsgs = notifyMock.mock.calls.map((c) => String(c[0]));
+      expect(notifyMsgs.some((m) => m.includes("operational commands"))).toBe(true);
+    } finally {
+      removePendingFlag(SESSION_ID);
+      clearSessionQueueState(SESSION_ID);
+      setActiveSessionProjectReady(true);
+      resetStartupReady();
+      resetRegisteredHindsightTools();
+      setDegradedReason(null);
+    }
+  });
+});
+
+// ============================================
+// /hindsight config shows session-specific project config section
+// ============================================
+
+describe("/hindsight config: session-specific project config section", () => {
+  it("shows resolved project name from a real cwd-local project config", async () => {
+    const { createMockPi } = await import("./fixtures");
+    const pi = createMockPi();
+    registerCommands(
+      pi,
+      { ...testConfig, apiUrl: "https://x", apiKey: "y", bankId: "b", observationScopes: [] },
+      createMockClient(),
+      () => null as RecallMessageDetails | null,
+      () => null,
+      () => {},
+      () => true,
+      { configPath: undefined, envVars: [], warning: undefined, validationWarnings: [] }
+    );
+
+    await withTempDir(async (cwd) => {
+      writeProjectConfig(cwd, "jsonc", JSON.stringify({ projectName: "stable-from-config" }));
+      const notify = mock((_msg: string, _level?: "info" | "warning" | "error") => {});
+      const ctx = {
+        sessionManager: {
+          getSessionId: () => "config-sess",
+          getEntries: () => [
+            {
+              type: "custom",
+              customType: "hindsight-meta",
+              data: { retained: true, usesProjectConfig: true },
+            },
+          ],
+          getSessionFile: () => null,
+          getHeader: () => ({ id: "config-sess", cwd }),
+          getSessionName: () => undefined,
+        },
+        ui: { notify, confirm: mock(), select: mock() },
+        signal: undefined,
+        cwd,
+      } as unknown as ExtensionContext;
+
+      const cmd = (
+        pi as unknown as {
+          commands: Map<string, { handler: (a: string, ctx: ExtensionContext) => Promise<void> }>;
+        }
+      ).commands.get("hindsight");
+      await cmd!.handler("config", ctx);
+      const calls = notify.mock.calls.map((c) => String(c[0]));
+      const section = calls.find((m) => m.includes("== Session-Specific Project Config =="));
+      expect(section).toBeDefined();
+      expect(section).toContain(`Session cwd: ${cwd}`);
+      expect(section).toContain("usesProjectConfig: true");
+      expect(section).toContain("Project-local config:");
+      expect(section).toContain("config.jsonc");
+      expect(section).toContain("(valid)");
+      expect(section).toContain("projectName: stable-from-config");
+      expect(section).toContain("Project name: stable-from-config (source: project-local-config)");
+      expect(section).not.toContain("default if detached:");
+      expect(section).not.toContain("Flush: would proceed");
+    });
+  });
+
+  it("shows blocked resolution when marked and cwd-local config is missing", async () => {
+    const { createMockPi } = await import("./fixtures");
+    const pi = createMockPi();
+    registerCommands(
+      pi,
+      { ...testConfig, apiUrl: "https://x", apiKey: "y", bankId: "b", observationScopes: [] },
+      createMockClient(),
+      () => null as RecallMessageDetails | null,
+      () => null,
+      () => {},
+      () => true,
+      { configPath: undefined, envVars: [], warning: undefined, validationWarnings: [] }
+    );
+
+    await withTempDir(async (cwd) => {
+      // No project-config written at cwd.
+      const notify = mock((_msg: string, _level?: "info" | "warning" | "error") => {});
+      const ctx = {
+        sessionManager: {
+          getSessionId: () => "config-sess",
+          getEntries: () => [
+            {
+              type: "custom",
+              customType: "hindsight-meta",
+              data: { retained: true, usesProjectConfig: true },
+            },
+          ],
+          getSessionFile: () => null,
+          getHeader: () => ({ id: "config-sess", cwd }),
+          getSessionName: () => undefined,
+        },
+        ui: { notify, confirm: mock(), select: mock() },
+        signal: undefined,
+        cwd,
+      } as unknown as ExtensionContext;
+
+      const cmd = (
+        pi as unknown as {
+          commands: Map<string, { handler: (a: string, ctx: ExtensionContext) => Promise<void> }>;
+        }
+      ).commands.get("hindsight");
+      await cmd!.handler("config", ctx);
+      const calls = notify.mock.calls.map((c) => String(c[0]));
+      const section = calls.find((m) => m.includes("== Session-Specific Project Config =="));
+      expect(section).toBeDefined();
+      expect(section).toContain("Project-local config: <missing>");
+      expect(section).toContain("Project name: (blocked)");
+      expect(section).toContain("Flush: blocked — pending left queued");
+    });
+  });
+});
+
+// ============================================
+// updateSessionMetadata carry-forward of usesProjectConfig
+// ============================================
+
+describe("updateSessionMetadata carry-forward of usesProjectConfig", () => {
+  const SESSION_ID = "carryforward-meta";
+
+  afterEach(() => {
+    rmSync(getSessionStatePath(SESSION_ID), { force: true });
+  });
+
+  it("buildMetaUpdate carries forward existing usesProjectConfig when updating other fields", async () => {
+    const { buildMetaUpdate } = await import("../src/meta");
+    const updated = buildMetaUpdate(
+      { retained: true, usesProjectConfig: true, tags: ["x"] },
+      { retained: true }
+    );
+    expect(updated.usesProjectConfig).toBe(true);
+    expect(updated.retained).toBe(true);
+    // tags should NOT be carried when input updates.tags is undefined? Actually
+    // buildMetaUpdate carries existing tags forward when updates.tags is undefined.
+    // Verify carry-forward keeps tags from existing.
+    expect(updated.tags).toEqual(["x"]);
+  });
+
+  it("updates api call: detach via updateSessionMetadata appends latest-wins false", async () => {
+    const { createMockPi } = await import("./fixtures");
+    const pi = createMockPi();
+    const existing = [
+      {
+        type: "custom",
+        customType: "hindsight-meta",
+        data: { retained: true, usesProjectConfig: true },
+      },
+    ];
+    await updateSessionMetadata(
+      pi as unknown as import("@earendil-works/pi-coding-agent").ExtensionAPI,
+      SESSION_ID,
+      existing,
+      { usesProjectConfig: false },
+      { ...testConfig }
+    );
+    const metaEntries = pi.appendedEntries.filter((e) => e.customType === "hindsight-meta");
+    expect(metaEntries).toHaveLength(1);
+    const data = metaEntries[0]?.data as { retained?: boolean; usesProjectConfig?: boolean };
+    expect(data.retained).toBe(true); // carried forward
+    expect(data.usesProjectConfig).toBe(false); // latest wins
+  });
+
+  it("getHindsightMeta exposes usesProjectConfig", () => {
+    const entries = [
+      {
+        type: "custom",
+        customType: "hindsight-meta",
+        data: { retained: true, usesProjectConfig: true },
+      },
+    ];
+    const meta = getHindsightMeta(entries);
+    expect(meta?.usesProjectConfig).toBe(true);
+  });
+});

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -4,16 +4,26 @@
  */
 
 import { afterEach, describe, expect, it, mock } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { RecallResponse, ReflectResponse } from "@vectorize-io/hindsight-client";
 import type { HindsightClientWrapper } from "../src/client";
 import type { HindsightConfig } from "../src/config";
 import { clearSessionQueueState, removePendingFlag } from "../src/queue";
-import { isToolEnabled, registerTools, updateRetainToolVisibility } from "../src/tools";
+import {
+  markStartupReady,
+  resetActiveSessionProjectReady,
+  resetRegisteredHindsightTools,
+  resetStartupReady,
+  setActiveSessionProjectReady,
+} from "../src/runtime-state";
+import { isToolEnabled, refreshToolVisibility, registerTools } from "../src/tools";
 import {
   readToolQueueFromDisk,
   setupTempAgentDir,
   testConfig as sharedTestConfig,
+  withTempDir,
 } from "./fixtures";
 
 setupTempAgentDir("tools");
@@ -117,6 +127,10 @@ afterEach(() => {
   // Clean up any queue files created during tests
   removePendingFlag(TEST_SESSION_ID);
   clearSessionQueueState(TEST_SESSION_ID);
+  // Reset runtime-state latches so tests start/leave operational state clean.
+  resetStartupReady();
+  resetActiveSessionProjectReady();
+  resetRegisteredHindsightTools();
 });
 
 // ============================================
@@ -314,6 +328,97 @@ describe("hindsight_retain", () => {
     expect(result.details.success).toBe(false);
     expect(result.details.error).toContain("does not allow retention");
     expect(result.content[0]!.text).toContain("Warning:");
+  });
+
+  it("returns error when project-local config is invalid (fix-config)", async () => {
+    // The retain tool re-resolves the project name before queueing (so a
+    // memory is never tagged with the wrong project name). A marked session
+    // whose cwd-local config is invalid fails closed: no queue entry, and the
+    // tool surfaces the specific reason + fix-config recovery advice.
+    await withTempDir(async (tmpCwd) => {
+      mkdirSync(join(tmpCwd, ".pi", "epimetheus"), { recursive: true });
+      writeFileSync(
+        join(tmpCwd, ".pi", "epimetheus", "config.jsonc"),
+        JSON.stringify({ notProjectName: "x" }),
+        "utf-8"
+      );
+
+      const pi = createMockPi();
+      registerTools(pi, testConfig, createMockClient());
+      const retainTool = pi.tools.find((t: ToolDef) => t.name === "hindsight_retain");
+      const ctx = createMockContext({
+        sessionManager: {
+          getSessionId: mock(() => TEST_SESSION_ID),
+          getEntries: mock(() => [
+            {
+              type: "custom",
+              customType: "hindsight-meta",
+              data: { retained: true, usesProjectConfig: true },
+            },
+          ]),
+          getHeader: mock(() => ({ id: TEST_SESSION_ID, cwd: tmpCwd })),
+        },
+      });
+
+      const result = (await retainTool!.execute(
+        "tc1",
+        { content: "Fact" },
+        undefined,
+        undefined,
+        ctx
+      )) as {
+        content: Array<{ type: string; text: string }>;
+        details: { success: boolean; error: string };
+      };
+      expect(result.details.success).toBe(false);
+      expect(result.details.error).toContain("project config");
+      expect(result.details.error).toContain("invalid");
+      expect(result.content[0]!.text).toContain("Failed to store memory");
+      expect(result.content[0]!.text).toContain("Fix the config at");
+      expect(result.content[0]!.text).toContain(tmpCwd);
+      // Nothing was queued.
+      expect(readToolQueueFromDisk(TEST_SESSION_ID)).toHaveLength(0);
+    });
+  });
+
+  it("returns error when project-local config is missing (detach-or-fix)", async () => {
+    // Marked session whose cwd has no project config file: fail closed with
+    // the detach-or-fix recovery advice (suggests /hindsight detach-project-name).
+    await withTempDir(async (tmpCwd) => {
+      // No .pi/epimetheus/config.jsonc at tmpCwd.
+      const pi = createMockPi();
+      registerTools(pi, testConfig, createMockClient());
+      const retainTool = pi.tools.find((t: ToolDef) => t.name === "hindsight_retain");
+      const ctx = createMockContext({
+        sessionManager: {
+          getSessionId: mock(() => TEST_SESSION_ID),
+          getEntries: mock(() => [
+            {
+              type: "custom",
+              customType: "hindsight-meta",
+              data: { retained: true, usesProjectConfig: true },
+            },
+          ]),
+          getHeader: mock(() => ({ id: TEST_SESSION_ID, cwd: tmpCwd })),
+        },
+      });
+
+      const result = (await retainTool!.execute(
+        "tc1",
+        { content: "Fact" },
+        undefined,
+        undefined,
+        ctx
+      )) as {
+        content: Array<{ type: string; text: string }>;
+        details: { success: boolean; error: string };
+      };
+      expect(result.details.success).toBe(false);
+      expect(result.details.error).toContain("no project config file is present");
+      expect(result.content[0]!.text).toContain("Failed to store memory");
+      expect(result.content[0]!.text).toContain("detach-project-name");
+      expect(readToolQueueFromDisk(TEST_SESSION_ID)).toHaveLength(0);
+    });
   });
 });
 
@@ -757,65 +862,94 @@ describe("hindsight_retain context forwarding", () => {
 });
 
 // ============================================
-// updateRetainToolVisibility tests
+// refreshToolVisibility tests
 // ============================================
 
-describe("updateRetainToolVisibility", () => {
-  it("removes hindsight_retain from active tools when not retained", () => {
+describe("refreshToolVisibility", () => {
+  /** Make the extension operational so tools can be shown. */
+  function beOperational(): void {
+    markStartupReady();
+    setActiveSessionProjectReady(true);
+  }
+
+  it("hides ALL hindsight tools when degraded (not operational)", () => {
     const pi = createMockPi();
     registerTools(pi, testConfig, createMockClient());
+    beOperational();
+    // Start operational+retained: all hindsight tools active.
+    refreshToolVisibility(pi, true);
+    expect(pi.getActiveTools()).toContain("hindsight_retain");
+    expect(pi.getActiveTools()).toContain("hindsight_recall");
+    expect(pi.getActiveTools()).toContain("hindsight_reflect");
 
-    // Initially all tools are active
-    const activeBefore = pi.getActiveTools();
-    expect(activeBefore).toContain("hindsight_retain");
-
-    updateRetainToolVisibility(pi, false);
-
-    const activeAfter = pi.getActiveTools();
-    expect(activeAfter).not.toContain("hindsight_retain");
-    // Other hindsight tools should remain
-    expect(activeAfter).toContain("hindsight_recall");
-    expect(activeAfter).toContain("hindsight_reflect");
+    // Flip to degraded: ALL hindsight tools hidden (not just retain).
+    setActiveSessionProjectReady(false);
+    refreshToolVisibility(pi, true);
+    const active = pi.getActiveTools();
+    expect(active).not.toContain("hindsight_retain");
+    expect(active).not.toContain("hindsight_recall");
+    expect(active).not.toContain("hindsight_reflect");
+    expect(active).not.toContain("hindsight_set_extra_context");
+    expect(active).not.toContain("hindsight_get_extra_context");
   });
 
-  it("adds hindsight_retain back when session becomes retained", () => {
+  it("when operational + retained, shows all registered hindsight tools incl retain", () => {
     const pi = createMockPi();
     registerTools(pi, testConfig, createMockClient());
+    beOperational();
 
-    // Remove first
-    updateRetainToolVisibility(pi, false);
-    const activeAfterRemove = pi.getActiveTools();
-    expect(activeAfterRemove).not.toContain("hindsight_retain");
+    refreshToolVisibility(pi, true);
 
-    // Add back
-    updateRetainToolVisibility(pi, true);
-    const activeAfterAdd = pi.getActiveTools();
-    expect(activeAfterAdd).toContain("hindsight_retain");
+    const active = pi.getActiveTools();
+    expect(active).toContain("hindsight_retain");
+    expect(active).toContain("hindsight_recall");
+    expect(active).toContain("hindsight_reflect");
   });
 
-  it("is a no-op when retained=true and tool is already active", () => {
+  it("when operational + not retained, hides only hindsight_retain", () => {
     const pi = createMockPi();
     registerTools(pi, testConfig, createMockClient());
+    beOperational();
 
-    // Tool is active by default
-    const callCountBefore = pi.setActiveToolsCalls.length;
-    updateRetainToolVisibility(pi, true);
+    refreshToolVisibility(pi, false);
 
-    // setActiveTools should not have been called
-    expect(pi.setActiveToolsCalls.length).toBe(callCountBefore);
+    const active = pi.getActiveTools();
+    expect(active).not.toContain("hindsight_retain");
+    // Read-only tools remain available when operational.
+    expect(active).toContain("hindsight_recall");
+    expect(active).toContain("hindsight_reflect");
   });
 
-  it("is a no-op when retained=false and tool is already inactive", () => {
+  it("restores hindsight_retain when transitioning not-retained -> retained while operational", () => {
     const pi = createMockPi();
     registerTools(pi, testConfig, createMockClient());
+    beOperational();
 
-    // Remove first
-    updateRetainToolVisibility(pi, false);
-    const callCountAfterRemove = pi.setActiveToolsCalls.length;
+    refreshToolVisibility(pi, false);
+    expect(pi.getActiveTools()).not.toContain("hindsight_retain");
 
-    // Calling again should be a no-op
-    updateRetainToolVisibility(pi, false);
-    expect(pi.setActiveToolsCalls.length).toBe(callCountAfterRemove);
+    refreshToolVisibility(pi, true);
+    expect(pi.getActiveTools()).toContain("hindsight_retain");
+  });
+
+  it("preserves non-hindsight tools across visibility changes", () => {
+    const pi = createMockPi();
+    // Register an unrelated tool to simulate other extensions/built-ins.
+    (pi as unknown as { registerTool: (t: unknown) => void }).registerTool({
+      name: "other_tool",
+      execute: () => ({}),
+      parameters: {},
+    });
+    registerTools(pi, testConfig, createMockClient());
+    beOperational();
+
+    refreshToolVisibility(pi, false); // hide retain
+    expect(pi.getActiveTools()).toContain("other_tool");
+
+    setActiveSessionProjectReady(false); // degraded
+    refreshToolVisibility(pi, true);
+    expect(pi.getActiveTools()).toContain("other_tool");
+    expect(pi.getActiveTools()).not.toContain("hindsight_retain");
   });
 });
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -5,8 +5,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import {
+  clearProjectNameCache,
   extractParentSessionId,
   extractTextFromContent,
   getBasedir,
@@ -181,62 +182,55 @@ describe("getBasedir", () => {
 });
 
 describe("getProjectName", () => {
-  it("returns EPIMETHEUS_PROJECT_NAME when set", () => {
-    const originalNew = process.env.EPIMETHEUS_PROJECT_NAME;
-    const originalOld = process.env.PI_HINDSIGHT_PROJECT_NAME;
-    process.env.EPIMETHEUS_PROJECT_NAME = "custom-project";
-    try {
-      expect(getProjectName("/home/user/myapp")).toBe("custom-project");
-    } finally {
-      if (originalNew === undefined) delete process.env.EPIMETHEUS_PROJECT_NAME;
-      else process.env.EPIMETHEUS_PROJECT_NAME = originalNew;
-      if (originalOld === undefined) delete process.env.PI_HINDSIGHT_PROJECT_NAME;
-      else process.env.PI_HINDSIGHT_PROJECT_NAME = originalOld;
-    }
+  // Env-var overrides (EPIMETHEUS_PROJECT_NAME / PI_HINDSIGHT_PROJECT_NAME) were
+  // removed because env vars do not track Pi session switching. Default
+  // derivation is git common dir -> basename (cached per cwd).
+  afterEach(() => clearProjectNameCache());
+
+  it("returns cwd basename for a non-git directory", () => {
+    expect(getProjectName("/home/user/myapp")).toBe("myapp");
   });
 
-  it("falls back to legacy PI_HINDSIGHT_PROJECT_NAME when EPIMETHEUS_PROJECT_NAME is unset", () => {
-    const originalNew = process.env.EPIMETHEUS_PROJECT_NAME;
-    const originalOld = process.env.PI_HINDSIGHT_PROJECT_NAME;
-    delete process.env.EPIMETHEUS_PROJECT_NAME;
-    process.env.PI_HINDSIGHT_PROJECT_NAME = "custom-project";
-    try {
-      expect(getProjectName("/home/user/myapp")).toBe("custom-project");
-    } finally {
-      if (originalNew === undefined) delete process.env.EPIMETHEUS_PROJECT_NAME;
-      else process.env.EPIMETHEUS_PROJECT_NAME = originalNew;
-      if (originalOld === undefined) delete process.env.PI_HINDSIGHT_PROJECT_NAME;
-      else process.env.PI_HINDSIGHT_PROJECT_NAME = originalOld;
-    }
-  });
-
-  it("prioritizes EPIMETHEUS_PROJECT_NAME over PI_HINDSIGHT_PROJECT_NAME", () => {
-    const originalNew = process.env.EPIMETHEUS_PROJECT_NAME;
-    const originalOld = process.env.PI_HINDSIGHT_PROJECT_NAME;
-    process.env.EPIMETHEUS_PROJECT_NAME = "new-project";
-    process.env.PI_HINDSIGHT_PROJECT_NAME = "old-project";
-    try {
-      expect(getProjectName("/home/user/myapp")).toBe("new-project");
-    } finally {
-      if (originalNew === undefined) delete process.env.EPIMETHEUS_PROJECT_NAME;
-      else process.env.EPIMETHEUS_PROJECT_NAME = originalNew;
-      if (originalOld === undefined) delete process.env.PI_HINDSIGHT_PROJECT_NAME;
-      else process.env.PI_HINDSIGHT_PROJECT_NAME = originalOld;
-    }
-  });
-
-  it("falls back to cwd basename when neither project-name env var is set", () => {
-    const originalNew = process.env.EPIMETHEUS_PROJECT_NAME;
-    const originalOld = process.env.PI_HINDSIGHT_PROJECT_NAME;
-    delete process.env.EPIMETHEUS_PROJECT_NAME;
-    delete process.env.PI_HINDSIGHT_PROJECT_NAME;
+  it("ignores EPIMETHEUS_PROJECT_NAME (env overrides removed)", () => {
+    process.env.EPIMETHEUS_PROJECT_NAME = "ignored-project";
     try {
       expect(getProjectName("/home/user/myapp")).toBe("myapp");
     } finally {
-      if (originalNew === undefined) delete process.env.EPIMETHEUS_PROJECT_NAME;
-      else process.env.EPIMETHEUS_PROJECT_NAME = originalNew;
-      if (originalOld === undefined) delete process.env.PI_HINDSIGHT_PROJECT_NAME;
-      else process.env.PI_HINDSIGHT_PROJECT_NAME = originalOld;
+      delete process.env.EPIMETHEUS_PROJECT_NAME;
     }
+  });
+
+  it("ignores legacy PI_HINDSIGHT_PROJECT_NAME (env overrides removed)", () => {
+    process.env.PI_HINDSIGHT_PROJECT_NAME = "ignored-legacy";
+    try {
+      expect(getProjectName("/home/user/myapp")).toBe("myapp");
+    } finally {
+      delete process.env.PI_HINDSIGHT_PROJECT_NAME;
+    }
+  });
+
+  it("derives the git common dir name when `<cwd>/.git` exists (single repo)", () => {
+    // Use a real temp dir with a .git directory so deriveGitProjectName runs.
+    // git rev-parse from outside a repo returns non-zero, so we only assert
+    // the basename fallback path here; the git-common-dir derivation is
+    // covered by project-config.test.ts real-git worktree tests.
+    const dir = join(tmpdir(), `epimetheus-utils-${Date.now()}`);
+    mkdirSync(join(dir, ".git"), { recursive: true });
+    try {
+      // No git repo config -> git fails -> basename fallback.
+      expect(getProjectName(dir)).toBe(basename(dir));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("caches the result per cwd (same cwd returns same name without re-deriving)", () => {
+    expect(getProjectName("/home/user/cached-app")).toBe("cached-app");
+    expect(getProjectName("/home/user/cached-app")).toBe("cached-app");
+  });
+
+  it("returns a different name for a different cwd", () => {
+    expect(getProjectName("/home/user/app-a")).toBe("app-a");
+    expect(getProjectName("/home/user/app-b")).toBe("app-b");
   });
 });


### PR DESCRIPTION
Add cwd-local flush-config support for session-specific project names. Marked sessions now require the project-local config at flush time and fail closed when it is missing or invalid.

Add /hindsight detach-flush-config as a recovery command, extend config diagnostics, and derive default project names from the git common dir before falling back to basename(cwd).

Document the config flow and update tests for cwd-specific session behavior.


- [X] retest first turn auto-recall

Resolution
- [X] basename resolution
- [X] worktree resolution
- [X] worktree project-local override (in config and retention)
  - [X] review /hindsight config
- [X] submodule resolution
- [X] submodule worktree resolution
- [X] removing project-local override
  - [X] auto flush error
  - [X] manual flush error
  - [X] get tool flush error
  - [X] review /hindsight config
- [X] Auto-recall uses same project resolution (works for worktrees)

flush blocked
- [X] only first gives warning for automatic flush
- [X] all manual flushes blocked with error (error printed every time)
- [X] invalid required config - /hindsight flush gives specific error
- [X] connection error - /hindsight flush gives specific error
- [X] invalid local config - /hindsight flush gives specific error
- [X] missing local config - /hindsight flush gives specific error
